### PR TITLE
Fix build error in comprehensive.test.ts

### DIFF
--- a/frontend/src/logic/guobiao/comprehensive.test.ts
+++ b/frontend/src/logic/guobiao/comprehensive.test.ts
@@ -3,6 +3,7 @@ import { Tile, TileSuit } from './tiles';
 import { Meld, GameOptions, CalcResult } from './types';
 import { calculateBestScore } from './fan';
 
+/**
  * Comprehensive Test Suite for Guobiao Mahjong Logic.
  * References from external engine validation.
  */


### PR DESCRIPTION
Restored the missing '/**' tag in the comment block that was accidentally removed during the cleanup refactor.