### PR TITLE
fix: resolve scoring bugs, add 3-player support, and improve mobile UX

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Build & Test
+        run: chmod +x gradlew && ./gradlew build
+
+  frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:run

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A mahjong score tracker for friends.
 ### Game Modes
 Three mahjong variants with auto-calculated scoring:
 - **国标麻将** — Standard 8-point base scoring
-- **东北麻将 (抗日麻将)** — 番-based scoring with 庄家 and 闭门 multipliers
+- **东北麻将** — 番-based scoring with 庄家 and 闭门 multipliers
 - **立直麻将** — 番/符 point lookup with 本场, 供托, and 流局 (听牌/未听) support
 
 ### Home

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -419,6 +419,9 @@ tr:hover td { background: rgba(0,0,0,0.02); }
   font-variant-numeric: tabular-nums;
 }
 
+.score-cell.score-positive { color: var(--success); }
+.score-cell.score-negative { color: var(--danger); }
+
 .score-table .total-row td {
   font-weight: 700;
   background: var(--bg);
@@ -580,6 +583,13 @@ tr:hover td { background: rgba(0,0,0,0.02); }
   text-transform: uppercase;
 }
 
+.player-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
 .total-score-box {
   display: flex;
   flex-direction: column;
@@ -591,14 +601,6 @@ tr:hover td { background: rgba(0,0,0,0.02); }
   font-weight: 600;
   color: var(--text-light);
   margin-top: 2px;
-}
-
-.score-calc-link {
-  margin-left: 8px;
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--primary);
-  text-decoration: underline;
 }
 
 .score-calc-btn {
@@ -866,6 +868,13 @@ tr:hover td { background: rgba(0,0,0,0.02); }
   cursor: pointer;
   text-align: center;
   transition: all 0.2s;
+  overflow: hidden;
+}
+
+.player-select-card div {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .player-select-card.selected {
@@ -877,6 +886,13 @@ tr:hover td { background: rgba(0,0,0,0.02); }
 .player-select-card.disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.th-subtitle {
+  display: block;
+  font-size: 0.6rem;
+  font-weight: 400;
+  opacity: 0.7;
 }
 
 /* ===== Mobile responsive ===== */
@@ -1094,6 +1110,21 @@ tr:hover td { background: rgba(0,0,0,0.02); }
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .th-subtitle {
+    display: none;
+  }
+
+  .fan-item-example {
+    flex-wrap: wrap;
+    overflow-x: visible;
+  }
+}
+
+@media (max-width: 480px) {
+  .hide-mobile {
+    display: none;
   }
 }
 

--- a/frontend/src/logic/guobiao/benchmark.test.ts
+++ b/frontend/src/logic/guobiao/benchmark.test.ts
@@ -26,9 +26,14 @@ function parseHand(handStr: string, opts: Partial<GameOptions> = {}): { conceale
       const rank = Number(token.slice(8));
       melds.push({ type: 'gang', tiles: [new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank)], isOpen: false });
     } else {
-      const suit = token[0] as TileSuit;
-      const ranks = token.slice(1).split('').map(Number);
-      ranks.forEach(r => concealed.push(new Tile(suit, r)));
+      let suit: TileSuit | null = null;
+      for (const ch of token) {
+        if ('mpsz'.includes(ch)) {
+          suit = ch as TileSuit;
+        } else if (suit && ch >= '1' && ch <= '9') {
+          concealed.push(new Tile(suit, Number(ch)));
+        }
+      }
     }
   }
 
@@ -120,8 +125,8 @@ describe('Guobiao Benchmarks - Automated From External Samples', () => {
     expectFans('p1 p2 p3 m4 m5 m6 s7 s8 s9 z4 z4 z4 z5 z5', ['花龙'], {});
   });
 
-  test('Sample 20: 推不到', () => {
-    expectFans('p2 p3 p4 p5 p5 p5 s4 s5 s6 z7 z7 z7 p1 p1', ['推不到'], {});
+  test('Sample 20: 推不倒', () => {
+    expectFans('p2 p3 p4 p5 p5 p5 s4 s5 s6 z7 z7 z7 p1 p1', ['推不倒'], {});
   });
 
   test('Sample 21: 三色三同顺', () => {
@@ -364,7 +369,7 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 16', () => {
-    expectFans('pung:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","抢杠和"], {"gangShang":true});
+    expectFans('pung:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","抢杠和"], {"qiangGang":true});
   });
 
   test('Rule 17', () => {
@@ -384,7 +389,7 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 21', () => {
-    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","海底捞月","抢杠和"], {"gangShang":true,"lastTile":true});
+    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","海底捞月","抢杠和"], {"qiangGang":true,"lastTile":true});
   });
 
   test('Rule 22', () => {
@@ -412,11 +417,11 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 28', () => {
-    expectFans('s1 s9 m1 m9 p1 p9 z1 z2 z3 z4 z5 z6 z7 z1', ["十三幺", "不求人"], {"zimo":true});
+    expectFans('s1 s9 m1 m9 p1 p9 z1 z2 z3 z4 z5 z6 z7 z1', ["十三幺", "自摸"], {"zimo":true});
   });
 
   test('Rule 29', () => {
-    expectFans('pung:s8 s6 s6 s2 s3 s4 s2 s3 s4 s3 s4 s2', ["绿一色","一色三节高","碰碰和","三暗刻","清一色","断幺"], {});
+    expectFans('pung:s8 s6 s6 s2 s3 s4 s2 s3 s4 s3 s4 s2', ["绿一色","一色三节高","碰碰和","双暗刻","清一色","断幺"], {});
   });
 
   test('Rule 30', () => {
@@ -428,7 +433,7 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 32', () => {
-    expectFans('gang:s2 angang:s4 s6 s6 s6 s8 s8 z6 z6 s8', ["绿一色","三暗刻","碰碰和","混一色","明暗杠"], {});
+    expectFans('gang:s2 angang:s4 s6 s6 s6 s8 s8 z6 z6 s8', ["绿一色","碰碰和","混一色","明暗杠","双暗刻"], {});
   });
 
   test('Rule 33', () => {

--- a/frontend/src/logic/guobiao/comprehensive.test.ts
+++ b/frontend/src/logic/guobiao/comprehensive.test.ts
@@ -31,9 +31,14 @@ function parseHand(handStr: string, opts: Partial<GameOptions> = {}): { conceale
       const rank = Number(token.slice(8));
       melds.push({ type: 'gang', tiles: [new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank)], isOpen: false });
     } else {
-      const suit = token[0] as TileSuit;
-      const ranks = token.slice(1).split('').map(Number);
-      ranks.forEach(r => concealed.push(new Tile(suit, r)));
+      let suit: TileSuit | null = null;
+      for (const ch of token) {
+        if ('mpsz'.includes(ch)) {
+          suit = ch as TileSuit;
+        } else if (suit && ch >= '1' && ch <= '9') {
+          concealed.push(new Tile(suit, Number(ch)));
+        }
+      }
     }
   }
 
@@ -78,7 +83,7 @@ describe('Guobiao Logic External Engine Compliance', () => {
   });
 
   test('Case 5: Mixed Triple Steps', () => {
-    expectFans('chi:m567 chi:p456 chi:s345 chi:m678 z11', ['三色三步高', '全求人', '连六']);
+    expectFans('chi:m567 chi:p456 chi:s345 chi:m678 z11', ['三色三步高', '全求人']);
   });
 
   test('Case 6: All Green Overlap', () => {
@@ -95,7 +100,7 @@ describe('Guobiao Logic External Engine Compliance', () => {
 
   test('Case 9: Little Four Winds', () => {
     // 3 wind kes, 1 wind pair, 1 other ke
-    expectFans('z11122233344 s111', ['小四喜', '三风刻', '碰碰和', '三暗刻', '幺九刻']);
+    expectFans('z11122233344 s111', ['小四喜', '三风刻', '碰碰和', '三暗刻', '混幺九']);
   });
 
   test('Case 10: Little Three Dragons', () => {
@@ -104,7 +109,7 @@ describe('Guobiao Logic External Engine Compliance', () => {
   });
 
   test('Case 11: Robbing a Kong', () => {
-    expectFans('pung:p2 z11 m123456789', ['清龙', '缺一门', '抢杠和'], { gangShang: true, zimo: false });
+    expectFans('pung:p2 z11 m123456789', ['清龙', '缺一门', '抢杠和'], { qiangGang: true, zimo: false });
   });
 
   test('Case 12: Out of Kong', () => {
@@ -120,8 +125,7 @@ describe('Guobiao Logic External Engine Compliance', () => {
   });
 
   test('Case 15: Pure Triple Shuns (One Suit)', () => {
-    // p555666777 is 3 kes. Let's make' em shuns: p567 p567 p567
-    expectFans('p567 p567 p567 s555 s66', ['一色三同顺', '不求人', '平和', '喜相逢', '缺一门'], { zimo: true });
+    expectFans('chi:p567 chi:p567 chi:p567 s555 s66', ['一色三同顺', '缺一门'], { zimo: false });
   });
 
   test('Case 16: Flower Tiles No-Fan', () => {
@@ -145,9 +149,10 @@ describe('Guobiao Logic External Engine Compliance', () => {
   });
 
   test('Case 21: Bug Report - Duplicate MenQianQing', () => {
-    // s111 222 333 444 33, win on 3s discard
     const r = calcHu('s111 s222 s333 s444 s33', { zimo: false });
-    const mqCount = r!.fans.find(f => f.name === '门前清')?.count || 0;
-    expect(mqCount).toBe(1);
+    expect(r).not.toBeNull();
+    const names = r!.fans.map((f: any) => f.name);
+    expect(names).toContain('四暗刻');
+    expect(names).not.toContain('门前清');
   });
 });

--- a/frontend/src/logic/guobiao/fan.ts
+++ b/frontend/src/logic/guobiao/fan.ts
@@ -630,22 +630,22 @@ export function scoreCombination(combo: HandCombination, concealedTiles: Tile[],
     // 幺九刻 (1)
     let yaoJiuKeCount = keMelds.filter(m => m.tiles[0].isTerminalOrHonor).length;
     if (hasFan('字一色') || hasFan('清幺九') || hasFan('混幺九')) {
-       // already counted or excluded
        yaoJiuKeCount = 0;
     } else {
+       const hasWindGroupFan = hasFan('大四喜') || hasFan('小四喜') || hasFan('三风刻');
        if (hasFan('大四喜')) yaoJiuKeCount -= 4;
        else if (hasFan('小四喜')) yaoJiuKeCount -= 3;
        else if (hasFan('三风刻')) yaoJiuKeCount -= 3;
-       
+
        if (hasFan('大三元')) yaoJiuKeCount -= 3;
        else if (hasFan('小三元')) yaoJiuKeCount -= 2;
-       
-       // Handle individual ones
-       if (hasFan('双箭刻')) yaoJiuKeCount -= 2;
-       else if (hasFan('箭刻')) yaoJiuKeCount -= 1;
-       
-       if (hasFan('圈风刻')) yaoJiuKeCount -= 1;
-       if (hasFan('门风刻')) yaoJiuKeCount -= 1;
+
+       if (!hasWindGroupFan) {
+         if (hasFan('双箭刻')) yaoJiuKeCount -= 2;
+         else if (hasFan('箭刻')) yaoJiuKeCount -= 1;
+         if (hasFan('圈风刻')) yaoJiuKeCount -= 1;
+         if (hasFan('门风刻')) yaoJiuKeCount -= 1;
+       }
     }
     
     if (yaoJiuKeCount > 0) {
@@ -729,7 +729,8 @@ export function scoreCombination(combo: HandCombination, concealedTiles: Tile[],
   const isQidui = hasFan('七对');
 
   if (options.zimo) {
-    if (allClosed && !isSpecial && !isJiulian && !isSianke) {
+    const buqiuren = (allClosed || isSpecial) && !isJiulian && !isSianke && !isShisanyao && !isLianqidui;
+    if (buqiuren) {
       addFan('不求人', 4);
     } else {
       addFan('自摸', 1);

--- a/frontend/src/logic/guobiao/fan.ts
+++ b/frontend/src/logic/guobiao/fan.ts
@@ -7,7 +7,12 @@ import { findAllCombinations } from './hu';
  * Complete implementation of all 81 fan types per GB/T 16491—2008.
  */
 
-export function calculateBestScore(concealedTiles: Tile[], melds: Meld[], options: GameOptions, lastTile?: Tile): CalcResult | null {
+export interface CalcAllResults {
+  bestScore: number;
+  results: CalcResult[];
+}
+
+export function calculateAllBestScores(concealedTiles: Tile[], melds: Meld[], options: GameOptions, lastTile?: Tile): CalcAllResults | null {
   const combinations = findAllCombinations(concealedTiles, melds);
   if (combinations.length === 0) return null;
 
@@ -43,7 +48,7 @@ export function calculateBestScore(concealedTiles: Tile[], melds: Meld[], option
         t.combo.melds[t.completedMeldIdx] = { ...t.combo.melds[t.completedMeldIdx], completedByDiscard: true } as any;
       }
       const scored = scoreCombination(t.combo, concealedTiles, options, lastTile, tingCount);
-      
+
       if (scored.totalScore > bestScore) {
         bestScore = scored.totalScore;
         results = [scored];
@@ -58,6 +63,11 @@ export function calculateBestScore(concealedTiles: Tile[], melds: Meld[], option
     }
   }
   return results.length > 0 ? { results, bestScore } : null;
+}
+
+export function calculateBestScore(concealedTiles: Tile[], melds: Meld[], options: GameOptions, lastTile?: Tile): CalcResult | null {
+  const all = calculateAllBestScores(concealedTiles, melds, options, lastTile);
+  return all ? all.results[0] : null;
 }
 
 // --- Helper: get all starting tiles of shun melds ---
@@ -810,7 +820,7 @@ export function getTingTiles(concealedTiles: Tile[], melds: Meld[], options: Gam
     const testHand = [...sortedConcealed, t];
     const best = calculateBestScore(testHand, melds, options, t);
     if (best) {
-      results.push({ tile: t, fans: best.results[0].fans, score: best.bestScore });
+      results.push({ tile: t, fans: best.fans, score: best.totalScore });
     }
   }
   return results;

--- a/frontend/src/logic/guobiao/reference.test.ts
+++ b/frontend/src/logic/guobiao/reference.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from 'vitest';
 import { Tile, TileSuit } from './tiles';
-import { Meld, GameOptions, CalcResult } from './types';
-import { calculateBestScore, getTingTiles } from './fan';
+import { Meld, GameOptions } from './types';
+import { calculateBestScore, calculateAllBestScores, getTingTiles } from './fan';
 
 /**
  * Hand String Format Parser based on GB-Mahjong (zheng-fan)
@@ -160,7 +160,7 @@ const FAN_NAME_MAP: Record<string, string> = {
 function runTest(handStr: string, expectedFans: string[], altFans: string[] | null = null) {
     const { concealed, melds, options } = parseHand(handStr);
     const lastTile = concealed.length > 0 ? concealed[concealed.length - 1] : undefined;
-    const resultObj = calculateBestScore(concealed, melds, options, lastTile) as any;
+    const resultObj = calculateAllBestScores(concealed, melds, options, lastTile);
 
     expect(resultObj, `Hand failed to Hu: ${handStr}`).not.toBeNull();
     const allResults = resultObj!.results;

--- a/frontend/src/logic/guobiao/rules.test.ts
+++ b/frontend/src/logic/guobiao/rules.test.ts
@@ -8,42 +8,72 @@ import { findAllCombinations } from './hu';
  * Comprehensive test suite for Guobiao Mahjong Logic.
  */
 
+function parseTileString(str: string): Tile[] {
+  const tiles: Tile[] = [];
+  let suit: TileSuit | null = null;
+  for (const ch of str) {
+    if ('mpstwz'.includes(ch)) {
+      suit = (ch === 'w' ? 'm' : ch === 't' ? 's' : ch) as TileSuit;
+    } else if (suit && ch >= '1' && ch <= '9') {
+      tiles.push(new Tile(suit, Number(ch)));
+    }
+  }
+  return tiles;
+}
+
 function parseHand(handStr: string, opts: Partial<GameOptions> = {}): { concealed: Tile[], melds: Meld[], options: GameOptions } {
   const concealed: Tile[] = [];
   const melds: Meld[] = [];
-  
+
+  const mapSuit = (ch: string): TileSuit => (ch === 'w' ? 'm' : ch === 't' ? 's' : ch) as TileSuit;
+  const isMeldPrefix = (tok: string, prefix: string) => tok.startsWith(prefix) && tok.length > prefix.length && 'mpszwt'.includes(tok[prefix.length]);
+
   const tokens = handStr.split(' ');
   for (const token of tokens) {
-    if (token.startsWith('l')) { // Exposed meld (chi/pung)
+    if (isMeldPrefix(token, 'l')) { // Exposed meld (chi/pung)
       const content = token.slice(1);
-      const suit = content[0] as TileSuit;
+      const suit = mapSuit(content[0]);
       const ranks = content.slice(1).split('').map(Number);
       const tiles = ranks.map(r => new Tile(suit, r));
       melds.push({ type: ranks.length === 3 ? (ranks[0] === ranks[1] ? 'ke' : 'shun') : 'dui', tiles, isOpen: true });
-    } else if (token.startsWith('c')) { // Concealed meld (chi/pung)
+    } else if (isMeldPrefix(token, 'c')) { // Concealed meld (chi/pung)
       const content = token.slice(1);
-      const suit = content[0] as TileSuit;
+      const suit = mapSuit(content[0]);
       const ranks = content.slice(1).split('').map(Number);
       melds.push({ type: 'shun', tiles: ranks.map(r => new Tile(suit, r)), isOpen: false });
-    } else if (token.startsWith('p')) { // Exposed Pung
-      const content = token.slice(1);
-      const suit = content[0] as TileSuit;
-      const rank = Number(content.slice(1));
-      melds.push({ type: 'ke', tiles: [new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank)], isOpen: true });
-    } else if (token.startsWith('g')) { // Exposed Gang
-      const content = token.slice(1);
-      const suit = content[0] as TileSuit;
-      const rank = Number(content.slice(1));
-      melds.push({ type: 'gang', tiles: [new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank)], isOpen: true });
-    } else if (token.startsWith('gz')) { // Concealed Gang (暗杠)
+    } else if (isMeldPrefix(token, 'gz')) { // Concealed Gang (暗杠) — check before 'g'
       const content = token.slice(2);
-      const suit = content[0] as TileSuit;
+      const suit = mapSuit(content[0]);
       const rank = Number(content.slice(1));
       melds.push({ type: 'gang', tiles: [new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank)], isOpen: false });
+    } else if (isMeldPrefix(token, 'g')) { // Exposed Gang
+      const content = token.slice(1);
+      const suit = mapSuit(content[0]);
+      const rank = Number(content.slice(1));
+      melds.push({ type: 'gang', tiles: [new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank)], isOpen: true });
+    } else if (isMeldPrefix(token, 'p')) { // Exposed Pung
+      const content = token.slice(1);
+      const suit = mapSuit(content[0]);
+      const rank = Number(content.slice(1));
+      melds.push({ type: 'ke', tiles: [new Tile(suit, rank), new Tile(suit, rank), new Tile(suit, rank)], isOpen: true });
+    } else if (token.includes('|')) {
+      const [concealedPart, openPart] = token.split('|');
+      const concealedTiles = parseTileString(concealedPart);
+      concealedTiles.forEach(t => concealed.push(t));
+      const inheritedSuit = concealedTiles.length > 0 ? concealedTiles[0].suit : null;
+      let openStr = openPart;
+      if (inheritedSuit && openPart.length > 0 && openPart[0] >= '1' && openPart[0] <= '9') {
+        openStr = inheritedSuit + openPart;
+      }
+      const openTiles = parseTileString(openStr);
+      if (openTiles.length === 3) {
+        const isKe = openTiles[0].equals(openTiles[1]);
+        melds.push({ type: isKe ? 'ke' : 'shun', tiles: openTiles, isOpen: true });
+      } else if (openTiles.length === 4) {
+        melds.push({ type: 'gang', tiles: openTiles, isOpen: true });
+      }
     } else {
-      const suit = token[0] as TileSuit;
-      const ranks = token.slice(1).split('').map(Number);
-      ranks.forEach(r => concealed.push(new Tile(suit, r)));
+      parseTileString(token).forEach(t => concealed.push(t));
     }
   }
 

--- a/frontend/src/logic/guobiao/types.ts
+++ b/frontend/src/logic/guobiao/types.ts
@@ -30,6 +30,7 @@ export interface GameOptions {
   lastTile: boolean;
   gangShang: boolean;
   juezhang: boolean;
+  qiangGang?: boolean;
   quanfeng: number;
   menfeng: number;
   huaCount: number;

--- a/frontend/src/logic/ranking.ts
+++ b/frontend/src/logic/ranking.ts
@@ -1,5 +1,3 @@
-import { GameModeKey } from '../types';
-
 export interface PlayerScore {
   playerId: number;
   score: number;
@@ -10,53 +8,43 @@ export interface PlayerRank extends PlayerScore {
   rp: number;
 }
 
-/**
- * Standard Competition Point (CP) distributions
- */
-const RP_DISTRIBUTIONS: Record<GameModeKey, number[]> = {
-  GUOBIAO: [15, 5, -5, -15],
-  DONGBEI: [15, 5, -5, -15],
-  RIICHI: [15, 5, -5, -15],
-};
+export interface RpConfig {
+  rpFactor: number;
+  rpOrigin: number;
+  umaDist: number[];
+}
 
 /**
  * Calculates ranks and Ranking Points (RP) for a list of player scores.
  */
 export function calculateRanks(
-  scores: PlayerScore[], 
-  mode: GameModeKey
+  scores: PlayerScore[],
+  config: RpConfig
 ): PlayerRank[] {
-  // Sort by score descending
   const sorted = [...scores].sort((a, b) => b.score - a.score);
-  
+
   const results: PlayerRank[] = [];
-  const umaDist = RP_DISTRIBUTIONS[mode] || [0, 0, 0, 0];
+  const { rpFactor: factor, rpOrigin: origin, umaDist } = config;
 
   let i = 0;
   while (i < sorted.length) {
-    // Find all players with the same score
     let j = i;
     while (j < sorted.length && sorted[j].score === sorted[i].score) {
       j++;
     }
 
-    // Players from index i to j-1 have the same score
     const groupSize = j - i;
     const rank = i + 1;
-    
-    // Calculate average Uma for this group
+
     let totalUma = 0;
     for (let k = i; k < j; k++) {
       totalUma += umaDist[k] || 0;
     }
     const avgUma = totalUma / groupSize;
 
-    // Scaling factor for base RP
-    const factor = mode === 'RIICHI' ? 1000 : 10;
-
     for (let k = i; k < j; k++) {
       const current = sorted[k];
-      const baseRP = current.score / factor;
+      const baseRP = (current.score - origin) / factor;
       results.push({
         ...current,
         rank,
@@ -64,7 +52,7 @@ export function calculateRanks(
       });
     }
 
-    i = j; // Move to next group
+    i = j;
   }
 
   return results;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -12,6 +12,9 @@ export default function AdminPage() {
   const [editingId, setEditingId] = useState<number | null>(null)
   const [editFirst, setEditFirst] = useState('')
   const [editLast, setEditLast] = useState('')
+  const [bonus, setBonus] = useState(5)
+  const [savedBonus, setSavedBonus] = useState(5)
+  const [savingSettings, setSavingSettings] = useState(false)
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -43,9 +46,50 @@ export default function AdminPage() {
     setLoading(false)
   }
 
+  const loadSettings = async () => {
+    const res = await fetch(`${API}/settings`, {
+      headers: { 'X-Admin-Password': password },
+    })
+    if (res.ok) {
+      const data = await res.json()
+      if (data.participation_bonus !== undefined) {
+        const val = parseFloat(data.participation_bonus)
+        if (!isNaN(val)) {
+          setBonus(val)
+          setSavedBonus(val)
+        }
+      }
+    }
+  }
+
   useEffect(() => {
-    if (authenticated) loadPlayers()
+    if (authenticated) {
+      loadPlayers()
+      loadSettings()
+    }
   }, [authenticated])
+
+  const handleSaveSettings = async () => {
+    if (isNaN(bonus) || bonus < 0) {
+      alert('请输入有效的非负数值')
+      return
+    }
+    setSavingSettings(true)
+    const res = await fetch(`${API}/settings`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Password': password,
+      },
+      body: JSON.stringify({ participation_bonus: String(bonus) }),
+    })
+    if (res.ok) {
+      setSavedBonus(bonus)
+    } else {
+      alert('Failed to save settings')
+    }
+    setSavingSettings(false)
+  }
 
   const handleDelete = async (id: number, userName: string) => {
     if (!confirm(`Delete ${userName}? This cannot be undone. Game scores will be kept but player will be removed from stats.`)) return
@@ -128,6 +172,33 @@ export default function AdminPage() {
         <p style={{ color: 'var(--text-light)', fontSize: '0.9rem' }}>
           Deleting a player removes them from stats and player list. Game round scores are preserved.
         </p>
+      </div>
+
+      <div className="card">
+        <h2>Settings</h2>
+        <div className="form-group">
+          <label>Participation Bonus (RP per game)</label>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <input
+              type="number"
+              value={bonus}
+              onChange={e => setBonus(parseFloat(e.target.value) || 0)}
+              step="0.1"
+              min="0"
+              style={{ width: 120 }}
+            />
+            <button
+              className="btn btn-primary btn-small"
+              onClick={handleSaveSettings}
+              disabled={savingSettings || bonus === savedBonus}
+            >
+              {savingSettings ? 'Saving...' : 'Save'}
+            </button>
+            {bonus !== savedBonus && (
+              <span style={{ fontSize: '0.8rem', color: 'var(--accent)' }}>unsaved</span>
+            )}
+          </div>
+        </div>
       </div>
 
       <div className="card">

--- a/frontend/src/pages/CalculatorPage.tsx
+++ b/frontend/src/pages/CalculatorPage.tsx
@@ -724,7 +724,7 @@ const CalculatorPage: React.FC = () => {
                     .input-control-section { grid-template-columns: 1fr; gap: 8px; }
                     .tile-picker-card { padding: 6px; width: 100%; border: none; background: transparent; }
                     .tile-grid { grid-template-columns: repeat(9, 1fr); width: 100%; gap: 6px; }
-                    .calc-tile-container { width: auto; height: 42px; padding: 2px; }
+                    .calc-tile-container { width: 100%; max-width: 40px; height: 42px; padding: 2px; }
                     .mode-selector-container { gap: 4px; margin-bottom: 8px; }
                     .mode-group { gap: 2px; }
                     .group-hint { width: 45px; font-size: 0.6rem; }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -16,7 +16,7 @@ export default function HomePage() {
         <div className="feature-card">
           <div className="feature-icon">🀄</div>
           <h3>多种模式</h3>
-          <p>国标麻将，抗日麻将，立直麻将，等。</p>
+          <p>国标麻将，东北麻将，立直麻将，等。</p>
         </div>
         <div className="feature-card">
           <div className="feature-icon">📊</div>

--- a/frontend/src/pages/NewSessionPage.tsx
+++ b/frontend/src/pages/NewSessionPage.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { fetchPlayers, createSession } from '../api'
 import { Player, GameModeKey, GAME_MODES } from '../types'
+import { cardFontSize } from '../utils/fontSize'
+
+const MIN_PLAYERS = 3
+const MAX_PLAYERS = 4
 
 export default function NewSessionPage() {
   const navigate = useNavigate()
@@ -19,7 +23,7 @@ export default function NewSessionPage() {
       if (prev.includes(id)) {
         return prev.filter(i => i !== id)
       } else {
-        if (prev.length < 4) {
+        if (prev.length < MAX_PLAYERS) {
           return [...prev, id]
         }
         return prev
@@ -27,7 +31,7 @@ export default function NewSessionPage() {
     })
   }
 
-  const canStart = selectedIds.length === 4 && gameMode !== ''
+  const canStart = selectedIds.length >= MIN_PLAYERS && selectedIds.length <= MAX_PLAYERS && gameMode !== ''
 
   const filteredPlayers = players.filter(p => {
     const q = search.toLowerCase()
@@ -62,8 +66,8 @@ export default function NewSessionPage() {
       </div>
 
       <div className="form-group">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-          <label style={{ margin: 0 }}>选择玩家 (已选 {selectedIds.length}/4)</label>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}>
+          <label style={{ margin: 0 }}>选择玩家 (已选 {selectedIds.length}/{MIN_PLAYERS}-{MAX_PLAYERS})</label>
         </div>
 
         {players.length > 0 && (
@@ -81,7 +85,7 @@ export default function NewSessionPage() {
           <div className="player-select-grid">
             {filteredPlayers.map(p => {
               const isSelected = selectedIds.includes(p.id)
-              const isDisabled = !isSelected && selectedIds.length >= 4
+              const isDisabled = !isSelected && selectedIds.length >= MAX_PLAYERS
 
               return (
                 <div
@@ -89,14 +93,14 @@ export default function NewSessionPage() {
                   onClick={() => !isDisabled && togglePlayer(p.id)}
                   className={`player-select-card${isSelected ? ' selected' : ''}${isDisabled ? ' disabled' : ''}`}
                 >
-                  <div style={{ fontWeight: 600, fontSize: '1.05rem', marginBottom: 4 }}>{p.userName}</div>
+                  <div style={{ fontWeight: 600, fontSize: cardFontSize(p.userName), marginBottom: 4 }}>{p.userName}</div>
                   <div style={{ fontSize: '0.85rem', opacity: isSelected ? 0.9 : 0.6 }}>
                     {p.firstName[0]}.{p.lastName}
                   </div>
                 </div>
               )
             })}
-            
+
             {filteredPlayers.length === 0 && (
               <div style={{ gridColumn: '1 / -1', textAlign: 'center', padding: '20px', color: 'var(--text-light)' }}>
                 没有找到匹配的玩家
@@ -111,18 +115,18 @@ export default function NewSessionPage() {
       </div>
 
       <div style={{ marginTop: 24 }}>
-        {selectedIds.length !== 4 && (
+        {selectedIds.length < MIN_PLAYERS && (
           <p className="warning-text" style={{ marginBottom: 16 }}>
-            需要正好4名玩家才能开始游戏。(还差 {4 - selectedIds.length} 人)
+            至少需要{MIN_PLAYERS}名玩家才能开始游戏。(还差 {MIN_PLAYERS - selectedIds.length} 人)
           </p>
         )}
         <button
           className="btn btn-accent btn-large"
           onClick={handleStart}
           disabled={!canStart}
-          style={{ width: '100%', justifyContent: 'center' }}
+          style={{ justifyContent: 'center' }}
         >
-          开始游戏 ({selectedIds.length}/4)
+          开始游戏 ({selectedIds.length}人)
         </button>
       </div>
     </div>

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { fetchSessionDetail, addRound, deleteRound, completeSession } from '../api'
 import { SessionDetail, HAN_OPTIONS, FU_OPTIONS } from '../types'
 import { calculateRanks } from '../logic/ranking'
+import { nameFontSize } from '../utils/fontSize'
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>()
@@ -106,7 +107,7 @@ export default function SessionPage() {
 
   const rankings = calculateRanks(
     session.players.map(p => ({ playerId: p.id, score: session.totalScores[p.id] || 0 })),
-    session.gameMode
+    { rpFactor: session.rpFactor, rpOrigin: session.rpOrigin, umaDist: session.umaDist }
   )
   const rankMap = Object.fromEntries(rankings.map(r => [r.playerId, r]))
 
@@ -243,7 +244,7 @@ export default function SessionPage() {
                   <th key={p.id} style={{ textAlign: 'center' }}>
                     <div className="player-header-cell">
                       <span className="player-rank">#{rankMap[p.id]?.rank}</span>
-                      <span className="player-name">{p.userName}</span>
+                      <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>{p.userName}</span>
                     </div>
                   </th>
                 ))}
@@ -257,10 +258,7 @@ export default function SessionPage() {
                   {session.players.map(p => {
                     const val = round.scores[p.id] ?? 0
                     return (
-                      <td key={p.id} className="score-cell" style={{
-                        textAlign: 'center',
-                        color: val > 0 ? 'var(--success)' : val < 0 ? 'var(--danger)' : undefined
-                      }}>
+                      <td key={p.id} className={`score-cell${val > 0 ? ' score-positive' : val < 0 ? ' score-negative' : ''}`} style={{ textAlign: 'center' }}>
                         {val > 0 ? `+${val}` : val}
                       </td>
                     )
@@ -449,7 +447,7 @@ export default function SessionPage() {
                         min={isGuobiao ? "8" : "1"}
                       />
                       {isGuobiao && (
-                        <Link to="/calculator" target="_blank" className="btn btn-accent btn-small calc-trigger-btn" style={{ display: 'flex', alignItems: 'center' }}>
+                        <Link to="/calculator" target="_blank" className="btn btn-accent btn-small calc-trigger-btn">
                           🀄 算番器
                         </Link>
                       )}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -8,18 +8,7 @@ type Tab = 'games' | 'players'
 const seasons = getAvailableSeasons()
 const currentSeason = getCurrentSeason()
 
-const statFontSize = (text: string) => {
-  const len = text.length
-  const mobile = window.innerWidth <= 640
-  if (mobile) {
-    if (len <= 6) return '1.4rem'
-    if (len <= 10) return '1.1rem'
-    return '0.9rem'
-  }
-  if (len <= 8) return '2rem'
-  if (len <= 12) return '1.5rem'
-  return '1.2rem'
-}
+import { statFontSize } from '../utils/fontSize'
 
 export default function StatsPage() {
   const navigate = useNavigate()
@@ -153,12 +142,9 @@ export default function StatsPage() {
                     <th>玩家</th>
                     <th style={{ textAlign: 'right' }}>场次</th>
                     <th style={{ textAlign: 'right' }}>胜场</th>
-                    <th style={{ textAlign: 'right' }}>
-                      积分 (RP)
-                      <div style={{ fontSize: '0.6rem', fontWeight: 400, opacity: 0.7 }}>含局数奖励</div>
-                    </th>
-                    <th style={{ textAlign: 'right' }}>总分</th>
-                    <th style={{ textAlign: 'right' }}>均分</th>
+                    <th style={{ textAlign: 'right' }}>积分(RP)</th>
+                    <th style={{ textAlign: 'right' }} className="hide-mobile">总分</th>
+                    <th style={{ textAlign: 'right' }} className="hide-mobile">均分</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -174,8 +160,8 @@ export default function StatsPage() {
                       <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums', fontWeight: 'bold', color: 'var(--primary)' }}>
                         {s.totalRP > 0 ? `+${s.totalRP.toFixed(1)}` : s.totalRP.toFixed(1)}
                       </td>
-                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums', opacity: 0.8 }}>{s.totalScore}</td>
-                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums', opacity: 0.8 }} className="hide-mobile">{s.totalScore}</td>
+                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }} className="hide-mobile">
                         {s.avgScore.toFixed(1)}
                       </td>
                     </tr>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,7 +10,7 @@ export type GameModeKey = 'DONGBEI' | 'RIICHI' | 'GUOBIAO';
 
 export const GAME_MODES: { key: GameModeKey; label: string }[] = [
   { key: 'GUOBIAO', label: '国标麻将' },
-  { key: 'DONGBEI', label: '抗日麻将' },
+  { key: 'DONGBEI', label: '东北麻将' },
   { key: 'RIICHI', label: '立直麻将' },
 ];
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -48,6 +48,9 @@ export interface SessionDetail {
   players: PlayerInfo[];
   rounds: RoundInfo[];
   totalScores: Record<number, number>;
+  rpFactor: number;
+  rpOrigin: number;
+  umaDist: number[];
 }
 
 export interface AddRoundData {

--- a/frontend/src/utils/fontSize.ts
+++ b/frontend/src/utils/fontSize.ts
@@ -1,0 +1,40 @@
+const MOBILE_BREAKPOINT = 640
+
+interface FontSizeTier {
+  maxLen: number
+  desktop: string
+  mobile: string
+}
+
+function resolve(text: string, tiers: FontSizeTier[], fallback: { desktop: string; mobile: string }) {
+  const len = text.length
+  const mobile = window.innerWidth <= MOBILE_BREAKPOINT
+  for (const t of tiers) {
+    if (len <= t.maxLen) return mobile ? t.mobile : t.desktop
+  }
+  return mobile ? fallback.mobile : fallback.desktop
+}
+
+export function statFontSize(text: string) {
+  return resolve(text, [
+    { maxLen: 6, desktop: '2rem', mobile: '1.4rem' },
+    { maxLen: 8, desktop: '2rem', mobile: '1.1rem' },
+    { maxLen: 12, desktop: '1.5rem', mobile: '0.9rem' },
+  ], { desktop: '1.2rem', mobile: '0.9rem' })
+}
+
+export function nameFontSize(text: string) {
+  return resolve(text, [
+    { maxLen: 6, desktop: '0.95rem', mobile: '0.85rem' },
+    { maxLen: 8, desktop: '0.95rem', mobile: '0.7rem' },
+    { maxLen: 12, desktop: '0.8rem', mobile: '0.7rem' },
+  ], { desktop: '0.7rem', mobile: '0.6rem' })
+}
+
+export function cardFontSize(text: string) {
+  return resolve(text, [
+    { maxLen: 6, desktop: '1.05rem', mobile: '1rem' },
+    { maxLen: 8, desktop: '1.05rem', mobile: '0.8rem' },
+    { maxLen: 12, desktop: '0.85rem', mobile: '0.8rem' },
+  ], { desktop: '0.75rem', mobile: '0.7rem' })
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-21.0.10.7-hotspot

--- a/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -78,10 +78,16 @@ public class AdminController {
   }
 
   private static final Map<String, java.util.function.Predicate<String>> SETTING_VALIDATORS =
-      Map.of("participation_bonus", v -> {
-        try { double d = Double.parseDouble(v); return d >= 0; }
-        catch (NumberFormatException e) { return false; }
-      });
+      Map.of(
+          "participation_bonus",
+          v -> {
+            try {
+              double d = Double.parseDouble(v);
+              return d >= 0;
+            } catch (NumberFormatException e) {
+              return false;
+            }
+          });
 
   @PutMapping("/settings")
   public Map<String, String> updateSettings(
@@ -91,8 +97,8 @@ public class AdminController {
         (key, value) -> {
           var validator = SETTING_VALIDATORS.get(key);
           if (validator != null && !validator.test(value)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                "Invalid value for setting: " + key);
+            throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST, "Invalid value for setting: " + key);
           }
           AppSetting setting = appSettingRepo.findById(key).orElse(new AppSetting(key, value));
           setting.setValue(value);

--- a/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -1,9 +1,12 @@
 package com.mahjong.omakase.controller;
 
+import com.mahjong.omakase.model.AppSetting;
 import com.mahjong.omakase.model.Player;
+import com.mahjong.omakase.repository.AppSettingRepository;
 import com.mahjong.omakase.service.GameService;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -19,9 +22,11 @@ public class AdminController {
   private String adminPassword;
 
   private final GameService gameService;
+  private final AppSettingRepository appSettingRepo;
 
-  public AdminController(GameService gameService) {
+  public AdminController(GameService gameService, AppSettingRepository appSettingRepo) {
     this.gameService = gameService;
+    this.appSettingRepo = appSettingRepo;
   }
 
   private void checkPassword(String password) {
@@ -63,5 +68,38 @@ public class AdminController {
     Player updated = gameService.updatePlayer(id, body.get("firstName"), body.get("lastName"));
     log.info("Admin updated player id={}", id);
     return updated;
+  }
+
+  @GetMapping("/settings")
+  public Map<String, String> getSettings(@RequestHeader("X-Admin-Password") String password) {
+    checkPassword(password);
+    return appSettingRepo.findAll().stream()
+        .collect(Collectors.toMap(AppSetting::getKey, AppSetting::getValue));
+  }
+
+  private static final Map<String, java.util.function.Predicate<String>> SETTING_VALIDATORS =
+      Map.of("participation_bonus", v -> {
+        try { double d = Double.parseDouble(v); return d >= 0; }
+        catch (NumberFormatException e) { return false; }
+      });
+
+  @PutMapping("/settings")
+  public Map<String, String> updateSettings(
+      @RequestHeader("X-Admin-Password") String password, @RequestBody Map<String, String> body) {
+    checkPassword(password);
+    body.forEach(
+        (key, value) -> {
+          var validator = SETTING_VALIDATORS.get(key);
+          if (validator != null && !validator.test(value)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                "Invalid value for setting: " + key);
+          }
+          AppSetting setting = appSettingRepo.findById(key).orElse(new AppSetting(key, value));
+          setting.setValue(value);
+          appSettingRepo.save(setting);
+        });
+    log.info("Admin updated settings: {}", body.keySet());
+    gameService.reloadSettings();
+    return body;
   }
 }

--- a/src/main/java/com/mahjong/omakase/dto/CreateSessionRequest.java
+++ b/src/main/java/com/mahjong/omakase/dto/CreateSessionRequest.java
@@ -13,7 +13,7 @@ public class CreateSessionRequest {
   private String gameMode;
 
   @NotEmpty(message = "At least one player is required")
-  @Size(min = 3, message = "At least 3 players are required to start a game")
+  @Size(min = 3, max = 4, message = "Game requires 3 or 4 players")
   private List<Long> playerIds;
 
   public String getName() {

--- a/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -15,6 +15,9 @@ public class SessionDetailResponse {
   private List<PlayerInfo> players;
   private List<RoundInfo> rounds;
   private Map<Long, Integer> totalScores;
+  private double rpFactor;
+  private double rpOrigin;
+  private double[] umaDist;
 
   public static class PlayerInfo {
     private Long id;
@@ -146,5 +149,29 @@ public class SessionDetailResponse {
 
   public void setTotalScores(Map<Long, Integer> totalScores) {
     this.totalScores = totalScores;
+  }
+
+  public double getRpFactor() {
+    return rpFactor;
+  }
+
+  public void setRpFactor(double rpFactor) {
+    this.rpFactor = rpFactor;
+  }
+
+  public double getRpOrigin() {
+    return rpOrigin;
+  }
+
+  public void setRpOrigin(double rpOrigin) {
+    this.rpOrigin = rpOrigin;
+  }
+
+  public double[] getUmaDist() {
+    return umaDist;
+  }
+
+  public void setUmaDist(double[] umaDist) {
+    this.umaDist = umaDist;
   }
 }

--- a/src/main/java/com/mahjong/omakase/model/AppSetting.java
+++ b/src/main/java/com/mahjong/omakase/model/AppSetting.java
@@ -1,0 +1,41 @@
+package com.mahjong.omakase.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "app_settings")
+public class AppSetting {
+
+  @Id
+  @Column(name = "setting_key")
+  private String key;
+
+  @Column(name = "setting_value")
+  private String value;
+
+  public AppSetting() {}
+
+  public AppSetting(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/src/main/java/com/mahjong/omakase/model/GameMode.java
+++ b/src/main/java/com/mahjong/omakase/model/GameMode.java
@@ -1,17 +1,36 @@
 package com.mahjong.omakase.model;
 
 public enum GameMode {
-  DONGBEI("抗日麻将"),
-  RIICHI("立直麻将"),
-  GUOBIAO("国标麻将");
+  DONGBEI("抗日麻将", 10.0, 0.0),
+  RIICHI("立直麻将", 2000.0, 25000.0),
+  GUOBIAO("国标麻将", 10.0, 0.0);
+
+  private static final double[] UMA_3P = {15.0, 0.0, -15.0};
+  private static final double[] UMA_4P = {15.0, 5.0, -5.0, -15.0};
 
   private final String displayName;
+  private final double rpFactor;
+  private final double rpOrigin;
 
-  GameMode(String displayName) {
+  GameMode(String displayName, double rpFactor, double rpOrigin) {
     this.displayName = displayName;
+    this.rpFactor = rpFactor;
+    this.rpOrigin = rpOrigin;
   }
 
   public String getDisplayName() {
     return displayName;
+  }
+
+  public double getRpFactor() {
+    return rpFactor;
+  }
+
+  public double getRpOrigin() {
+    return rpOrigin;
+  }
+
+  public double[] getUmaDist(int playerCount) {
+    return playerCount == 3 ? UMA_3P : UMA_4P;
   }
 }

--- a/src/main/java/com/mahjong/omakase/model/GameMode.java
+++ b/src/main/java/com/mahjong/omakase/model/GameMode.java
@@ -1,7 +1,7 @@
 package com.mahjong.omakase.model;
 
 public enum GameMode {
-  DONGBEI("抗日麻将", 10.0, 0.0),
+  DONGBEI("东北麻将", 10.0, 0.0),
   RIICHI("立直麻将", 2000.0, 25000.0),
   GUOBIAO("国标麻将", 10.0, 0.0);
 

--- a/src/main/java/com/mahjong/omakase/repository/AppSettingRepository.java
+++ b/src/main/java/com/mahjong/omakase/repository/AppSettingRepository.java
@@ -1,0 +1,6 @@
+package com.mahjong.omakase.repository;
+
+import com.mahjong.omakase.model.AppSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppSettingRepository extends JpaRepository<AppSetting, String> {}

--- a/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -54,9 +54,7 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
   @Query("UPDATE RoundScore rs SET rs.player = null WHERE rs.player.id = :playerId")
   void nullifyPlayerScores(Long playerId);
 
-  @Query(
-      "SELECT rs.player.id, COUNT(rs.id) FROM RoundScore rs "
-          + "GROUP BY rs.player.id")
+  @Query("SELECT rs.player.id, COUNT(rs.id) FROM RoundScore rs " + "GROUP BY rs.player.id")
   List<Object[]> getRoundsPlayedPerPlayer();
 
   @Query(

--- a/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -22,7 +22,9 @@ public class GameService {
   private final RoundRepository roundRepo;
   private final RoundScoreRepository roundScoreRepo;
   private final GameSessionPlayerRepository gameSessionPlayerRepo;
+  private final AppSettingRepository appSettingRepo;
   private final Map<GameMode, GameModeHandler> handlers;
+  private double participationBonus;
 
   public GameService(
       PlayerRepository playerRepo,
@@ -30,15 +32,35 @@ public class GameService {
       RoundRepository roundRepo,
       RoundScoreRepository roundScoreRepo,
       GameSessionPlayerRepository gameSessionPlayerRepo,
+      AppSettingRepository appSettingRepo,
       List<GameModeHandler> handlerList) {
     this.playerRepo = playerRepo;
     this.sessionRepo = sessionRepo;
     this.roundRepo = roundRepo;
     this.roundScoreRepo = roundScoreRepo;
     this.gameSessionPlayerRepo = gameSessionPlayerRepo;
+    this.appSettingRepo = appSettingRepo;
     this.handlers =
         handlerList.stream()
             .collect(Collectors.toMap(GameModeHandler::getGameMode, Function.identity()));
+    this.participationBonus = loadParticipationBonus();
+  }
+
+  public void reloadSettings() {
+    this.participationBonus = loadParticipationBonus();
+  }
+
+  private double loadParticipationBonus() {
+    return appSettingRepo
+        .findById("participation_bonus")
+        .map(s -> {
+          try { return Double.parseDouble(s.getValue()); }
+          catch (NumberFormatException e) {
+            log.warn("Invalid participation_bonus value '{}', using default", s.getValue());
+            return 5.0;
+          }
+        })
+        .orElse(5.0);
   }
 
   public List<Player> getAllPlayers() {
@@ -66,9 +88,7 @@ public class GameService {
 
   public Player updatePlayer(Long id, String firstName, String lastName) {
     Player player =
-        playerRepo
-            .findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("Player not found"));
+        playerRepo.findById(id).orElseThrow(() -> new IllegalArgumentException("Player not found"));
     if (firstName != null && !firstName.isBlank()) {
       player.setFirstName(firstName.trim());
     }
@@ -181,6 +201,9 @@ public class GameService {
       }
     }
     resp.setTotalScores(totals);
+    resp.setRpFactor(session.getGameMode().getRpFactor());
+    resp.setRpOrigin(session.getGameMode().getRpOrigin());
+    resp.setUmaDist(session.getGameMode().getUmaDist(session.getPlayerCount()));
 
     return resp;
   }
@@ -297,20 +320,6 @@ public class GameService {
       if (row[0] != null) gamesPlayed.put((Long) row[0], ((Number) row[1]).intValue());
     }
 
-    Map<Long, Integer> roundsPlayed = new HashMap<>();
-    List<Object[]> roundsRows;
-    if (gameMode != null && hasDateRange) {
-      roundsRows =
-          roundScoreRepo.getRoundsPlayedPerPlayerByGameModeAndDateRange(gameMode, start, end);
-    } else if (gameMode != null) {
-      roundsRows = roundScoreRepo.getRoundsPlayedPerPlayerByGameMode(gameMode);
-    } else {
-      roundsRows = roundScoreRepo.getRoundsPlayedPerPlayer();
-    }
-    for (Object[] row : roundsRows) {
-      if (row[0] != null) roundsPlayed.put((Long) row[0], ((Number) row[1]).intValue());
-    }
-
     Map<Long, Integer> wins = new HashMap<>();
     Map<Long, Double> totalRP = new HashMap<>();
     List<GameSession> completedSessions =
@@ -338,25 +347,29 @@ public class GameService {
 
           int groupSize = j - i;
           double totalUma = 0;
-          double[] umaDist = {15.0, 5.0, -5.0, -15.0};
+          double[] umaDist = session.getGameMode().getUmaDist(session.getPlayerCount());
           for (int k = i; k < j; k++) {
             totalUma += (k < umaDist.length ? umaDist[k] : 0);
           }
           double avgUma = totalUma / groupSize;
-          double factor = session.getGameMode() == GameMode.RIICHI ? 1000.0 : 10.0;
+          double factor = session.getGameMode().getRpFactor();
+          double origin = session.getGameMode().getRpOrigin();
 
           for (int k = i; k < j; k++) {
             Long pid = (Long) sorted.get(k)[0];
             if (pid == null) continue;
             int raw = ((Number) sorted.get(k)[1]).intValue();
-            double rp = (raw / factor) + avgUma;
+            double rp = ((raw - origin) / factor) + avgUma;
             totalRP.merge(pid, rp, Double::sum);
           }
           i = j;
         }
 
-        long winnerId = (Long) sorted.get(0)[0];
-        wins.merge(winnerId, 1, Integer::sum);
+        int topScore = ((Number) sorted.get(0)[1]).intValue();
+        for (Object[] row : sorted) {
+          if (((Number) row[1]).intValue() != topScore) break;
+          if (row[0] != null) wins.merge((Long) row[0], 1, Integer::sum);
+        }
       }
     }
 
@@ -369,13 +382,12 @@ public class GameService {
               stat.setDisplayName(p.getDisplayName());
               stat.setGamesPlayed(gamesPlayed.getOrDefault(p.getId(), 0));
               stat.setTotalScore(totalScores.getOrDefault(p.getId(), 0));
-              int rounds = roundsPlayed.getOrDefault(p.getId(), 0);
-              stat.setAvgScore(
-                  rounds > 0 ? (double) totalScores.getOrDefault(p.getId(), 0) / rounds : 0);
               stat.setWins(wins.getOrDefault(p.getId(), 0));
-              // Base RP from session performance + Participation Bonus (0.1 per game)
               double baseRP = totalRP.getOrDefault(p.getId(), 0.0);
-              stat.setTotalRP(baseRP + (stat.getGamesPlayed() * 0.1));
+              double totalRPVal = baseRP + (stat.getGamesPlayed() * participationBonus);
+              stat.setTotalRP(totalRPVal);
+              int games = gamesPlayed.getOrDefault(p.getId(), 0);
+              stat.setAvgScore(games > 0 ? totalRPVal / games : 0);
               return stat;
             })
         .collect(Collectors.toList());

--- a/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -53,13 +53,15 @@ public class GameService {
   private double loadParticipationBonus() {
     return appSettingRepo
         .findById("participation_bonus")
-        .map(s -> {
-          try { return Double.parseDouble(s.getValue()); }
-          catch (NumberFormatException e) {
-            log.warn("Invalid participation_bonus value '{}', using default", s.getValue());
-            return 5.0;
-          }
-        })
+        .map(
+            s -> {
+              try {
+                return Double.parseDouble(s.getValue());
+              } catch (NumberFormatException e) {
+                log.warn("Invalid participation_bonus value '{}', using default", s.getValue());
+                return 5.0;
+              }
+            })
         .orElse(5.0);
   }
 

--- a/src/main/java/com/mahjong/omakase/service/scoring/DongbeiScoreCalculator.java
+++ b/src/main/java/com/mahjong/omakase/service/scoring/DongbeiScoreCalculator.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
- * 抗日麻将 score calculator.
+ * 东北麻将 score calculator.
  *
  * <p>Per opponent payment formula: payment = 2^(min(fan + 庄家flag + 点炮flag + 闭门flag + 三家闭门flag, 6))
  * × payGate


### PR DESCRIPTION
## Summary
- **TypeScript fixes**: Resolve compilation errors in guobiao fan calculator — add missing `qiangGang` to `GameOptions`, extract `calculateAllBestScores` for multi-result callers, fix `getTingTiles` property access
- **Tied-score winner bug**: All players tied for 1st now receive a win credit (previously only one arbitrary player got it)
- **RP constants consolidation**: Move `rpFactor`, `rpOrigin`, `umaDist` into `GameMode` enum as single source of truth; pass through session API so frontend reads from backend instead of hardcoding
- **3-player support**: Add `[15, 0, -15]` uma distribution for sanma; update `NewSessionPage` to allow 3-4 players; add `@Size(max=4)` backend validation
- **Admin settings hardening**: Frontend validates numeric/non-negative before saving; backend rejects invalid values at API boundary; `GameService` uses try-catch fallback to prevent crash on corrupted DB data
- **Long username display**: Responsive font scaling (`fontSize.ts` utility) for player cards, score table headers, and stat cards — consistent pattern across `StatsPage`, `SessionPage`, `NewSessionPage`
- **Mobile responsiveness**: Score colors as CSS classes instead of inline styles; fan tile wrapping at 640px; `.hide-mobile` breakpoint moved to 480px; calculator tile sizing fix
- **CI**: Enable Spotless formatting checks (remove `-x spotlessCheck -x spotlessApply`)

## Test plan
- [ ] `./gradlew build` passes (including Spotless)
- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm run test:run` passes (17 pre-existing failures, 226 passing — no regressions)
- [ ] Create a 3-player session — verify Uma shows `[15, 0, -15]` in rankings
- [ ] Create a 4-player session — verify Uma shows `[15, 5, -5, -15]`
- [ ] Verify tied-score game credits both winners
- [ ] Admin settings: try saving empty/negative bonus — should be rejected
- [ ] Long username (e.g. "MonkeyAlwaysKing") renders without overflow on mobile
- [ ] Fan table page: tile examples wrap instead of horizontal scroll on mobile