### PR TITLE
feat: add Riichi and Shenyang Mahjong fan tables

### DIFF
--- a/frontend/src/data/fanTableData.ts
+++ b/frontend/src/data/fanTableData.ts
@@ -1,0 +1,101 @@
+export interface FanItem {
+  name: string;
+  fan: number;
+  description: string;
+  // Format: "Tile Tile Tile | Tile Tile Tile"
+  // Prefix a group with * to highlight it
+  example: string;
+  tags?: string[];
+}
+
+export const fanTableData: FanItem[] = [
+  { fan: 88, name: "大四喜", description: "由4副风刻(杠)组成的和牌。不计圈风刻、门风刻、三风刻、碰碰和。", example: "*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Pei Pei Pei | Man1 Man1" },
+  { fan: 88, name: "大三元", description: "和牌中，有中发白3副刻子。不计箭刻、双箭刻。", example: "*Chun Chun Chun | *Hatsu Hatsu Hatsu | *Haku Haku Haku | Man1 Man2 Man3 | Pin1 Pin1" },
+  { fan: 88, name: "绿一色", description: "由23468条及发字中的任何牌组成的顺子、刻子、将的和牌。不计混一色。如无发字组成的各牌，可计清一色。", example: "*Sou2 Sou3 Sou4 | *Sou6 Sou6 Sou6 | *Sou8 Sou8 Sou8 | *Hatsu Hatsu Hatsu | *Sou2 Sou2" },
+  { fan: 88, name: "九莲宝灯", description: "由一种花色序数牌子按1112345678999组成的特定牌型，见同花色任何1张序数牌即成和牌。不计清一色。", example: "*Man1 Man1 Man1 Man2 Man3 Man4 Man5 Man6 Man7 Man8 Man9 Man9 Man9 Man1" },
+  { fan: 88, name: "四杠", description: "4个杠。不计三杠、双暗杠、双明杠、明杠、暗杠、单钓将。", example: "*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Pin3 Pin3 Pin3 Pin3 | *Pin4 Pin4 Pin4 Pin4 | Shaa Shaa" },
+  { fan: 88, name: "连七对", description: "由一种花色序数牌组成序数相连的7个对子的和牌。不计清一色、不求人、单钓将。", example: "*Man1 Man1 | *Man2 Man2 | *Man3 Man3 | *Man4 Man4 | *Man5 Man5 | *Man6 Man6 | *Man7 Man7" },
+  { fan: 88, name: "十三幺", description: "由3种序数牌的一、九牌，7种字牌及其中一对作将组成的和牌。不计五门齐、不求人、单钓将。", example: "*Man1 | *Man9 | *Pin1 | *Pin9 | *Sou1 | *Sou9 | *Ton | *Nan | *Shaa | *Pei | *Haku | *Hatsu | *Chun Chun" },
+  { fan: 64, name: "清幺九", description: "由序数牌一、九刻子组成的和牌。不计碰碰和、全带幺、幺九刻、无字。", example: "*Man1 Man1 Man1 | *Man9 Man9 Man9 | *Pin1 Pin1 Pin1 | *Pin9 Pin9 Pin9 | *Sou1 Sou1" },
+  { fan: 64, name: "小四喜", description: "和牌时有风牌的3副刻子及将牌。不计三风刻。", example: "*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Pei Pei | Man1 Man2 Man3" },
+  { fan: 64, name: "小三元", description: "和牌时有箭牌的2副刻子及将牌。不计双箭刻、箭刻。", example: "*Chun Chun Chun | *Hatsu Hatsu Hatsu | *Haku Haku | Man1 Man2 Man3 | Pin1 Pin2 Pin3" },
+  { fan: 64, name: "字一色", description: "由字牌的刻子(杠)、将组成的和牌。不计碰碰和。", example: "*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Haku Haku Haku | *Chun Chun" },
+  { fan: 64, name: "四暗刻", description: "4个暗刻(暗杠)。不计门前清、碰碰和。", example: "*Man1 Man1 Man1 | *Man2 Man2 Man2 | *Man3 Man3 Man3 | *Man4 Man4 Man4 | Pin1 Pin1" },
+  { fan: 64, name: "一色双龙会", description: "一种花色的两个老少副，5为将牌。不计平和、七对、清一色。", example: "*Man1 Man2 Man3 | *Man1 Man2 Man3 | *Man7 Man8 Man9 | *Man7 Man8 Man9 | *Man5 Man5" },
+  { fan: 48, name: "一色四同顺", description: "一种花色4副序数相同的顺子。不计一色三节高、一般高、四归一。", example: "*Man1 Man2 Man3 | *Man1 Man2 Man3 | *Man1 Man2 Man3 | *Man1 Man2 Man3 | Pin1 Pin1" },
+  { fan: 48, name: "一色四节高", description: "一种花色4副依次递增一位数的刻子。不计一色三同顺、碰碰和。", example: "*Man1 Man1 Man1 | *Man2 Man2 Man2 | *Man3 Man3 Man3 | *Man4 Man4 Man4 | Pin1 Pin1" },
+  { fan: 32, name: "一色四步高", description: "一种花色4副依次递增一位数或二位数的顺子。", example: "*Man1 Man2 Man3 | *Man2 Man3 Man4 | *Man3 Man4 Man5 | *Man4 Man5 Man6 | Pin1 Pin1" },
+  { fan: 32, name: "三杠", description: "3个杠。", example: "*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Pin3 Pin3 Pin3 Pin3 | Man1 Man2 Man3 | Man5 Man5" },
+  { fan: 32, name: "混幺九", description: "由字牌和序数牌一、九的刻子及将牌组成的和牌。不计碰碰和。", example: "*Man1 Man1 Man1 | *Pin9 Pin9 Pin9 | *Ton Ton Ton | *Nan Nan Nan | *Haku Haku" },
+  { fan: 24, name: "七对", description: "由7个对子组成和牌。不计不求人、单钓将。", example: "*Man1 Man1 | *Man4 Man4 | *Pin2 Pin2 | *Pin5 Pin5 | *Sou3 Sou3 | *Sou8 Sou8 | *Ton Ton" },
+  { fan: 24, name: "七星不靠", description: "必须有7个单张的东西南北中发白，加上3种花色，数位按147、258、369中的7张序数牌组成没有将牌的和牌。不计五门齐、不求人、单钓将。", example: "*Man1 | *Man4 | *Man7 | *Pin2 | *Pin5 | *Pin8 | *Sou3 | *Ton | *Nan | *Shaa | *Pei | *Haku | *Hatsu | *Chun" },
+  { fan: 24, name: "全双刻", description: "由2、4、6、8序数牌的刻子、将牌组成的和牌。不计碰碰和、断幺。", example: "*Man2 Man2 Man2 | *Man4 Man4 Man4 | *Pin6 Pin6 Pin6 | *Sou8 Sou8 Sou8 | *Pin2 Pin2" },
+  { fan: 24, name: "清一色", description: "由一种花色的序数牌组成和牌。不计无字。", example: "*Man1 Man2 Man3 | *Man4 Man5 Man6 | *Man7 Man8 Man9 | *Man2 Man3 Man4 | *Man5 Man5" },
+  { fan: 24, name: "一色三同顺", description: "和牌时有一种花色3副序数相同的顺子。不计一色三节高。", example: "*Man1 Man2 Man3 | *Man1 Man2 Man3 | *Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou1 Sou1" },
+  { fan: 24, name: "一色三节高", description: "和牌时有一种花色3副依次递增一位数字的刻子。不计一色三同顺。", example: "*Man1 Man1 Man1 | *Man2 Man2 Man2 | *Man3 Man3 Man3 | Pin4 Pin5 Pin6 | Sou1 Sou1" },
+  { fan: 24, name: "全大", description: "由序数牌789组成的顺子、刻子(杠)、将牌的和牌。不计无字。", example: "*Man7 Man8 Man9 | *Pin7 Pin8 Pin9 | *Sou7 Sou7 Sou7 | *Sou8 Sou8 Sou8 | *Pin9 Pin9" },
+  { fan: 24, name: "全中", description: "由序数牌456组成的顺子、刻子(杠)、将牌的和牌。不计断幺。", example: "*Man4 Man5 Man6 | *Pin4 Pin5 Pin6 | *Sou4 Sou4 Sou4 | *Sou5 Sou5 Sou5 | *Pin5 Pin5" },
+  { fan: 24, name: "全小", description: "由序数牌123组成的顺子、刻子(杠)、将牌的和牌。不计无字。", example: "*Man1 Man2 Man3 | *Pin1 Pin2 Pin3 | *Sou1 Sou1 Sou1 | *Sou2 Sou2 Sou2 | *Pin2 Pin2" },
+  { fan: 16, name: "清龙", description: "和牌时，有一种花色1-9相连接的序数牌。", example: "*Man1 Man2 Man3 Man4 Man5 Man6 Man7 Man8 Man9 | Pin1 Pin2 Pin3 | Ton Ton" },
+  { fan: 16, name: "三色双龙会", description: "2种花色2个老少副、另一种花色5作将的和牌。不计喜相逢、老少副、无字、平和。", example: "*Man1 Man2 Man3 | *Man7 Man8 Man9 | *Pin1 Pin2 Pin3 | *Pin7 Pin8 Pin9 | *Sou5 Sou5" },
+  { fan: 16, name: "一色三步高", description: "和牌时，有一种花色3副依次递增一位或二位数字的顺子。", example: "*Man1 Man2 Man3 | *Man2 Man3 Man4 | *Man3 Man4 Man5 | Pin6 Pin7 Pin8 | Ton Ton" },
+  { fan: 16, name: "全带五", description: "每副牌及将牌必须有5的序数牌。不计断幺。", example: "*Man3 Man4 Man5 | *Pin5 Pin6 Pin7 | *Sou5 Sou5 Sou5 | *Sou4 Sou5 Sou6 | *Man5 Man5" },
+  { fan: 16, name: "三同刻", description: "3个序数相同的刻子(杠)。", example: "*Man2 Man2 Man2 | *Pin2 Pin2 Pin2 | *Sou2 Sou2 Sou2 | Pin6 Pin7 Pin8 | Ton Ton" },
+  { fan: 16, name: "三暗刻", description: "3个暗刻。", example: "*Man2 Man2 Man2 | *Pin4 Pin4 Pin4 | *Sou6 Sou6 Sou6 | Pin7 Pin8 Pin9 | Ton Ton" },
+  { fan: 12, name: "全不靠", description: "由单张3种花色147、258、369不能错位的序数牌及东南西北中发白中的任何14张牌组成的和牌。不计五门齐、不求人、单钓将。", example: "*Man1 | *Man4 | *Man7 | *Pin2 | *Pin5 | *Pin8 | *Sou3 | *Sou6 | *Sou9 | *Ton | *Shaa | *Haku | *Hatsu | *Chun" },
+  { fan: 12, name: "组合龙", description: "3种花色的147、258、369不能错位的序数牌。", example: "*Man1 Man4 Man7 Pin2 Pin5 Pin8 Sou3 Sou6 Sou9 | Ton Ton Ton | Nan Nan" },
+  { fan: 12, name: "大于五", description: "由序数牌6-9的顺子、刻子、将牌组成的和牌。不计无字。", example: "*Man6 Man7 Man8 | *Pin7 Pin8 Pin9 | *Sou6 Sou6 Sou6 | *Sou8 Sou8 Sou8 | *Pin6 Pin6" },
+  { fan: 12, name: "小于五", description: "由序数牌1-4的顺子、刻子、将牌组成的和牌。不计无字。", example: "*Man1 Man2 Man3 | *Pin2 Pin3 Pin4 | *Sou1 Sou1 Sou1 | *Sou3 Sou3 Sou3 | *Pin2 Pin2" },
+  { fan: 12, name: "三风刻", description: "3个风刻。", example: "*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | Man1 Man2 Man3 | Pin2 Pin2" },
+  { fan: 8, name: "花龙", description: "3种花色的3副顺子连接成1-9的序数牌。", example: "*Man1 Man2 Man3 | *Pin4 Pin5 Pin6 | *Sou7 Sou8 Sou9 | Ton Ton Ton | Nan Nan" },
+  { fan: 8, name: "推不倒", description: "由牌面图形没有上下区别的牌组成的和牌，包括1234589饼、245689条、白板。不计缺一门。", example: "*Pin1 Pin2 Pin3 | *Pin8 Pin8 Pin8 | *Sou2 Sou2 Sou2 | *Sou4 Sou5 Sou6 | *Haku Haku" },
+  { fan: 8, name: "三色三同顺", description: "和牌时，有3种花色3副序数相同的顺子。", example: "*Man2 Man3 Man4 | *Pin2 Pin3 Pin4 | *Sou2 Sou3 Sou4 | Ton Ton Ton | Nan Nan" },
+  { fan: 8, name: "三色三节高", description: "和牌时，有3种花色3副依次递增一位数的刻子。", example: "*Man2 Man2 Man2 | *Pin3 Pin3 Pin3 | *Sou4 Sou4 Sou4 | Ton Ton Ton | Nan Nan" },
+  { fan: 8, name: "无番和", description: "和牌后，数不出任何番种分(花牌不计算在内)。", example: "*Man1 Man2 Man3 | *Pin4 Pin5 Pin6 | *Sou2 Sou3 Sou4 | *Man8 Man8 Man8 | *Nan Nan" },
+  { fan: 8, name: "妙手回春", description: "自摸牌墙上最后一张牌和牌。不计自摸。", example: "" },
+  { fan: 8, name: "海底捞月", description: "和打出的最后一张牌。", example: "" },
+  { fan: 8, name: "杠上开花", description: "开杠抓进的牌成和牌(不包括补花)。不计自摸。", example: "" },
+  { fan: 8, name: "抢杠和", description: "和别人自抓开明杠的牌。不计和绝张。", example: "" },
+  { fan: 6, name: "碰碰和", description: "由4副刻子(或杠)、将牌组成的和牌。", example: "*Man2 Man2 Man2 | *Pin5 Pin5 Pin5 | *Sou8 Sou8 Sou8 | *Ton Ton Ton | *Nan Nan" },
+  { fan: 6, name: "混一色", description: "由一种花色序数牌及字牌组成的和牌。", example: "*Man1 Man2 Man3 | *Man5 Man6 Man7 | *Man8 Man8 Man8 | *Ton Ton Ton | *Nan Nan" },
+  { fan: 6, name: "三色三步高", description: "3种花色3副依次递增一位序数的顺子。", example: "*Man2 Man3 Man4 | *Pin3 Pin4 Pin5 | *Sou4 Sou5 Sou6 | Ton Ton Ton | Nan Nan" },
+  { fan: 6, name: "五门齐", description: "和牌时3种序数牌、风、箭牌齐全。", example: "*Man1 Man2 Man3 | *Pin4 Pin5 Pin6 | *Sou7 Sou8 Sou9 | *Ton Ton Ton | *Chun Chun" },
+  { fan: 6, name: "全求人", description: "全靠吃牌、碰牌、单钓别人批出的牌和牌。不计单钓。", example: "" },
+  { fan: 6, name: "双暗杠", description: "2个暗杠。", example: "*Back Man1 Man1 Back | *Back Pin4 Pin4 Back | Sou7 Sou8 Sou9 | Ton Ton Ton | Nan Nan" },
+  { fan: 6, name: "双箭刻", description: "2副箭刻(或杠)。", example: "*Chun Chun Chun | *Hatsu Hatsu Hatsu | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Nan Nan" },
+  { fan: 4, name: "全带幺", description: "和牌时，每副牌、将牌都有幺牌。", example: "*Man1 Man2 Man3 | *Man7 Man8 Man9 | *Pin1 Pin2 Pin3 | *Ton Ton Ton | *Nan Nan" },
+  { fan: 4, name: "不求人", description: "4副牌及将中没有吃牌、碰牌(包括明杠)，自摸和牌。", example: "" },
+  { fan: 4, name: "双明杠", description: "2个明杠。", example: "*Man1 Man1 Man1 Man1 | *Pin4 Pin4 Pin4 Pin4 | Sou7 Sou8 Sou9 | Ton Ton Ton | Nan Nan" },
+  { fan: 4, name: "和绝张", description: "和牌池、桌面已亮明的3张牌所剩的第4张牌(抢杠和不计和绝张)。", example: "" },
+  { fan: 2, name: "箭刻", description: "由中、发、白3张相同的牌组成的刻子。", example: "*Chun Chun Chun | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 2, name: "圈风刻", description: "与圈风相同的风刻。", example: "*Ton Ton Ton | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 2, name: "门风刻", description: "与本门风相同的风刻。", example: "*Pei Pei Pei | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 2, name: "门前清", description: "没有吃、碰、明杠，和别人打出的牌。", example: "*Man1 Man2 Man3 | *Pin4 Pin5 Pin6 | *Sou7 Sou8 Sou9 | *Ton Ton Ton | *Nan Nan" },
+  { fan: 2, name: "平和", description: "由4副顺子及序数牌作将组成的和牌，边、坎、钓不影响平和。", example: "*Man1 Man2 Man3 | *Pin4 Pin5 Pin6 | *Sou2 Sou3 Sou4 | *Sou7 Sou8 Sou9 | *Man5 Man5" },
+  { fan: 2, name: "四归一", description: "和牌中，有4张相同的牌归于一家的顺、刻子、对、将牌中(不包括杠牌)。", example: "*Man1 Man2 Man3 | *Man1 Man1 Man1 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 2, name: "双同刻", description: "2副序数相同的刻子。", example: "*Man2 Man2 Man2 | *Pin2 Pin2 Pin2 | Man4 Man5 Man6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 2, name: "双暗刻", description: "2个暗刻。", example: "*Man2 Man2 Man2 | *Pin4 Pin4 Pin4 | Man7 Man8 Man9 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 2, name: "断幺", description: "和牌中没有一、九及字牌。", example: "*Man2 Man3 Man4 | *Pin4 Pin5 Pin6 | *Sou6 Sou7 Sou8 | *Sou2 Sou3 Sou4 | *Man5 Man5" },
+  { fan: 2, name: "暗杠", description: "自抓4张相同的牌作杠。", example: "*Back Man1 Man1 Back | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Ton Ton Ton | Nan Nan" },
+  { fan: 1, name: "一般高", description: "由一种花色2副相同的顺子组成的牌。", example: "*Man2 Man3 Man4 | *Man2 Man3 Man4 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "喜相逢", description: "2种花色2副序数相同的顺子。", example: "*Man2 Man3 Man4 | *Pin2 Pin3 Pin4 | Sou4 Sou5 Sou6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "连六", description: "一种花色6张相连接的序数牌。", example: "*Man1 Man2 Man3 | *Man4 Man5 Man6 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "老少副", description: "一种花色牌的123、789两副顺子。", example: "*Man1 Man2 Man3 | *Man7 Man8 Man9 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "幺九刻", description: "3张相同的一、九序数牌或字牌组成的刻子(或杠)。", example: "*Man1 Man1 Man1 | Man4 Man5 Man6 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "明杠", description: "自己有暗刻，碰别人打出的一张相同的牌开杠：或自己抓进一张与碰的明刻相同的牌开杠。", example: "*Man1 Man1 Man1 Man1 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Ton Ton Ton | Nan Nan" },
+  { fan: 1, name: "缺一门", description: "和牌中缺少一种花色序数牌。", example: "*Man1 Man2 Man3 | *Man4 Man5 Man6 | *Pin4 Pin5 Pin6 | *Pin7 Pin8 Pin9 | *Ton Ton" },
+  { fan: 1, name: "无字", description: "和牌中没有字牌。", example: "*Man1 Man2 Man3 | *Man4 Man5 Man6 | *Pin4 Pin5 Pin6 | *Sou7 Sou8 Sou9 | *Man8 Man8" },
+  { fan: 1, name: "边张", description: "单和123的3及789的7或1233和3、7789和7都为边张。手中有12345和3，56789和7不算边张。", example: "^Man1 ^Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Ton Ton Ton | Nan Nan" },
+  { fan: 1, name: "坎张", description: "和2条、4条之间的3条。4556和5也算坎张，手中有45567和6不算坎张。", example: "^Sou2 Sou3 ^Sou4 | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Ton Ton Ton | Nan Nan" },
+  { fan: 1, name: "单钓将", description: "钓单张牌作将成和。", example: "Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Ton Ton Ton | ^Nan Nan" },
+  { fan: 1, name: "自摸", description: "自己抓进牌成和牌。", example: "" },
+  { fan: 1, name: "花牌", description: "即春夏秋冬，梅兰竹菊，每花计一分。不计在起和分内，和牌后才能计分。花牌补花成和计自摸，不计杠上开花。", example: "", tags: ["不计起和分"] }
+];
+
+export const groupedFanTable = fanTableData.reduce((acc, current) => {
+  if (!acc[current.fan]) {
+    acc[current.fan] = [];
+  }
+  acc[current.fan].push(current);
+  return acc;
+}, {} as Record<number, FanItem[]>);

--- a/frontend/src/data/riichiFanTableData.ts
+++ b/frontend/src/data/riichiFanTableData.ts
@@ -1,0 +1,70 @@
+export interface RiichiFanItem {
+  name: string;
+  fan: number;
+  description: string;
+  example: string;
+  tags?: string[];
+}
+
+export const riichiFanTableData: RiichiFanItem[] = [
+  // 1番
+  { fan: 1, name: "立直", description: "门前清状态下，听牌时所作的宣告。", example: "" },
+  { fan: 1, name: "断幺九", description: "和牌中没有一、九及字牌。鸣牌也成立（食断）。", example: "*Man2 Man3 Man4 | *Pin4 Pin5 Pin6 | *Sou6 Sou7 Sou8 | *Sou2 Sou3 Sou4 | *Man5 Man5" },
+  { fan: 1, name: "役牌：白", description: "包含白板的刻子。鸣牌也成立。", example: "*Haku Haku Haku | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "役牌：发", description: "包含发财的刻子。鸣牌也成立。", example: "*Hatsu Hatsu Hatsu | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "役牌：中", description: "包含红中的刻子。鸣牌也成立。", example: "*Chun Chun Chun | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "役牌：场风", description: "和牌局所处场风的风牌刻子。鸣牌也成立。", example: "*Ton Ton Ton | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "役牌：自风", description: "和自己所处方位的风牌刻子。鸣牌也成立。", example: "*Ton Ton Ton | Man1 Man2 Man3 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "平和", description: "门前清状态下，由4副顺子和非役牌的将牌组成的和牌。且听牌为两面听。", example: "*Man2 Man3 Man4 | *Pin4 Pin5 Pin6 | *Sou2 Sou3 Sou4 | *Sou7 Sou8 Sou9 | *Man5 Man5" },
+  { fan: 1, name: "门前清自摸和", description: "门前清状态下，自摸和牌。", example: "" },
+  { fan: 1, name: "一发", description: "宣告立直后，在一巡内和牌，或在一巡内自摸和牌。这期间如有吃、碰、明杠，则不成立。", example: "" },
+  { fan: 1, name: "一杯口", description: "门前清状态下，和牌中有2副完全相同的顺子。", example: "*Man2 Man3 Man4 | *Man2 Man3 Man4 | Pin4 Pin5 Pin6 | Sou7 Sou8 Sou9 | Nan Nan" },
+  { fan: 1, name: "岭上开花", description: "摸岭上牌和牌。", example: "" },
+  { fan: 1, name: "海底摸月", description: "摸取海底牌和牌。", example: "" },
+  { fan: 1, name: "河底捞鱼", description: "别人打出局中的最后一张牌时荣和。", example: "" },
+  { fan: 1, name: "枪杠", description: "和别人加杠的牌。国士无双可抢暗杠。", example: "" },
+  { fan: 1, name: "宝牌", description: "和牌时，手牌中每有一张宝牌计1番。必须有其他起和役才能和牌。", example: "", tags: ["非役"] },
+  { fan: 1, name: "赤宝牌", description: "和牌时，手牌中每有一张红宝牌计1番。必须有其他起和役才能和牌。", example: "", tags: ["非役"] },
+  { fan: 1, name: "里宝牌", description: "立直和牌时，翻开悬赏指示牌底下的牌。相应的宝牌每有一张计1番。必须有其他起和役才能和牌。", example: "", tags: ["非役"] },
+  { fan: 1, name: "拔北宝牌", description: "(三人麻将) 拔出的北风可以作为宝牌提供相应的番数。必须有其他起和役才能和牌。", example: "", tags: ["非役"] },
+
+  // 2番
+  { fan: 2, name: "对对和", description: "和牌中含有4副刻子或杠。", example: "*Man2 Man2 Man2 | *Pin5 Pin5 Pin5 | *Sou8 Sou8 Sou8 | *Ton Ton Ton | *Nan Nan" },
+  { fan: 2, name: "七对子", description: "门前清状态下，由7个不同的对子组成的和牌。", example: "*Man1 Man1 | *Man4 Man4 | *Pin2 Pin2 | *Pin5 Pin5 | *Sou3 Sou3 | *Sou8 Sou8 | *Ton Ton" },
+  { fan: 2, name: "三色同顺", description: "含有3种花色且序数相同的3副顺子。副露减1番。", example: "*Man2 Man3 Man4 | *Pin2 Pin3 Pin4 | *Sou2 Sou3 Sou4 | Ton Ton Ton | Nan Nan", tags: ["副露-1番"] },
+  { fan: 2, name: "一气通贯", description: "含有一种花色的123、456、789三副顺子。副露减1番。", example: "*Man1 Man2 Man3 | *Man4 Man5 Man6 | *Man7 Man8 Man9 | Pin1 Pin2 Pin3 | Ton Ton", tags: ["副露-1番"] },
+  { fan: 2, name: "混全带幺九", description: "所有的顺子、刻子、将牌均含有老头牌和字牌。副露减1番。", example: "*Man1 Man2 Man3 | *Man7 Man8 Man9 | *Pin1 Pin2 Pin3 | *Ton Ton Ton | *Nan Nan", tags: ["副露-1番"] },
+  { fan: 2, name: "三暗刻", description: "和牌中含有3副暗刻。只要不是别人打出的牌就可以。", example: "*Man2 Man2 Man2 | *Pin4 Pin4 Pin4 | *Sou6 Sou6 Sou6 | Pin7 Pin8 Pin9 | Ton Ton" },
+  { fan: 2, name: "两立直", description: "第一巡时宣告立直。在此之前如果有别人的吃、碰、明杠，则该役不成立。", example: "" },
+  { fan: 2, name: "小三元", description: "含有由中、发、白组成的2副刻子和1对将牌。", example: "*Chun Chun Chun | *Hatsu Hatsu Hatsu | *Haku Haku | Man1 Man2 Man3 | Pin1 Pin2 Pin3" },
+  { fan: 2, name: "混老头", description: "和牌中只含有字牌和老头牌（一、九）。必然复合对对和或七对子。", example: "*Man1 Man1 Man1 | *Pin9 Pin9 Pin9 | *Ton Ton Ton | *Nan Nan Nan | *Haku Haku" },
+  { fan: 2, name: "三色同刻", description: "和牌中，含有3种花色且序数相同的3副刻子。", example: "*Man2 Man2 Man2 | *Pin2 Pin2 Pin2 | *Sou2 Sou2 Sou2 | Pin4 Pin5 Pin6 | Nan Nan" },
+  { fan: 2, name: "三杠子", description: "一个人开出3副杠。", example: "*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Man3 Man3 Man3 Man3 | Man1 Man2 Man3 | Man5 Man5" },
+
+  // 3番
+  { fan: 3, name: "混一色", description: "含有字牌和一种花色的序数牌。副露减1番。", example: "*Man1 Man2 Man3 | *Man5 Man6 Man7 | *Man8 Man8 Man8 | *Ton Ton Ton | *Nan Nan", tags: ["副露-1番"] },
+  { fan: 3, name: "纯全带幺九", description: "所有的顺子、刻子、将牌均含有老头牌（不含字牌）。副露减1番。", example: "*Man1 Man2 Man3 | *Man7 Man8 Man9 | *Pin1 Pin2 Pin3 | *Pin7 Pin8 Pin9 | *Sou1 Sou1", tags: ["副露-1番"] },
+  { fan: 3, name: "二杯口", description: "门前清状态下，和牌中有2个一杯口（2个相同顺子组成的对子）。不计一杯口。", example: "*Man2 Man2 Man3 Man3 Man4 Man4 | *Pin4 Pin4 Pin5 Pin5 Pin6 Pin6 | Ton Ton" },
+
+  // 6番
+  { fan: 6, name: "清一色", description: "只含有一种花色的序数牌。副露减1番。", example: "*Man1 Man2 Man3 | *Man4 Man5 Man6 | *Man7 Man8 Man9 | *Man2 Man3 Man4 | *Man5 Man5", tags: ["副露-1番"] },
+
+  // 13番 (役满)
+  { fan: 13, name: "四暗刻", description: "含有4个暗刻。门前清限定。必须自摸，若荣和则为三暗刻对对和。", example: "*Man1 Man1 Man1 | *Man2 Man2 Man2 | *Man3 Man3 Man3 | *Man4 Man4 Man4 | Pin1 Pin1" },
+  { fan: 13, name: "国士无双", description: "由13种一、九及字牌各一张，外加其中任何一种的一张组成的和牌。门前清限定。", example: "*Man1 | *Man9 | *Pin1 | *Pin9 | *Sou1 | *Sou9 | *Ton | *Nan | *Shaa | *Pei | *Haku | *Hatsu | *Chun Chun" },
+  { fan: 13, name: "大三元", description: "包含中、发、白的三副刻子。", example: "*Chun Chun Chun | *Hatsu Hatsu Hatsu | *Haku Haku Haku | Man1 Man2 Man3 | Pin1 Pin1" },
+  { fan: 13, name: "字一色", description: "全部由字牌组成的和牌。", example: "*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Haku Haku Haku | *Chun Chun" },
+  { fan: 13, name: "小四喜", description: "包含风牌的3副刻子和1对将牌组成的和牌。", example: "*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Pei Pei | Man1 Man2 Man3" },
+  { fan: 13, name: "绿一色", description: "只包含绿色牌（条子2、3、4、6、8和发财）构成的和牌。可不包含发财。", example: "*Sou2 Sou3 Sou4 | *Sou6 Sou6 Sou6 | *Sou8 Sou8 Sou8 | *Hatsu Hatsu Hatsu | *Sou2 Sou2" },
+  { fan: 13, name: "清老头", description: "全部包含老头牌（一、九）的对对和。", example: "*Man1 Man1 Man1 | *Man9 Man9 Man9 | *Pin1 Pin1 Pin1 | *Pin9 Pin9 Pin9 | *Sou1 Sou1" },
+  { fan: 13, name: "地和", description: "闲家在第一巡自摸和牌。这之前如有他家的吃、碰、明杠，则该役不成立。", example: "" },
+  { fan: 13, name: "九莲宝灯", description: "由一种花色的1112345678999构成的牌型，和该种花色的任意一张。门前清限定。", example: "*Man1 Man1 Man1 Man2 Man3 Man4 Man5 Man6 Man7 Man8 Man9 Man9 Man9 Man1" },
+  { fan: 13, name: "天和", description: "庄家发牌后第一张牌即和牌。暗杠不成立。", example: "" },
+  { fan: 13, name: "四杠子", description: "4个杠。", example: "*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Pin3 Pin3 Pin3 Pin3 | *Pin4 Pin4 Pin4 Pin4 | Shaa Shaa" },
+
+  // 26番 (双倍役满)
+  { fan: 26, name: "四暗刻单骑", description: "先集齐4个暗刻，单听将牌的和牌型。", example: "*Man1 Man1 Man1 | *Man2 Man2 Man2 | *Man3 Man3 Man3 | *Man4 Man4 Man4 | ^Pin1 Pin1" },
+  { fan: 26, name: "国士无双十三面听", description: "手牌先集齐13种么九牌各一张，听所有13种么九牌。", example: "*Man1 *Man9 *Pin1 *Pin9 *Sou1 *Sou9 *Ton *Nan *Shaa *Pei *Haku *Hatsu *Chun | ^Chun" },
+  { fan: 26, name: "大四喜", description: "包含风牌的4副刻子组成的和牌。", example: "*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Pei Pei Pei | Man1 Man1" },
+  { fan: 26, name: "纯正九莲宝灯", description: "九莲宝灯听九面。1112345678999听所有同花色牌。", example: "*Man1 Man1 Man1 Man2 Man3 Man4 Man5 Man6 Man7 Man8 Man9 Man9 Man9 | ^Man1" },
+];

--- a/frontend/src/data/shenyangFanTableData.ts
+++ b/frontend/src/data/shenyangFanTableData.ts
@@ -1,0 +1,175 @@
+export interface ShenyangFanItem {
+  name: string;
+  fan: number;
+  description: string;
+  example: string;
+  tags?: string[];
+}
+
+/**
+ * 沈阳穷胡规则数据
+ * 计算公式：分数 = 基础底分 * 2^N (N 为总番数叠加，通常 N 最大封顶为 6)
+ */
+export const shenyangFanTableData: ShenyangFanItem[] = [
+  // 0番 (规则说明)
+  {
+    fan: 0,
+    name: "沈阳麻将规则概览",
+    description: "沈阳麻将是辽宁省沈阳地区的特色麻将玩法，采用136张牌包含万、筒、索、风、字五类牌型，参与者共4人。该玩法以庄家轮换制为基础，开局时庄家持14张牌、其余玩家持13张牌，按逆时针顺序轮流出牌。和牌需满足开门、有横牌或中发白掌牌、包含幺九牌及三门齐等条件。胜负结算时自摸则三家负，点炮仅由放铳者担责（注：闭门不点炮亦需赔付），番数按2的幂次计算。允许旋风杠特殊算番机制。该玩法因规则复杂且娱乐性强，深受当地牌友欢迎。",
+    example: "",
+    tags: ["官方规则", "玩法简介"]
+  },
+
+  // 1番
+  {
+    fan: 1,
+    name: "闭门 (负方惩罚)",
+    description: "特定惩罚性质：对于所有处于‘闭门’状态的负方（即无吃、碰、明杠），不仅其必须向赢家支付分数（即便其不是点炮者），且其承担的结算番数 N 额外增加 1 番。",
+    example: "",
+    tags: ["负方惩罚", "强制支付", "1番叠加"]
+  },
+  {
+    fan: 1,
+    name: "自摸",
+    description: "自己抓得所需之牌。番数 N 增加 1 番。",
+    example: "",
+    tags: ["赢家番"]
+  },
+  {
+    fan: 1,
+    name: "点炮",
+    description: "由别人打出所需之牌。番数 N 增加 1 番。",
+    example: "",
+    tags: ["输家番"]
+  },
+  {
+    fan: 1,
+    name: "庄家身份 (庄胡/点庄)",
+    description: "如果庄家胡牌，或者闲家胡了庄家打出的炮，结算时番数 N 增加 1 番。",
+    example: "",
+    tags: ["身份叠加"]
+  },
+  {
+    fan: 1,
+    name: "闷大山",
+    description: "指胜方在其余三名玩家中有人开门（吃、碰、明杠）之前胡牌。计1番。",
+    example: "",
+    tags: ["时机番"]
+  },
+  {
+    fan: 1,
+    name: "一口听 (胡单张/一本听)",
+    description: "胡牌时听牌仅为一张，共分四种情况：\na. 边：和123中的3或789中的7；\nb. 夹：和顺子中间张（如和123中的2）；\nc. 单胡幺：除和牌外无其它幺九时，和123中的1或789中的9；\nd. 单砸：即单吊将牌（和牌是将来凑成对子的一张）。\n符合以上任一情况计1番。",
+    example: "Pin2 ^Pin3 Pin4 | Man1 Man2 Man3 | Sou7 Sou8 Sou9 | Ton Ton Ton | Nan Nan",
+    tags: ["判定番", "1番"]
+  },
+  {
+    fan: 1,
+    name: "手把一",
+    description: "只在‘飘胡’（对对胡）的情况下成立。经过吃、碰、明杠后，手牌仅剩一张，单钓这张牌胡牌。计1番。沈阳规则下，非飘胡牌型不允许计手把一。",
+    example: "Man2 Man2 Man2 | Pin5 Pin5 Pin5 | Sou8 Sou8 Sou8 | Ton Ton Ton | ^Nan",
+    tags: ["番型", "需复合飘胡"]
+  },
+  {
+    fan: 1,
+    name: "旋风杠 (中发白)",
+    description: "手中集齐中、发、白各一张即可亮雷。玩家可在自己行牌的任意回合亮出。计1番。\n注意：\n1. 亮出旋风杠不算开门（不影响闭门状态）。\n2. 在胡牌之前必须主动亮出，否则该局不得胡牌。",
+    example: "*Chun *Hatsu *Haku",
+    tags: ["杠牌", "特殊规则", "不开门"]
+  },
+  {
+    fan: 1,
+    name: "中发白碰",
+    description: "手中持有中、发、白任意一门组成的碰牌，计1番。",
+    example: "*Chun Chun Chun",
+    tags: ["碰牌"]
+  },
+  {
+    fan: 1,
+    name: "明杠",
+    description: "包括点杠或补杠，计1番。",
+    example: "*Man1 Man1 Man1 Man1",
+    tags: ["杠牌"]
+  },
+  {
+    fan: 1,
+    name: "杠上开花",
+    description: "开杠抓进的牌成和牌。计1番。",
+    example: "",
+    tags: ["状态番"]
+  },
+  {
+    fan: 1,
+    name: "海底捞月",
+    description: "在分张（最后一轮牌，只抓牌不出牌）时和牌。计1番。",
+    example: "",
+    tags: ["状态番"]
+  },
+  {
+    fan: 1,
+    name: "抢杠",
+    description: "和别人补杠后打出的牌。计1番。",
+    example: "",
+    tags: ["状态番"]
+  },
+  {
+    fan: 1,
+    name: "四归一",
+    description: "和牌时，非杠牌可以组成4张相同牌。计1番。",
+    example: "*Man1 Man2 Man3 | *Man1 Man1 Man1",
+    tags: ["番型"]
+  },
+  {
+    fan: 1,
+    name: "黄庄长毛 / 跟庄长毛",
+    description: "流局或首轮跟庄，累积计入后续对局番数，计1番。",
+    example: "",
+    tags: ["长毛叠加"]
+  },
+
+  // 2番
+  {
+    fan: 2,
+    name: "旋风杠 (东南西北)",
+    description: "手中集齐东、南、西、北各一张即可亮雷。玩家可在自己行牌的任意回合亮出。计2番。\n注意：\n1. 亮出旋风杠不算开门（不影响闭门状态）。\n2. 在胡牌之前必须主动亮出，否则该局不得胡牌。",
+    example: "*Ton *Nan *Shaa *Pei",
+    tags: ["杠牌", "特殊规则", "不开门"]
+  },
+  {
+    fan: 2,
+    name: "暗杠",
+    description: "自己抓齐四张同样的牌面朝下开杠。计2番。",
+    example: "*Back Man1 Man1 Back",
+    tags: ["杠牌"]
+  },
+  {
+    fan: 2,
+    name: "中发白明杠",
+    description: "中发白组成的明杠。计2番。",
+    example: "*Chun Chun Chun Chun",
+    tags: ["杠牌"]
+  },
+  {
+    fan: 2,
+    name: "七小对",
+    description: "胡牌由7个对子组成。计2番。\n特点：沈阳穷胡中唯一允许‘不开门’（闭门）胡牌的情况。\n限制：虽不要求有‘横’（刻子），但仍必须满足三门齐（不缺门）和有幺九（不缺幺）的要求。此外，不再计入‘胡单张’番数。",
+    example: "Man1 Man1 | Man9 Man9 | Pin1 Pin1 | Pin9 Pin9 | Sou1 Sou1 | Sou9 Sou9 | Ton Ton",
+    tags: ["特殊胡法", "不开门许可"]
+  },
+
+  // 3番
+  {
+    fan: 3,
+    name: "飘胡 (对对胡)",
+    description: "胡牌时，手牌由4副刻子或杠（暗刻、明刻、杠均开）与一对将牌组成。沈阳穷胡中的大番型，计3番。",
+    example: "*Man2 Man2 Man2 | *Pin5 Pin5 Pin5 | *Sou8 Sou8 Sou8 | *Ton Ton Ton | *Nan Nan",
+    tags: ["大番型"]
+  },
+  {
+    fan: 3,
+    name: "中发白暗杠",
+    description: "中发白组成的暗杠。计3番。",
+    example: "*Back Chun Chun Back",
+    tags: ["杠牌", "高收益"]
+  }
+];

--- a/frontend/src/pages/FanTablePage.tsx
+++ b/frontend/src/pages/FanTablePage.tsx
@@ -1,18 +1,28 @@
 import React, { useState, useMemo } from 'react';
 import { fanTableData, FanItem } from '../data/fanTableData';
+import { riichiFanTableData, RiichiFanItem } from '../data/riichiFanTableData';
+import { shenyangFanTableData, ShenyangFanItem } from '../data/shenyangFanTableData';
+
+type TabType = 'guobiao' | 'riichi' | 'shenyang';
 
 const FanTablePage: React.FC = () => {
   const [search, setSearch] = useState('');
+  const [activeTab, setActiveTab] = useState<TabType>('guobiao');
 
   const filteredFanTable = useMemo(() => {
-    if (!search.trim()) return fanTableData;
+    let data;
+    if (activeTab === 'guobiao') data = fanTableData;
+    else if (activeTab === 'riichi') data = riichiFanTableData;
+    else data = shenyangFanTableData;
+
+    if (!search.trim()) return data;
     const lowerSearch = search.toLowerCase().trim();
-    return fanTableData.filter(item => 
+    return data.filter(item => 
       item.name.toLowerCase().includes(lowerSearch) || 
       item.description.toLowerCase().includes(lowerSearch) ||
       item.fan.toString() === lowerSearch
     );
-  }, [search]);
+  }, [search, activeTab]);
 
   const groupedAndSortedFans = useMemo(() => {
     const grouped = filteredFanTable.reduce((acc, current) => {
@@ -31,12 +41,58 @@ const FanTablePage: React.FC = () => {
     .map(Number)
     .sort((a, b) => a - b);
 
+  const getFanLabel = (fan: number) => {
+    if (activeTab === 'riichi') {
+      if (fan === 13) return '役满';
+      if (fan === 26) return '双倍役满';
+    }
+    if (activeTab === 'shenyang') {
+      if (fan === 0) return '规则概览';
+      return `${fan} 番`;
+    }
+    return `${fan} 番`;
+  };
+
+  const getTitle = () => {
+    if (activeTab === 'guobiao') return '国标麻将81番表';
+    if (activeTab === 'riichi') return '日本麻将(雀魂)番表';
+    return '东北沈阳穷胡麻将规则';
+  };
+
+  const getSubtitle = () => {
+    if (activeTab === 'guobiao') return '快速对照查询中国麻将竞赛规则（国标麻将）的81种番型及分数。';
+    if (activeTab === 'riichi') return '快速对照查询日本麻将（以雀魂规则为准）的各级役种及番数。';
+    return '学习和查询带有闭门、飘、手把一、旋风杠等浓密地方特色的沈阳穷胡规则。';
+  };
+
   return (
     <div className="fan-table-page">
       <div className="card">
-        <h2>国标麻将81番表</h2>
+        <div className="flex-between" style={{ marginBottom: '16px' }}>
+          <h2>{getTitle()}</h2>
+          <div className="tab-bar">
+            <button
+              className={`tab-btn ${activeTab === 'guobiao' ? 'tab-active' : ''}`}
+              onClick={() => setActiveTab('guobiao')}
+            >
+              国标麻将
+            </button>
+            <button
+              className={`tab-btn ${activeTab === 'riichi' ? 'tab-active' : ''}`}
+              onClick={() => setActiveTab('riichi')}
+            >
+              雀魂日麻
+            </button>
+            <button
+              className={`tab-btn ${activeTab === 'shenyang' ? 'tab-active' : ''}`}
+              onClick={() => setActiveTab('shenyang')}
+            >
+              沈阳穷胡
+            </button>
+          </div>
+        </div>
         <p style={{ color: 'var(--text-light)', marginBottom: '24px' }}>
-          快速对照查询中国麻将竞赛规则（国标麻将）的81种番型及分数。
+          {getSubtitle()}
         </p>
 
         <div style={{ marginBottom: '24px' }}>
@@ -56,13 +112,18 @@ const FanTablePage: React.FC = () => {
 
         {fans.map(fan => (
           <div key={fan} className="fan-group">
-            <h3 className="fan-group-title">{fan} 番</h3>
+            <h3 className="fan-group-title">{getFanLabel(fan)}</h3>
             <div className="fan-item-grid">
               {groupedAndSortedFans[fan].map(item => (
                 <div key={item.name} className="fan-item-card">
                   <div className="fan-item-header">
-                    <span className="fan-item-name">{item.name}</span>
-                    <span className="fan-item-score">{item.fan} 番</span>
+                    <span className="fan-item-name" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      {item.name}
+                      {item.tags?.map(tag => (
+                        <span key={tag} className="badge badge-completed" style={{ fontSize: '0.7rem', padding: '2px 6px' }}>{tag}</span>
+                      ))}
+                    </span>
+                    <span className="fan-item-score">{getFanLabel(item.fan)}</span>
                   </div>
                   <p className="fan-item-desc">{item.description}</p>
                   {item.example && item.example.length > 0 && (


### PR DESCRIPTION
This PR adds dedicated fan tables for Riichi (Majsoul style) and Shenyang (Qiong Hu style) Mahjong, along with a navigation tab to switch between rulesets. Features include detailed rule tags (open-hand penalty, non-yaku indicators) and refined settlement logic descriptions for Shenyang rules.