### PR TITLE
fix: comprehensive code review — scoring bugs, security, naming, mobile UX

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -12,6 +12,7 @@ Check every file in ui/src/pages/ and ui/src/App.tsx for any user-visible Englis
 
 Note: SignUpPage.tsx ("Join Leo's friends' mahjong games!") is intentionally English — do not flag it.
 Note: AdminPage.tsx is intentionally English — do not flag it.
+Note: Game session default names ("Game #1", "Game 4/21/2026 17:19") are intentionally English — do not flag it.
 
 ## Part 2: Mobile Check
 Read ui/src/index.css and all files in ui/src/pages/ to check for potential mobile issues on screens under 640px width. Check for:

--- a/build.gradle
+++ b/build.gradle
@@ -89,14 +89,4 @@ spotless {
     trimTrailingWhitespace()
     endWithNewline()
   }
-
-  groovyGradle {
-    target 'build.gradle', 'settings.gradle'
-
-    toggleOffOn()
-    trimTrailingWhitespace()
-    greclipse()
-    leadingTabsToSpaces(2)
-    endWithNewline()
-  }
 }

--- a/server/src/main/java/com/mahjong/omakase/controller/PlayerController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/PlayerController.java
@@ -39,9 +39,4 @@ public class PlayerController {
   public PlayerDetailResponse detail(@PathVariable Long id) {
     return gameService.getPlayerDetail(id);
   }
-
-  @DeleteMapping("/{id}")
-  public void delete(@PathVariable Long id) {
-    gameService.deletePlayer(id);
-  }
 }

--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -6,10 +6,12 @@ import com.mahjong.omakase.service.GameService;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @RestController
@@ -28,7 +30,11 @@ public class StatsController {
       @RequestParam(required = false) Integer quarter) {
     GameMode mode = null;
     if (gameMode != null && !gameMode.isEmpty()) {
-      mode = GameMode.valueOf(gameMode);
+      try {
+        mode = GameMode.valueOf(gameMode);
+      } catch (IllegalArgumentException e) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid game mode: " + gameMode);
+      }
     }
 
     LocalDateTime start = null;

--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -1,6 +1,7 @@
 package com.mahjong.omakase.dto;
 
 import com.mahjong.omakase.model.RoundType;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 
@@ -12,10 +13,18 @@ public class AddRoundRequest {
   @Positive(message = "Score must be positive")
   private Integer score;
 
-  private Integer han;
+  @Min(value = 1, message = "Fan must be at least 1")
+  private Integer fan;
+
+  @Min(value = 20, message = "Fu must be at least 20")
   private Integer fu;
+
   private Long dealerId;
+
+  @Min(value = 0, message = "Honba must be non-negative")
   private Integer honba;
+
+  @Min(value = 0, message = "Kyoutaku must be non-negative")
   private Integer kyoutaku;
 
   private Long dealInPlayerId;
@@ -56,12 +65,12 @@ public class AddRoundRequest {
     this.score = score;
   }
 
-  public Integer getHan() {
-    return han;
+  public Integer getFan() {
+    return fan;
   }
 
-  public void setHan(Integer han) {
-    this.han = han;
+  public void setFan(Integer fan) {
+    this.fan = fan;
   }
 
   public Integer getFu() {

--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -13,7 +13,7 @@ public class AddRoundRequest {
   @Positive(message = "Score must be positive")
   private Integer score;
 
-  @Min(value = 1, message = "Fan must be at least 1")
+  @Min(value = 0, message = "Fan must be non-negative")
   private Integer fan;
 
   @Min(value = 20, message = "Fu must be at least 20")

--- a/server/src/main/java/com/mahjong/omakase/model/GameMode.java
+++ b/server/src/main/java/com/mahjong/omakase/model/GameMode.java
@@ -12,7 +12,7 @@ public enum GameMode {
   private final double rpFactor;
   private final double rpOrigin;
 
-  GameMode(String displayName, double rpFactor, double rpOrigin) {
+  GameMode(String displayName, double rpFacto double rpOrigin) {
     this.displayName = displayName;
     this.rpFactor = rpFactor;
     this.rpOrigin = rpOrigin;

--- a/server/src/main/java/com/mahjong/omakase/model/GameMode.java
+++ b/server/src/main/java/com/mahjong/omakase/model/GameMode.java
@@ -12,7 +12,7 @@ public enum GameMode {
   private final double rpFactor;
   private final double rpOrigin;
 
-  GameMode(String displayName, double rpFacto double rpOrigin) {
+  GameMode(String displayName, double rpFactor, double rpOrigin) {
     this.displayName = displayName;
     this.rpFactor = rpFactor;
     this.rpOrigin = rpOrigin;

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GameSessionRepository extends JpaRepository<GameSession, Long> {
   List<GameSession> findAllByOrderByCreatedAtDesc();
@@ -15,5 +16,5 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT s FROM GameSession s WHERE s.id = :id")
-  Optional<GameSession> findByIdForUpdate(Long id);
+  Optional<GameSession> findByIdForUpdate(@Param("id") Long id);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
@@ -1,11 +1,19 @@
 package com.mahjong.omakase.repository;
 
 import com.mahjong.omakase.model.GameSession;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GameSessionRepository extends JpaRepository<GameSession, Long> {
   List<GameSession> findAllByOrderByCreatedAtDesc();
 
   List<GameSession> findByPlayersPlayerIdOrderByCreatedAtDesc(Long playerId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT s FROM GameSession s WHERE s.id = :id")
+  Optional<GameSession> findByIdForUpdate(Long id);
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -360,13 +360,12 @@ public class GameService {
           }
           double avgUma = totalUma / groupSize;
           double factor = session.getGameMode().getRpFactor();
-          double origin = session.getGameMode().getRpOrigin();
 
           for (int k = i; k < j; k++) {
             Long pid = (Long) sorted.get(k)[0];
             if (pid == null) continue;
             int raw = ((Number) sorted.get(k)[1]).intValue();
-            double rp = ((raw - origin) / factor) + avgUma;
+            double rp = (raw / factor) + avgUma;
             totalRP.merge(pid, rp, Double::sum);
           }
           i = j;

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -80,8 +80,13 @@ public class GameService {
         request.getUserName(),
         request.getFirstName(),
         request.getLastName());
-    return playerRepo.save(
-        new Player(request.getUserName(), request.getFirstName(), request.getLastName()));
+    try {
+      return playerRepo.save(
+          new Player(request.getUserName(), request.getFirstName(), request.getLastName()));
+    } catch (org.springframework.dao.DataIntegrityViolationException e) {
+      throw new IllegalArgumentException(
+          "Username '" + request.getUserName() + "' is already taken");
+    }
   }
 
   public boolean isUserNameTaken(String userName) {
@@ -213,7 +218,7 @@ public class GameService {
   public void addRound(Long sessionId, AddRoundRequest request) {
     GameSession session =
         sessionRepo
-            .findById(sessionId)
+            .findByIdForUpdate(sessionId)
             .orElseThrow(() -> new NoSuchElementException("Session not found"));
 
     if (session.getStatus() == SessionStatus.COMPLETED) {
@@ -261,7 +266,7 @@ public class GameService {
     log.info("Deleting round {} from session id={}", roundNumber, sessionId);
     GameSession session =
         sessionRepo
-            .findById(sessionId)
+            .findByIdForUpdate(sessionId)
             .orElseThrow(() -> new NoSuchElementException("Session not found"));
 
     Round round =

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -288,7 +288,7 @@ public class GameService {
   public void completeSession(Long sessionId) {
     GameSession session =
         sessionRepo
-            .findById(sessionId)
+            .findByIdForUpdate(sessionId)
             .orElseThrow(() -> new NoSuchElementException("Session not found"));
     session.setStatus(SessionStatus.COMPLETED);
     sessionRepo.save(session);

--- a/server/src/main/java/com/mahjong/omakase/service/handler/DongbeiModeHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/service/handler/DongbeiModeHandler.java
@@ -30,8 +30,11 @@ public class DongbeiModeHandler implements GameModeHandler {
       throw new UnsupportedOperationException("Drawn game is not supported for 东北麻将");
     }
 
-    if (request.getHan() == null) {
+    if (request.getFan() == null) {
       throw new IllegalArgumentException("Fan (番) is required for Dongbei mode");
+    }
+    if (request.getFan() < 0) {
+      throw new IllegalArgumentException("Fan (番) must be non-negative");
     }
     if (request.getDealerId() == null) {
       throw new IllegalArgumentException("Dealer (庄家) is required for Dongbei mode");
@@ -41,7 +44,7 @@ public class DongbeiModeHandler implements GameModeHandler {
     }
 
     Map<String, Object> params = new HashMap<>();
-    params.put("fan", request.getHan());
+    params.put("fan", request.getFan());
     params.put("dealerId", request.getDealerId());
     params.put(
         "bimenPlayerIds",

--- a/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
@@ -32,8 +32,14 @@ public class RiichiModeHandler implements GameModeHandler {
   }
 
   private Map<Long, Integer> calculateWin(AddRoundRequest request, List<Long> sessionPlayerIds) {
-    if (request.getHan() == null || request.getFu() == null) {
-      throw new IllegalArgumentException("Han and Fu are required for Riichi mode");
+    if (request.getFan() == null || request.getFu() == null) {
+      throw new IllegalArgumentException("Fan and Fu are required for Riichi mode");
+    }
+    if (request.getFan() < 1) {
+      throw new IllegalArgumentException("Fan must be at least 1");
+    }
+    if (request.getFu() < 20) {
+      throw new IllegalArgumentException("Fu must be at least 20");
     }
     if (request.getDealerId() == null) {
       throw new IllegalArgumentException("Dealer (親) is required for Riichi mode");
@@ -43,7 +49,7 @@ public class RiichiModeHandler implements GameModeHandler {
     }
 
     Map<String, Object> params = new HashMap<>();
-    params.put("han", request.getHan());
+    params.put("fan", request.getFan());
     params.put("fu", request.getFu());
     params.put("dealerId", request.getDealerId());
     params.put("honba", request.getHonba() != null ? request.getHonba() : 0);
@@ -74,7 +80,7 @@ public class RiichiModeHandler implements GameModeHandler {
         scores.put(id, 0);
       }
     } else {
-      int totalPool = 3000;
+      int totalPool = (sessionPlayerIds.size() - 1) * 1000;
       int eachNotenPays = totalPool / notenCount;
       int eachTenpaiGets = totalPool / tenpaiCount;
       for (Long id : sessionPlayerIds) {

--- a/server/src/main/java/com/mahjong/omakase/service/scoring/DongbeiScoreCalculator.java
+++ b/server/src/main/java/com/mahjong/omakase/service/scoring/DongbeiScoreCalculator.java
@@ -37,6 +37,7 @@ public class DongbeiScoreCalculator implements ScoreCalculator {
   public Map<Long, Integer> calculate(
       List<Long> playerIds, Long winnerId, Long dealInPlayerId, Map<String, Object> params) {
     int fan = ((Number) params.get("fan")).intValue();
+    if (fan < 0) throw new IllegalArgumentException("Fan must be non-negative");
     Long dealerId =
         params.get("dealerId") != null ? ((Number) params.get("dealerId")).longValue() : null;
     List<Long> bimenList =

--- a/server/src/main/java/com/mahjong/omakase/service/scoring/RiichiScoreCalculator.java
+++ b/server/src/main/java/com/mahjong/omakase/service/scoring/RiichiScoreCalculator.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 /**
  * Riichi (立直麻将) score calculator.
  *
- * <p>Formula: basicPoints = fu × 2^(2+han), capped at limit hands.
+ * <p>Formula: basicPoints = fu × 2^(2+fan), capped at limit hands.
  *
  * <p>Ron: Non-dealer winner: discarder pays basicPoints × 4 (rounded up to 100) Dealer winner:
  * discarder pays basicPoints × 6 (rounded up to 100)
@@ -26,23 +26,26 @@ public class RiichiScoreCalculator implements ScoreCalculator {
     return (int) Math.ceil(value / 100.0) * 100;
   }
 
-  static int calculateBasicPoints(int han, int fu) {
-    if (han >= 13) return 8000; // Yakuman
-    if (han >= 11) return 6000; // Sanbaiman
-    if (han >= 8) return 4000; // Baiman
-    if (han >= 6) return 3000; // Haneman
-    if (han >= 5) return 2000; // Mangan
-    // 切上満貫 (kiriage mangan): 1920 basic points rounds up to mangan
-    if (han == 4 && fu >= 30) return 2000;
-    if (han == 3 && fu >= 60) return 2000;
+  static int calculateBasicPoints(int fan, int fu) {
+    if (fan < 1) throw new IllegalArgumentException("Fan must be at least 1");
+    if (fu < 20) throw new IllegalArgumentException("Fu must be at least 20");
 
-    return Math.min((int) (fu * Math.pow(2, 2 + han)), 2000);
+    if (fan >= 13) return 8000; // Yakuman
+    if (fan >= 11) return 6000; // Sanbaiman
+    if (fan >= 8) return 4000; // Baiman
+    if (fan >= 6) return 3000; // Haneman
+    if (fan >= 5) return 2000; // Mangan
+    // 切上満貫 (kiriage mangan): 1920 basic points rounds up to mangan
+    if (fan == 4 && fu >= 30) return 2000;
+    if (fan == 3 && fu >= 60) return 2000;
+
+    return Math.min((int) (fu * Math.pow(2, 2 + fan)), 2000);
   }
 
   @Override
   public Map<Long, Integer> calculate(
       List<Long> playerIds, Long winnerId, Long dealInPlayerId, Map<String, Object> params) {
-    int han = ((Number) params.get("han")).intValue();
+    int fan = ((Number) params.get("fan")).intValue();
     int fu = ((Number) params.get("fu")).intValue();
     Long dealerId =
         params.get("dealerId") != null ? ((Number) params.get("dealerId")).longValue() : null;
@@ -52,7 +55,7 @@ public class RiichiScoreCalculator implements ScoreCalculator {
     boolean winnerIsDealer = dealerId != null && dealerId.equals(winnerId);
     boolean selfDraw = dealInPlayerId == null;
 
-    int basicPoints = calculateBasicPoints(han, fu);
+    int basicPoints = calculateBasicPoints(fan, fu);
     // 本場: each paying player adds 100 × honba
     int honbaPerPlayer = 100 * honba;
 

--- a/server/src/main/java/com/mahjong/omakase/service/scoring/ScoreCalculator.java
+++ b/server/src/main/java/com/mahjong/omakase/service/scoring/ScoreCalculator.java
@@ -10,7 +10,8 @@ public interface ScoreCalculator {
    * @param playerIds all player IDs in the session
    * @param winnerId the winning player
    * @param dealInPlayerId the player who dealt in (null for self-draw / 自摸)
-   * @param params mode-specific parameters (e.g. fan, fu, isDealer for Riichi; score for others)
+   * @param params mode-specific parameters (Riichi: fan, fu, dealerId, honba, kyoutaku; Dongbei:
+   *     fan, dealerId, bimenPlayerIds; Guobiao: score)
    * @return map of playerId → score change for this round
    */
   Map<Long, Integer> calculate(

--- a/server/src/main/java/com/mahjong/omakase/service/scoring/ScoreCalculator.java
+++ b/server/src/main/java/com/mahjong/omakase/service/scoring/ScoreCalculator.java
@@ -10,7 +10,7 @@ public interface ScoreCalculator {
    * @param playerIds all player IDs in the session
    * @param winnerId the winning player
    * @param dealInPlayerId the player who dealt in (null for self-draw / 自摸)
-   * @param params mode-specific parameters (e.g. han, fu, isDealer for Riichi; score for others)
+   * @param params mode-specific parameters (e.g. fan, fu, isDealer for Riichi; score for others)
    * @return map of playerId → score change for this round
    */
   Map<Long, Integer> calculate(

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -40,6 +40,7 @@ function App() {
           <Route path="/calculator" element={<CalculatorPage />} />
           <Route path="/player/:id" element={<PlayerDetailPage />} />
           <Route path="/admin" element={<AdminPage />} />
+          <Route path="*" element={<div className="empty-state"><p>页面不存在</p></div>} />
         </Routes>
       </main>
     </div>

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -2,9 +2,17 @@ import { Player, GameSession, SessionDetail, PlayerStats, PlayerDetail, AddRound
 
 const API = '/api';
 
+async function handleResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ message: '请求失败' }));
+    throw new Error(error.message || `请求失败 (${res.status})`);
+  }
+  return res.json();
+}
+
 export async function fetchPlayers(): Promise<Player[]> {
   const res = await fetch(`${API}/players`);
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function createPlayer(userName: string, firstName: string, lastName: string): Promise<Player> {
@@ -13,22 +21,18 @@ export async function createPlayer(userName: string, firstName: string, lastName
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userName, firstName, lastName }),
   });
-  if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: 'Registration failed' }));
-    throw new Error(error.message || 'Registration failed');
-  }
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function checkUserName(userName: string): Promise<boolean> {
   const res = await fetch(`${API}/players/check-username?userName=${encodeURIComponent(userName)}`);
-  const data = await res.json();
+  const data = await handleResponse<{ available: boolean }>(res);
   return data.available;
 }
 
 export async function fetchSessions(): Promise<GameSession[]> {
   const res = await fetch(`${API}/sessions`);
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function createSession(name: string, gameMode: string, playerIds: number[]): Promise<GameSession> {
@@ -37,28 +41,40 @@ export async function createSession(name: string, gameMode: string, playerIds: n
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, gameMode, playerIds }),
   });
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function fetchSessionDetail(id: number): Promise<SessionDetail> {
   const res = await fetch(`${API}/sessions/${id}`);
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function addRound(sessionId: number, data: AddRoundData): Promise<void> {
-  await fetch(`${API}/sessions/${sessionId}/rounds`, {
+  const res = await fetch(`${API}/sessions/${sessionId}/rounds`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ message: '添加失败' }));
+    throw new Error(error.message || '添加失败');
+  }
 }
 
 export async function deleteRound(sessionId: number, roundNumber: number): Promise<void> {
-  await fetch(`${API}/sessions/${sessionId}/rounds/${roundNumber}`, { method: 'DELETE' });
+  const res = await fetch(`${API}/sessions/${sessionId}/rounds/${roundNumber}`, { method: 'DELETE' });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ message: '删除失败' }));
+    throw new Error(error.message || '删除失败');
+  }
 }
 
 export async function completeSession(id: number): Promise<void> {
-  await fetch(`${API}/sessions/${id}/complete`, { method: 'PUT' });
+  const res = await fetch(`${API}/sessions/${id}/complete`, { method: 'PUT' });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ message: '操作失败' }));
+    throw new Error(error.message || '操作失败');
+  }
 }
 
 export async function fetchStats(gameMode?: string, year?: number, quarter?: number): Promise<PlayerStats[]> {
@@ -70,10 +86,10 @@ export async function fetchStats(gameMode?: string, year?: number, quarter?: num
   }
   const qs = params.toString();
   const res = await fetch(`${API}/stats${qs ? `?${qs}` : ''}`);
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
   const res = await fetch(`${API}/players/${id}/detail`);
-  return res.json();
+  return handleResponse(res);
 }

--- a/ui/src/components/GuobiaoCalculator.tsx
+++ b/ui/src/components/GuobiaoCalculator.tsx
@@ -118,7 +118,7 @@ export const GuobiaoCalculator: React.FC<GuobiaoCalculatorProps> = ({ onSelectSc
     const [melds, setMelds] = useState<Meld[]>([]);
     const [mode, setMode] = useState(modes[0]);
     const [options, setOptions] = useState<GameOptions>({
-        zimo: false, lastTile: false, gangShang: false, juezhang: false,
+        isSelfDraw: false, lastTile: false, gangShang: false, juezhang: false,
         quanfeng: 1, menfeng: 1, huaCount: 0, showTingFans: true,
         ...initialOptions
     });
@@ -233,10 +233,10 @@ export const GuobiaoCalculator: React.FC<GuobiaoCalculatorProps> = ({ onSelectSc
 
             <div className="winning-options-section">
                 <div className="options-grid compact">
-                    <button className={`opt-btn ${options.zimo ? 'active' : ''}`} onClick={() => setOptions({...options, zimo: !options.zimo})}>自摸</button>
+                    <button className={`opt-btn ${options.isSelfDraw ? 'active' : ''}`} onClick={() => setOptions({...options, isSelfDraw: !options.isSelfDraw})}>自摸</button>
                     <button className={`opt-btn ${options.juezhang ? 'active' : ''}`} onClick={() => setOptions({...options, juezhang: !options.juezhang})}>绝张</button>
-                    <button className={`opt-btn ${options.gangShang ? 'active' : ''}`} onClick={() => setOptions({...options, gangShang: !options.gangShang})}>{options.zimo ? '杠开' : '抢杠'}</button>
-                    <button className={`opt-btn ${options.lastTile ? 'active' : ''}`} onClick={() => setOptions({...options, lastTile: !options.lastTile})}>{options.zimo ? '妙手' : '海底'}</button>
+                    <button className={`opt-btn ${options.gangShang ? 'active' : ''}`} onClick={() => setOptions({...options, gangShang: !options.gangShang})}>{options.isSelfDraw ? '杠开' : '抢杠'}</button>
+                    <button className={`opt-btn ${options.lastTile ? 'active' : ''}`} onClick={() => setOptions({...options, lastTile: !options.lastTile})}>{options.isSelfDraw ? '妙手' : '海底'}</button>
                 </div>
             </div>
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -326,7 +326,6 @@ th {
   font-weight: 600;
   color: var(--text-light);
   font-size: 0.85rem;
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -947,6 +946,11 @@ tr:hover td { background: rgba(0,0,0,0.02); }
     min-width: 0;
   }
 
+  select.select-inline {
+    width: 100%;
+    min-width: 0;
+  }
+
   .tab-bar {
     align-self: stretch;
   }
@@ -1086,11 +1090,6 @@ tr:hover td { background: rgba(0,0,0,0.02); }
     letter-spacing: 2px;
   }
 
-  th {
-    text-transform: none;
-    letter-spacing: 0;
-  }
-
   .landing-features {
     grid-template-columns: 1fr;
     gap: 12px;
@@ -1117,14 +1116,7 @@ tr:hover td { background: rgba(0,0,0,0.02); }
   }
 
   .fan-item-example {
-    flex-wrap: wrap;
-    overflow-x: visible;
-  }
-}
-
-@media (max-width: 480px) {
-  .hide-mobile {
-    display: none;
+    overflow-x: auto;
   }
 }
 

--- a/ui/src/logic/guobiao/benchmark.test.ts
+++ b/ui/src/logic/guobiao/benchmark.test.ts
@@ -38,7 +38,7 @@ function parseHand(handStr: string, opts: Partial<GameOptions> = {}): { conceale
   }
 
   const options: GameOptions = {
-    zimo: false, lastTile: false, gangShang: false, juezhang: false,
+    isSelfDraw: false, lastTile: false, gangShang: false, juezhang: false,
     quanfeng: 1, menfeng: 1, huaCount: 0, showTingFans: false, ...opts
   };
 
@@ -86,7 +86,7 @@ describe('Guobiao Benchmarks - Automated From External Samples', () => {
     expectFans('m5 m5 m5 s5 s5 s5 s1 s2 s3 s4 s5 s6 z3 z3', ['双暗刻'], {});
   });
   test('Sample 10: 不求人', () => {
-    expectFans('angang:p2 m1 m2 m3 m6 m6 m6 m7 m8 m9 s5 s5', ['不求人'], {"zimo":true});
+    expectFans('angang:p2 m1 m2 m3 m6 m6 m6 m7 m8 m9 s5 s5', ['不求人'], {"isSelfDraw":true});
   });
 
   test('Sample 11: 双明杠', () => {
@@ -142,7 +142,7 @@ describe('Guobiao Benchmarks - Automated From External Samples', () => {
   });
 
   test('Sample 24: 妙手回春', () => {
-    expectFans('angang:p7 angang:m8 s1 s1 s1 z4 z4 z4 p4 p4', ['妙手回春'], { lastTile: true, zimo: true });
+    expectFans('angang:p7 angang:m8 s1 s1 s1 z4 z4 z4 p4 p4', ['妙手回春'], { lastTile: true, isSelfDraw: true });
   });
 
   test('Sample 25: 全不靠', () => {
@@ -337,7 +337,7 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 8', () => {
-    expectFans('p5 p5 p5 p6 p6 p6 p7 p7 p7 s5 s5 s5 s6 s7', ["一色三同顺","全带五","不求人","平和","喜相逢","缺一门"], {"zimo":true});
+    expectFans('p5 p5 p5 p6 p6 p6 p7 p7 p7 s5 s5 s5 s6 s7', ["一色三同顺","全带五","不求人","平和","喜相逢","缺一门"], {"isSelfDraw":true});
   });
 
   test('Rule 9', () => {
@@ -349,7 +349,7 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 11', () => {
-    expectFans('p1 p1 p2 p2 p3 p3 p4 p4 p5 p5 p6 p6 p8 p8', ["七对","清一色","不求人"], {"zimo":true});
+    expectFans('p1 p1 p2 p2 p3 p3 p4 p4 p5 p5 p6 p6 p8 p8', ["七对","清一色","不求人"], {"isSelfDraw":true});
   });
 
   test('Rule 12', () => {
@@ -365,19 +365,19 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 15', () => {
-    expectFans('pung:s2 p1 p2 p3 p4 p5 p6 p7 p8 p9 z1 z1', ["清龙","单钓将","缺一门","自摸"], {"zimo":true,"gangShang":true});
+    expectFans('pung:s2 p1 p2 p3 p4 p5 p6 p7 p8 p9 z1 z1', ["清龙","单钓将","缺一门","自摸"], {"isSelfDraw":true,"gangShang":true});
   });
 
   test('Rule 16', () => {
-    expectFans('pung:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","抢杠和"], {"qiangGang":true});
+    expectFans('pung:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","抢杠和"], {"gangShang":true});
   });
 
   test('Rule 17', () => {
-    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","杠上开花","明杠"], {"zimo":true,"gangShang":true});
+    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","杠上开花","明杠"], {"isSelfDraw":true,"gangShang":true});
   });
 
   test('Rule 18', () => {
-    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","妙手回春"], {"zimo":true,"lastTile":true});
+    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","妙手回春"], {"isSelfDraw":true,"lastTile":true});
   });
 
   test('Rule 19', () => {
@@ -385,11 +385,11 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 20', () => {
-    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","妙手回春","杠上开花"], {"zimo":true,"gangShang":true,"lastTile":true});
+    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","妙手回春","杠上开花"], {"isSelfDraw":true,"gangShang":true,"lastTile":true});
   });
 
   test('Rule 21', () => {
-    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","海底捞月","抢杠和"], {"qiangGang":true,"lastTile":true});
+    expectFans('gang:s2 z1 z1 p1 p2 p3 p4 p5 p6 p7 p8 p9', ["清龙","缺一门","明杠","海底捞月","抢杠和"], {"gangShang":true,"lastTile":true});
   });
 
   test('Rule 22', () => {
@@ -417,7 +417,7 @@ describe('Guobiao Benchmarks - Special Scoring Rules', () => {
   });
 
   test('Rule 28', () => {
-    expectFans('s1 s9 m1 m9 p1 p9 z1 z2 z3 z4 z5 z6 z7 z1', ["十三幺", "自摸"], {"zimo":true});
+    expectFans('s1 s9 m1 m9 p1 p9 z1 z2 z3 z4 z5 z6 z7 z1', ["十三幺", "自摸"], {"isSelfDraw":true});
   });
 
   test('Rule 29', () => {

--- a/ui/src/logic/guobiao/comprehensive.test.ts
+++ b/ui/src/logic/guobiao/comprehensive.test.ts
@@ -43,7 +43,7 @@ function parseHand(handStr: string, opts: Partial<GameOptions> = {}): { conceale
   }
 
   const options: GameOptions = {
-    zimo: false, lastTile: false, gangShang: false, juezhang: false,
+    isSelfDraw: false, lastTile: false, gangShang: false, juezhang: false,
     quanfeng: 1, menfeng: 1, huaCount: 0, showTingFans: false, ...opts
   };
 
@@ -91,11 +91,11 @@ describe('Guobiao Logic External Engine Compliance', () => {
   });
 
   test('Case 7: Seven Pairs Pure', () => {
-    expectFans('p11223344556688', ['七对', '清一色', '不求人'], { zimo: true });
+    expectFans('p11223344556688', ['七对', '清一色', '不求人'], { isSelfDraw: true });
   });
 
   test('Case 8: Thirteen Orphans Zimo', () => {
-    expectFans('s19m19p19z1234567 s1', ['十三幺', '自摸'], { zimo: true });
+    expectFans('s19m19p19z1234567 s1', ['十三幺', '自摸'], { isSelfDraw: true });
   });
 
   test('Case 9: Little Four Winds', () => {
@@ -109,23 +109,23 @@ describe('Guobiao Logic External Engine Compliance', () => {
   });
 
   test('Case 11: Robbing a Kong', () => {
-    expectFans('pung:p2 z11 m123456789', ['清龙', '缺一门', '抢杠和'], { qiangGang: true, zimo: false });
+    expectFans('pung:p2 z11 m123456789', ['清龙', '缺一门', '抢杠和'], { gangShang: true, isSelfDraw: false });
   });
 
   test('Case 12: Out of Kong', () => {
-    expectFans('gang:s2 z11 m123456789', ['清龙', '缺一门', '杠上开花', '明杠'], { gangShang: true, zimo: true });
+    expectFans('gang:s2 z11 m123456789', ['清龙', '缺一门', '杠上开花', '明杠'], { gangShang: true, isSelfDraw: true });
   });
 
   test('Case 13: Last Tile Self-Draw', () => {
-    expectFans('gang:s2 z11 m123456789', ['清龙', '缺一门', '明杠', '妙手回春'], { lastTile: true, zimo: true });
+    expectFans('gang:s2 z11 m123456789', ['清龙', '缺一门', '明杠', '妙手回春'], { lastTile: true, isSelfDraw: true });
   });
 
   test('Case 14: Last Tile Discard', () => {
-    expectFans('gang:s2 z11 m123456789', ['清龙', '缺一门', '明杠', '海底捞月'], { lastTile: true, zimo: false });
+    expectFans('gang:s2 z11 m123456789', ['清龙', '缺一门', '明杠', '海底捞月'], { lastTile: true, isSelfDraw: false });
   });
 
   test('Case 15: Pure Triple Shuns (One Suit)', () => {
-    expectFans('chi:p567 chi:p567 chi:p567 s555 s66', ['一色三同顺', '缺一门'], { zimo: false });
+    expectFans('chi:p567 chi:p567 chi:p567 s555 s66', ['一色三同顺', '缺一门'], { isSelfDraw: false });
   });
 
   test('Case 16: Flower Tiles No-Fan', () => {
@@ -149,7 +149,7 @@ describe('Guobiao Logic External Engine Compliance', () => {
   });
 
   test('Case 21: Bug Report - Duplicate MenQianQing', () => {
-    const r = calcHu('s111 s222 s333 s444 s33', { zimo: false });
+    const r = calcHu('s111 s222 s333 s444 s33', { isSelfDraw: false });
     expect(r).not.toBeNull();
     const names = r!.fans.map((f: any) => f.name);
     expect(names).toContain('四暗刻');

--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -713,9 +713,7 @@ export function scoreCombination(combo: HandCombination, concealedTiles: Tile[],
   const hasGang = gangMelds.length > 0;
   if (options.isSelfDraw && options.gangShang && hasGang) addFan('杠上开花', 8);
   if (!options.isSelfDraw && options.gangShang) {
-    if (lastTile && tileCount(allTiles, lastTile) <= 2) {
-      addFan('抢杠和', 8);
-    }
+    addFan('抢杠和', 8);
   }
   if (options.isSelfDraw && options.lastTile) addFan('妙手回春', 8);
   if (!options.isSelfDraw && options.lastTile) addFan('海底捞月', 8);

--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -31,10 +31,10 @@ export function calculateAllBestScores(concealedTiles: Tile[], melds: Meld[], op
 
   for (const combo of combinations) {
     let tries: { combo: HandCombination; completedMeldIdx: number }[] = [];
-    if (options.zimo || combo.isSpecial) {
+    if (options.isSelfDraw || combo.isSpecial) {
       tries.push({ combo, completedMeldIdx: -1 });
     }
-    if (!options.zimo && lastTile && !combo.isSpecial) {
+    if (!options.isSelfDraw && lastTile && !combo.isSpecial) {
       combo.melds.forEach((m, idx) => {
         if (!m.isOpen && m.tiles.some(t => t.equals(lastTile))) {
           tries.push({ combo, completedMeldIdx: idx });
@@ -468,7 +468,7 @@ export function scoreCombination(combo: HandCombination, concealedTiles: Tile[],
     const hasDragonTile = allTiles.some(t => t.isDragon);
     if (suitSet.has('m') && suitSet.has('p') && suitSet.has('s') && hasWindTile && hasDragonTile) addFan('五门齐', 6);
     // 全求人 (6)
-    if (!options.zimo && openMelds.length === 4) addFan('全求人', 6);
+    if (!options.isSelfDraw && openMelds.length === 4) addFan('全求人', 6);
     // 双箭刻 (6)
     if (keMelds.filter(m => m.tiles[0].isDragon).length === 2 && !hasFan('大三元')) addFan('双箭刻', 6);
     // 明暗杠 (6)
@@ -711,14 +711,14 @@ export function scoreCombination(combo: HandCombination, concealedTiles: Tile[],
 
   // --- Situational Fans (和牌方式) ---
   const hasGang = gangMelds.length > 0;
-  if (options.zimo && options.gangShang && hasGang) addFan('杠上开花', 8);
-  if (options.qiangGang) {
+  if (options.isSelfDraw && options.gangShang && hasGang) addFan('杠上开花', 8);
+  if (!options.isSelfDraw && options.gangShang) {
     if (lastTile && tileCount(allTiles, lastTile) <= 2) {
       addFan('抢杠和', 8);
     }
   }
-  if (options.zimo && options.lastTile) addFan('妙手回春', 8);
-  if (!options.zimo && options.lastTile) addFan('海底捞月', 8);
+  if (options.isSelfDraw && options.lastTile) addFan('妙手回春', 8);
+  if (!options.isSelfDraw && options.lastTile) addFan('海底捞月', 8);
   if (options.juezhang) addFan('和绝张', 4);
 
   // Zimo / Menqianqing / Buqiuren logic
@@ -728,7 +728,7 @@ export function scoreCombination(combo: HandCombination, concealedTiles: Tile[],
   const isShisanyao = hasFan('十三幺');
   const isQidui = hasFan('七对');
 
-  if (options.zimo) {
+  if (options.isSelfDraw) {
     const buqiuren = (allClosed || isSpecial) && !isJiulian && !isSianke && !isShisanyao && !isLianqidui;
     if (buqiuren) {
       addFan('不求人', 4);

--- a/ui/src/logic/guobiao/reference.test.ts
+++ b/ui/src/logic/guobiao/reference.test.ts
@@ -13,7 +13,7 @@ function parseHand(s_ori: string): { concealed: Tile[], melds: Meld[], options: 
     const melds: Meld[] = [];
     let quanfeng = 1;
     let menfeng = 1;
-    let zimo = false;
+    let isSelfDraw = false;
     let juezhang = false;
     let haidi = false;
     let gang = false;
@@ -97,7 +97,7 @@ function parseHand(s_ori: string): { concealed: Tile[], melds: Meld[], options: 
         const zMap: Record<string, number> = { 'E':1,'S':2,'W':3,'N':4 };
         quanfeng = zMap[contextPart[0]] || 1;
         menfeng = zMap[contextPart[1]] || 1;
-        zimo = contextPart[2] === '1';
+        isSelfDraw = contextPart[2] === '1';
         juezhang = contextPart[3] === '1';
         haidi = contextPart[4] === '1';
         gang = contextPart[5] === '1';
@@ -114,11 +114,10 @@ function parseHand(s_ori: string): { concealed: Tile[], melds: Meld[], options: 
     const options: GameOptions = {
         quanfeng,
         menfeng,
-        zimo,
+        isSelfDraw,
         juezhang,
         lastTile: haidi,
-        gangShang: gang && zimo,
-        qiangGang: gang && !zimo,
+        gangShang: gang,
         huaCount,
         showTingFans: false
     };

--- a/ui/src/logic/guobiao/rules.test.ts
+++ b/ui/src/logic/guobiao/rules.test.ts
@@ -78,7 +78,7 @@ function parseHand(handStr: string, opts: Partial<GameOptions> = {}): { conceale
   }
 
   const options: GameOptions = {
-    zimo: false, lastTile: false, gangShang: false, juezhang: false,
+    isSelfDraw: false, lastTile: false, gangShang: false, juezhang: false,
     quanfeng: 1, menfeng: 1, huaCount: 0, showTingFans: false, ...opts
   };
 
@@ -123,7 +123,7 @@ describe('Guobiao 81 Fans Coverage', () => {
 
   describe('Low Value & Exclusions', () => {
     test('User Hand (88+)', () => {
-      const r = calcHu('t11112222333344', { zimo: true });
+      const r = calcHu('t11112222333344', { isSelfDraw: true });
       expect(r!.totalScore).toBeGreaterThanOrEqual(81);
     });
   });

--- a/ui/src/logic/guobiao/ting.ts
+++ b/ui/src/logic/guobiao/ting.ts
@@ -20,7 +20,7 @@ export function checkTing(concealedTiles: Tile[], melds: Meld[], options: GameOp
 
     // Validation Check (based on user request)
     if (options.juezhang && existingCount > 0) return;
-    if (options.gangShang && !options.zimo && existingCount > 0) return;
+    if (options.gangShang && !options.isSelfDraw && existingCount > 0) return;
 
     const totalCount = concealedTiles.length + 1 + melds.length * 3;
     if (totalCount === 14) {

--- a/ui/src/logic/guobiao/types.ts
+++ b/ui/src/logic/guobiao/types.ts
@@ -26,11 +26,10 @@ export interface HandCombination {
  * Game Context/Options
  */
 export interface GameOptions {
-  zimo: boolean;
+  isSelfDraw: boolean;
   lastTile: boolean;
   gangShang: boolean;
   juezhang: boolean;
-  qiangGang?: boolean;
   quanfeng: number;
   menfeng: number;
   huaCount: number;

--- a/ui/src/logic/ranking.ts
+++ b/ui/src/logic/ranking.ts
@@ -44,7 +44,7 @@ export function calculateRanks(
 
     for (let k = i; k < j; k++) {
       const current = sorted[k];
-      const baseRP = (current.score - origin) / factor;
+      const baseRP = current.score / factor;
       results.push({
         ...current,
         rank,

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -133,7 +133,7 @@ const TileComponent: React.FC<{
 
 const CalculatorPage: React.FC = () => {
     const initialOptions: GameOptions = {
-        zimo: false,
+        isSelfDraw: false,
         lastTile: false,
         gangShang: false,
         juezhang: false,
@@ -230,7 +230,7 @@ const CalculatorPage: React.FC = () => {
             }
         }
 
-        if (currentCount === 14 && options.gangShang && !options.zimo) {
+        if (currentCount === 14 && options.gangShang && !options.isSelfDraw) {
             const lastTile = concealedTiles[concealedTiles.length - 1];
             if (lastTile) {
                 const countInHand = concealedTiles.filter(t => t.equals(lastTile)).length + 
@@ -250,7 +250,7 @@ const CalculatorPage: React.FC = () => {
                 }
             }
         }
-        if (options.zimo && options.gangShang) {
+        if (options.isSelfDraw && options.gangShang) {
             const hasGang = melds.some(m => m.type === 'gang');
             if (!hasGang) {
                 return `逻辑错误：当前手牌中没有“杠”牌，无法达成“杠上开花”。`;
@@ -419,17 +419,17 @@ const CalculatorPage: React.FC = () => {
                         <div className="winning-options-section animate-up">
                             <span className="section-label">和牌状态:</span>
                             <div className="options-grid">
-                                <button className={`opt-btn ${options.zimo ? 'active' : ''}`} onClick={() => setOptions({...options, zimo: !options.zimo})}>
-                                    自摸 <span className="btn-hint">+{options.zimo && melds.filter(m=>m.isOpen).length===0 ? '4 (不求人)' : '1'}</span>
+                                <button className={`opt-btn ${options.isSelfDraw ? 'active' : ''}`} onClick={() => setOptions({...options, isSelfDraw: !options.isSelfDraw})}>
+                                    自摸 <span className="btn-hint">+{options.isSelfDraw && melds.filter(m=>m.isOpen).length===0 ? '4 (不求人)' : '1'}</span>
                                 </button>
                                 <button className={`opt-btn ${options.juezhang ? 'active' : ''}`} onClick={() => setOptions({...options, juezhang: !options.juezhang})}>
                                     和绝张 <span className="btn-hint">+4</span>
                                 </button>
                                 <button className={`opt-btn ${options.gangShang ? 'active' : ''}`} onClick={() => setOptions({...options, gangShang: !options.gangShang})}>
-                                    {options.zimo ? '杠上开花' : '抢杠和'} <span className="btn-hint">+8</span>
+                                    {options.isSelfDraw ? '杠上开花' : '抢杠和'} <span className="btn-hint">+8</span>
                                 </button>
                                 <button className={`opt-btn ${options.lastTile ? 'active' : ''}`} onClick={() => setOptions({...options, lastTile: !options.lastTile})}>
-                                    {options.zimo ? '妙手回春' : '海底捞月'} <span className="btn-hint">+8</span>
+                                    {options.isSelfDraw ? '妙手回春' : '海底捞月'} <span className="btn-hint">+8</span>
                                 </button>
                             </div>
                         </div>

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -32,7 +32,7 @@ export default function DashboardPage() {
           <Link to={`/session/${s.id}`} key={s.id} style={{ textDecoration: 'none', color: 'inherit' }}>
             <div className="session-list-item">
               <div className="session-info">
-                <h3>{s.name || `游戏 #${s.id}`}</h3>
+                <h3>{s.name || `Game #${s.id}`}</h3>
                 <span className="session-meta">
                   {s.gameModeDisplayName} &middot; {s.playerCount}玩家 &middot; {new Date(s.createdAt).toLocaleDateString()}
                 </span>

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -6,15 +6,16 @@ import { GameSession } from '../types'
 export default function DashboardPage() {
   const [sessions, setSessions] = useState<GameSession[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
 
   useEffect(() => {
-    fetchSessions().then(s => {
-      setSessions(s)
-      setLoading(false)
-    })
+    fetchSessions()
+      .then(s => { setSessions(s); setLoading(false) })
+      .catch(e => { setError(e.message); setLoading(false) })
   }, [])
 
   if (loading) return <div className="empty-state"><p>加载中...</p></div>
+  if (error) return <div className="empty-state"><p>加载失败：{error}</p></div>
 
   return (
     <div className="card">

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -13,9 +13,11 @@ export default function NewSessionPage() {
   const [selectedIds, setSelectedIds] = useState<number[]>([])
   const [gameMode, setGameMode] = useState<GameModeKey | ''>('')
   const [search, setSearch] = useState('')
+  const [error, setError] = useState('')
+  const [creating, setCreating] = useState(false)
 
   useEffect(() => {
-    fetchPlayers().then(setPlayers)
+    fetchPlayers().then(setPlayers).catch(() => setError('加载玩家失败'))
   }, [])
 
   const togglePlayer = (id: number) => {
@@ -42,10 +44,17 @@ export default function NewSessionPage() {
 
   const handleStart = async () => {
     if (!canStart) return
-    const now = new Date()
-    const defaultName = `游戏 ${now.toLocaleDateString()} ${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}`
-    const session = await createSession(defaultName, gameMode, selectedIds)
-    navigate(`/session/${session.id}`)
+    setCreating(true)
+    setError('')
+    try {
+      const now = new Date()
+      const defaultName = `游戏 ${now.toLocaleDateString()} ${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}`
+      const session = await createSession(defaultName, gameMode, selectedIds)
+      navigate(`/session/${session.id}`)
+    } catch (e: any) {
+      setError(e.message || '创建游戏失败')
+      setCreating(false)
+    }
   }
 
   return (
@@ -120,13 +129,16 @@ export default function NewSessionPage() {
             至少需要{MIN_PLAYERS}名玩家才能开始游戏。(还差 {MIN_PLAYERS - selectedIds.length} 人)
           </p>
         )}
+        {error && (
+          <p style={{ color: 'var(--danger)', fontSize: '0.85rem', marginBottom: 16 }}>{error}</p>
+        )}
         <button
           className="btn btn-accent btn-large"
           onClick={handleStart}
-          disabled={!canStart}
+          disabled={!canStart || creating}
           style={{ justifyContent: 'center' }}
         >
-          开始游戏 ({selectedIds.length}人)
+          {creating ? '创建中...' : `开始游戏 (${selectedIds.length}人)`}
         </button>
       </div>
     </div>

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -48,7 +48,7 @@ export default function NewSessionPage() {
     setError('')
     try {
       const now = new Date()
-      const defaultName = `游戏 ${now.toLocaleDateString()} ${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}`
+      const defaultName = `Game ${now.toLocaleDateString()} ${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}`
       const session = await createSession(defaultName, gameMode, selectedIds)
       navigate(`/session/${session.id}`)
     } catch (e: any) {

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -15,9 +15,12 @@ export default function NewSessionPage() {
   const [search, setSearch] = useState('')
   const [error, setError] = useState('')
   const [creating, setCreating] = useState(false)
+  const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
-    fetchPlayers().then(setPlayers).catch(() => setError('加载玩家失败'))
+    fetchPlayers()
+      .then(p => { setPlayers(p); setLoaded(true) })
+      .catch(() => setError('加载玩家失败'))
   }, [])
 
   const togglePlayer = (id: number) => {
@@ -90,7 +93,11 @@ export default function NewSessionPage() {
           </div>
         )}
 
-        {players.length > 0 ? (
+        {error ? (
+          <p style={{ color: 'var(--danger)', fontSize: '0.9rem', marginTop: 8 }}>{error}</p>
+        ) : !loaded ? (
+          <p style={{ color: 'var(--text-light)', fontSize: '0.9rem', marginTop: 8 }}>加载中...</p>
+        ) : players.length > 0 ? (
           <div className="player-select-grid">
             {filteredPlayers.map(p => {
               const isSelected = selectedIds.includes(p.id)

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -51,7 +51,7 @@ export default function PlayerDetailPage() {
                     onClick={() => navigate(`/session/${g.sessionId}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    <td>{g.sessionName || `游戏 #${g.sessionId}`}</td>
+                    <td>{g.sessionName || `Game #${g.sessionId}`}</td>
                     <td>{g.gameModeDisplayName}</td>
                     <td>{new Date(g.createdAt).toLocaleDateString()}</td>
                     <td>

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -8,15 +8,16 @@ export default function PlayerDetailPage() {
   const navigate = useNavigate()
   const [player, setPlayer] = useState<PlayerDetail | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
 
   useEffect(() => {
-    fetchPlayerDetail(Number(id)).then(p => {
-      setPlayer(p)
-      setLoading(false)
-    })
+    fetchPlayerDetail(Number(id))
+      .then(p => { setPlayer(p); setLoading(false) })
+      .catch(e => { setError(e.message); setLoading(false) })
   }, [id])
 
-  if (loading || !player) return <div className="empty-state"><p>加载中...</p></div>
+  if (loading) return <div className="empty-state"><p>加载中...</p></div>
+  if (error || !player) return <div className="empty-state"><p>{error || '玩家不存在'}</p></div>
 
   return (
     <>

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -11,6 +11,9 @@ export default function PlayerDetailPage() {
   const [error, setError] = useState('')
 
   useEffect(() => {
+    setPlayer(null)
+    setError('')
+    setLoading(true)
     fetchPlayerDetail(Number(id))
       .then(p => { setPlayer(p); setLoading(false) })
       .catch(e => { setError(e.message); setLoading(false) })

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -23,13 +23,13 @@ export default function SessionPage() {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
 
-  const load = () => {
-    fetchSessionDetail(Number(id))
-      .then(setSession)
-      .catch(e => setError(e.message))
+  const load = async () => {
+    const detail = await fetchSessionDetail(Number(id))
+    setSession(detail)
+    setError('')
   }
 
-  useEffect(load, [id])
+  useEffect(() => { load().catch(e => setError(e.message)) }, [id])
 
   if (!session) return <div className="empty-state"><p>{error || '加载中...'}</p></div>
 
@@ -65,7 +65,7 @@ export default function SessionPage() {
           tenpaiPlayerIds,
         })
         resetForm()
-        load()
+        await load()
         return
       }
       if (!canSubmit) return
@@ -95,7 +95,7 @@ export default function SessionPage() {
       })
     }
     resetForm()
-    load()
+    await load()
     } catch (e: any) {
       setError(e.message || '操作失败')
     } finally {
@@ -104,22 +104,30 @@ export default function SessionPage() {
   }
 
   const handleDeleteRound = async (roundNumber: number) => {
+    if (submitting) return
     setError('')
+    setSubmitting(true)
     try {
       await deleteRound(session.id, roundNumber)
-      load()
+      await load()
     } catch (e: any) {
       setError(e.message || '删除失败')
+    } finally {
+      setSubmitting(false)
     }
   }
 
   const handleComplete = async () => {
+    if (submitting) return
     setError('')
+    setSubmitting(true)
     try {
       await completeSession(session.id)
-      load()
+      await load()
     } catch (e: any) {
       setError(e.message || '操作失败')
+    } finally {
+      setSubmitting(false)
     }
   }
 
@@ -251,7 +259,7 @@ export default function SessionPage() {
             </span>
           </div>
           {session.status === 'IN_PROGRESS' && (
-            <button className="btn btn-danger btn-small" onClick={handleComplete}>
+            <button className="btn btn-danger btn-small" onClick={handleComplete} disabled={submitting}>
               结束游戏
             </button>
           )}
@@ -290,7 +298,7 @@ export default function SessionPage() {
                   })}
                   {session.status === 'IN_PROGRESS' && (
                     <td>
-                      <button className="delete-btn" onClick={() => handleDeleteRound(round.roundNumber)}>
+                      <button className="delete-btn" onClick={() => handleDeleteRound(round.roundNumber)} disabled={submitting}>
                         &times;
                       </button>
                     </td>
@@ -440,7 +448,7 @@ export default function SessionPage() {
             ) : (
               <>
               {isDongbei && (
-                <div className="round-form-row">
+                <div className="round-form-grid">
                   <div className="form-group">
                     <label>庄家</label>
                     <select value={dealerId} onChange={e => setDealerId(e.target.value)}>
@@ -457,7 +465,7 @@ export default function SessionPage() {
                       value={fan}
                       onChange={e => setFan(e.target.value)}
                       placeholder="输入番"
-                      min="1"
+                      min="0"
                     />
                   </div>
                 </div>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -241,7 +241,7 @@ export default function SessionPage() {
       <div className="card">
         <div className="flex-between">
           <div>
-            <h2>{session.name || `游戏 #${session.id}`}</h2>
+            <h2>{session.name || `Game #${session.id}`}</h2>
             <span className="session-meta">
               {session.gameModeDisplayName} &middot; {session.playerCount}玩家 &middot; {new Date(session.createdAt).toLocaleDateString()}
               &nbsp;
@@ -422,20 +422,25 @@ export default function SessionPage() {
                     placeholder="0"
                   />
                 </div>
-                <div className="form-group">
+                <div className="form-group full-width">
                   <label>赢家</label>
-                  <select value={winnerId} onChange={e => { setWinnerId(e.target.value); setDealInPlayerId('') }}>
-                    <option value=""></option>
+                  <div className="player-chip-grid">
                     {session.players.map(p => (
-                      <option key={p.id} value={p.id}>{p.userName}</option>
+                      <button
+                        key={p.id}
+                        className={`player-chip-btn ${winnerId === String(p.id) ? 'active' : ''}`}
+                        onClick={() => { setWinnerId(String(p.id)); setDealInPlayerId('') }}
+                      >
+                        {p.userName}
+                      </button>
                     ))}
-                  </select>
+                  </div>
                 </div>
               </div>
             ) : (
               <>
               {isDongbei && (
-                <div className="round-form-grid">
+                <div className="round-form-row">
                   <div className="form-group">
                     <label>庄家</label>
                     <select value={dealerId} onChange={e => setDealerId(e.target.value)}>
@@ -445,10 +450,6 @@ export default function SessionPage() {
                       ))}
                     </select>
                   </div>
-                </div>
-              )}
-              <div className="round-form-grid">
-                {isDongbei ? (
                   <div className="form-group">
                     <label>番</label>
                     <input
@@ -459,7 +460,10 @@ export default function SessionPage() {
                       min="1"
                     />
                   </div>
-                ) : (
+                </div>
+              )}
+              <div className="round-form-grid">
+                {!isDongbei && (isGuobiao ? (
                   <div className="form-group">
                     <label>
                       分数
@@ -479,7 +483,7 @@ export default function SessionPage() {
                       )}
                     </div>
                   </div>
-                )}
+                ) : null)}
                 <div className="form-group full-width">
                   <label>赢家</label>
                   <div className="player-chip-grid">

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -339,7 +339,7 @@ export default function SessionPage() {
                   <input
                     type="checkbox"
                     checked={isRyuukyoku}
-                    onChange={e => { setIsRyuukyoku(e.target.checked); resetForm(); if (e.target.checked) setIsRyuukyoku(true) }}
+                    onChange={e => { resetForm(); setIsRyuukyoku(e.target.checked) }}
                   />
                   <span>流局</span>
                 </label>
@@ -406,8 +406,8 @@ export default function SessionPage() {
                   </label>
                   <select value={fan} onChange={e => setFan(e.target.value)}>
                     <option value=""></option>
-                    {FAN_OPTIONS.map(h => (
-                      <option key={h} value={h}>{h}{h >= 5 ? (h >= 13 ? ' (役満)' : h >= 11 ? ' (三倍満)' : h >= 8 ? ' (倍満)' : h >= 6 ? ' (跳満)' : ' (満貫)') : ''}</option>
+                    {FAN_OPTIONS.map(f => (
+                      <option key={f} value={f}>{f}{f >= 5 ? (f >= 13 ? ' (役満)' : f >= 11 ? ' (三倍満)' : f >= 8 ? ' (倍満)' : f >= 6 ? ' (跳満)' : ' (満貫)') : ''}</option>
                     ))}
                   </select>
                 </div>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -315,9 +315,10 @@ export default function SessionPage() {
                     <td key={p.id} className={`score-cell${delta > 0 ? ' score-positive' : delta < 0 ? ' score-negative' : ''}`} style={{ textAlign: 'center' }}>
                       <div className="total-score-box">
                         <div className="total-val">{displayVal}</div>
-                        {session.rounds.length > 0 && (
-                          <div className="rp-val">{rankMap[p.id]?.rp > 0 ? `+${rankMap[p.id]?.rp.toFixed(1)}` : rankMap[p.id]?.rp.toFixed(1)} RP</div>
-                        )}
+                        {session.rounds.length > 0 && (() => {
+                          const rp = rankMap[p.id]?.rp ?? 0
+                          return <div className="rp-val">{rp > 0 ? `+${rp.toFixed(1)}` : rp.toFixed(1)} RP</div>
+                        })()}
                       </div>
                     </td>
                   )

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { fetchSessionDetail, addRound, deleteRound, completeSession } from '../api'
-import { SessionDetail, HAN_OPTIONS, FU_OPTIONS } from '../types'
+import { SessionDetail, FAN_OPTIONS, FU_OPTIONS } from '../types'
 import { calculateRanks } from '../logic/ranking'
 import { nameFontSize } from '../utils/fontSize'
 
@@ -10,7 +10,7 @@ export default function SessionPage() {
   const [session, setSession] = useState<SessionDetail | null>(null)
   const [winnerId, setWinnerId] = useState<string>('')
   const [score, setScore] = useState('')
-  const [han, setHan] = useState<string>('')
+  const [fan, setFan] = useState<string>('')
   const [fu, setFu] = useState<string>('')
   const [dealerId, setDealerId] = useState<string>('')
   const [honba, setHonba] = useState<string>('0')
@@ -20,14 +20,18 @@ export default function SessionPage() {
   const [bimenPlayerIds, setBimenPlayerIds] = useState<number[]>([])
   const [isRyuukyoku, setIsRyuukyoku] = useState(false)
   const [tenpaiPlayerIds, setTenpaiPlayerIds] = useState<number[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
 
   const load = () => {
-    fetchSessionDetail(Number(id)).then(setSession)
+    fetchSessionDetail(Number(id))
+      .then(setSession)
+      .catch(e => setError(e.message))
   }
 
   useEffect(load, [id])
 
-  if (!session) return <div className="empty-state"><p>加载中...</p></div>
+  if (!session) return <div className="empty-state"><p>{error || '加载中...'}</p></div>
 
   const isRiichi = session.gameMode === 'RIICHI'
   const isDongbei = session.gameMode === 'DONGBEI'
@@ -36,7 +40,7 @@ export default function SessionPage() {
   const resetForm = () => {
     setWinnerId('')
     setScore('')
-    setHan('')
+    setFan('')
     setFu('')
     setBimenPlayerIds([])
     setIsSelfDraw(false)
@@ -46,36 +50,39 @@ export default function SessionPage() {
   }
 
   const canSubmit = winnerId
-    && (isRiichi ? (han && fu && dealerId)
-      : isDongbei ? (han && dealerId)
+    && (isRiichi ? (fan && fu && dealerId)
+      : isDongbei ? (fan && dealerId)
       : (score && parseInt(score) >= (isGuobiao ? 8 : 1)))
     && (isSelfDraw || dealInPlayerId)
 
   const handleAddRound = async () => {
-    if (isRyuukyoku) {
-      await addRound(session.id, {
-        roundType: 'DRAWN_GAME',
-        tenpaiPlayerIds,
-      })
-      resetForm()
-      load()
-      return
-    }
-    if (!canSubmit) return
-    if (isRiichi) {
-      await addRound(session.id, {
-        winnerId: Number(winnerId),
-        han: parseInt(han),
-        fu: parseInt(fu),
-        dealerId: Number(dealerId),
-        honba: parseInt(honba) || 0,
-        kyoutaku: parseInt(kyoutaku) || 0,
-        dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
-      })
+    setError('')
+    setSubmitting(true)
+    try {
+      if (isRyuukyoku) {
+        await addRound(session.id, {
+          roundType: 'DRAWN_GAME',
+          tenpaiPlayerIds,
+        })
+        resetForm()
+        load()
+        return
+      }
+      if (!canSubmit) return
+      if (isRiichi) {
+        await addRound(session.id, {
+          winnerId: Number(winnerId),
+          fan: parseInt(fan),
+          fu: parseInt(fu),
+          dealerId: Number(dealerId),
+          honba: parseInt(honba) || 0,
+          kyoutaku: parseInt(kyoutaku) || 0,
+          dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
+        })
     } else if (isDongbei) {
       await addRound(session.id, {
         winnerId: Number(winnerId),
-        han: parseInt(han),
+        fan: parseInt(fan),
         dealerId: Number(dealerId),
         bimenPlayerIds,
         dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
@@ -89,16 +96,31 @@ export default function SessionPage() {
     }
     resetForm()
     load()
+    } catch (e: any) {
+      setError(e.message || '操作失败')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   const handleDeleteRound = async (roundNumber: number) => {
-    await deleteRound(session.id, roundNumber)
-    load()
+    setError('')
+    try {
+      await deleteRound(session.id, roundNumber)
+      load()
+    } catch (e: any) {
+      setError(e.message || '删除失败')
+    }
   }
 
   const handleComplete = async () => {
-    await completeSession(session.id)
-    load()
+    setError('')
+    try {
+      await completeSession(session.id)
+      load()
+    } catch (e: any) {
+      setError(e.message || '操作失败')
+    }
   }
 
   const sortedPlayers = [...session.players].sort(
@@ -111,14 +133,17 @@ export default function SessionPage() {
   )
   const rankMap = Object.fromEntries(rankings.map(r => [r.playerId, r]))
 
+  const playerColPct = `${Math.floor(90 / session.players.length)}%`
+  const playerColStyle = { textAlign: 'center' as const, width: playerColPct, minWidth: 80 }
+
   const otherPlayers = session.players.filter(p => p.id !== Number(winnerId))
   const winnerIsDealer = winnerId && dealerId && winnerId === dealerId
 
   // Score preview
   const getScorePreview = (): string | null => {
     if (isRiichi) {
-      if (!han || !fu || !dealerId) return null
-      const h = parseInt(han), f = parseInt(fu)
+      if (!fan || !fu || !dealerId) return null
+      const h = parseInt(fan), f = parseInt(fu)
       let basic: number
       if (h >= 13) basic = 8000
       else if (h >= 11) basic = 6000
@@ -153,8 +178,8 @@ export default function SessionPage() {
     }
 
     if (isDongbei) {
-      if (!han || !dealerId || !winnerId) return null
-      const fan = parseInt(han)
+      if (!fan || !dealerId || !winnerId) return null
+      const fanNum = parseInt(fan)
       const bimenSet = new Set(bimenPlayerIds)
       const opponents = session.players.filter(p => p.id !== Number(winnerId))
       const allBimen = opponents.length > 0 && opponents.every(p => bimenSet.has(p.id))
@@ -172,7 +197,7 @@ export default function SessionPage() {
         const dianpaoFlag = (isDealIn || isSelfDraw) ? 1 : 0
         const bimenFlag = isBimen ? 1 : 0
         const sanjiaBimenFlag = allBimen ? 1 : 0
-        const exponent = Math.min(fan + zhuangjiaFlag + dianpaoFlag + bimenFlag + sanjiaBimenFlag, 6)
+        const exponent = Math.min(fanNum + zhuangjiaFlag + dianpaoFlag + bimenFlag + sanjiaBimenFlag, 6)
         const payment = Math.pow(2, exponent)
 
         const flags: string[] = []
@@ -241,7 +266,7 @@ export default function SessionPage() {
               <tr>
                 <th>局</th>
                 {session.players.map(p => (
-                  <th key={p.id} style={{ textAlign: 'center' }}>
+                  <th key={p.id} style={playerColStyle}>
                     <div className="player-header-cell">
                       <span className="player-rank">#{rankMap[p.id]?.rank}</span>
                       <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>{p.userName}</span>
@@ -273,17 +298,18 @@ export default function SessionPage() {
                 </tr>
               ))}
               <tr className="total-row">
-                <td><strong>合计</strong></td>
+                <td style={{ whiteSpace: 'nowrap' }}><strong>合计</strong></td>
                 {session.players.map(p => {
-                  const val = session.totalScores[p.id] || 0
+                  const delta = session.totalScores[p.id] || 0
+                  const total = session.rpOrigin + delta
+                  const displayVal = session.rpOrigin ? total : delta
                   return (
-                    <td key={p.id} className="score-cell" style={{
-                      textAlign: 'center',
-                      color: val > 0 ? 'var(--success)' : val < 0 ? 'var(--danger)' : undefined
-                    }}>
+                    <td key={p.id} className={`score-cell${delta > 0 ? ' score-positive' : delta < 0 ? ' score-negative' : ''}`} style={{ textAlign: 'center' }}>
                       <div className="total-score-box">
-                        <div className="total-val">{val > 0 ? `+${val}` : val}</div>
-                        <div className="rp-val">{rankMap[p.id]?.rp > 0 ? `+${rankMap[p.id]?.rp.toFixed(1)}` : rankMap[p.id]?.rp.toFixed(1)} RP</div>
+                        <div className="total-val">{displayVal}</div>
+                        {session.rounds.length > 0 && (
+                          <div className="rp-val">{rankMap[p.id]?.rp > 0 ? `+${rankMap[p.id]?.rp.toFixed(1)}` : rankMap[p.id]?.rp.toFixed(1)} RP</div>
+                        )}
                       </div>
                     </td>
                   )
@@ -336,8 +362,8 @@ export default function SessionPage() {
                       : `${tenpaiPlayerIds.length}人听牌, ${session.players.length - tenpaiPlayerIds.length}人未听 → 未听各付${3000 / (session.players.length - tenpaiPlayerIds.length)}, 听牌各得${3000 / tenpaiPlayerIds.length}`}
                   </span>
                 </div>
-                <button className="btn btn-primary" onClick={handleAddRound}>
-                  添加流局
+                <button className="btn btn-primary" onClick={handleAddRound} disabled={submitting}>
+                  {submitting ? '提交中...' : '添加流局'}
                 </button>
               </>
             ) : (
@@ -369,9 +395,9 @@ export default function SessionPage() {
                     番
                     <a href="https://linlexiao.com/maj/#/calculator" target="_blank" rel="noopener noreferrer" className="score-calc-link">计算器</a>
                   </label>
-                  <select value={han} onChange={e => setHan(e.target.value)}>
+                  <select value={fan} onChange={e => setFan(e.target.value)}>
                     <option value=""></option>
-                    {HAN_OPTIONS.map(h => (
+                    {FAN_OPTIONS.map(h => (
                       <option key={h} value={h}>{h}{h >= 5 ? (h >= 13 ? ' (役満)' : h >= 11 ? ' (三倍満)' : h >= 8 ? ' (倍満)' : h >= 6 ? ' (跳満)' : ' (満貫)') : ''}</option>
                     ))}
                   </select>
@@ -427,8 +453,8 @@ export default function SessionPage() {
                     <label>番</label>
                     <input
                       type="number"
-                      value={han}
-                      onChange={e => setHan(e.target.value)}
+                      value={fan}
+                      onChange={e => setFan(e.target.value)}
                       placeholder="输入番"
                       min="1"
                     />
@@ -532,8 +558,10 @@ export default function SessionPage() {
               <div className="score-preview">{preview}</div>
             )}
 
-            <button className="btn btn-primary" onClick={handleAddRound} disabled={!canSubmit}>
-              添加
+            {error && <p style={{ color: 'var(--danger)', fontSize: '0.85rem', margin: '8px 0' }}>{error}</p>}
+
+            <button className="btn btn-primary" onClick={handleAddRound} disabled={!canSubmit || submitting}>
+              {submitting ? '提交中...' : '添加'}
             </button>
             </>
             )}

--- a/ui/src/pages/SignUpPage.tsx
+++ b/ui/src/pages/SignUpPage.tsx
@@ -19,8 +19,12 @@ export default function SignUpPage() {
     }
     setChecking(true)
     const timer = setTimeout(async () => {
-      const available = await checkUserName(userName.trim())
-      setUserNameAvailable(available)
+      try {
+        const available = await checkUserName(userName.trim())
+        setUserNameAvailable(available)
+      } catch {
+        setUserNameAvailable(null)
+      }
       setChecking(false)
     }, 400)
     return () => clearTimeout(timer)

--- a/ui/src/pages/SignUpPage.tsx
+++ b/ui/src/pages/SignUpPage.tsx
@@ -10,20 +10,24 @@ export default function SignUpPage() {
   const [userNameAvailable, setUserNameAvailable] = useState<boolean | null>(null)
   const [checking, setChecking] = useState(false)
   const [error, setError] = useState('')
+  const [checkError, setCheckError] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     if (!userName.trim()) {
       setUserNameAvailable(null)
+      setCheckError('')
       return
     }
     setChecking(true)
+    setCheckError('')
     const timer = setTimeout(async () => {
       try {
         const available = await checkUserName(userName.trim())
         setUserNameAvailable(available)
       } catch {
         setUserNameAvailable(null)
+        setCheckError('用户名检查失败，请重试')
       }
       setChecking(false)
     }, 400)
@@ -68,6 +72,7 @@ export default function SignUpPage() {
                 {checking ? '检查中...' : userNameAvailable === true ? '可用' : userNameAvailable === false ? '已被占用' : ''}
               </span>
             )}
+            {checkError && <span className="field-hint hint-error">{checkError}</span>}
           </div>
 
           <div className="form-row">

--- a/ui/src/pages/SignUpPage.tsx
+++ b/ui/src/pages/SignUpPage.tsx
@@ -25,6 +25,7 @@ export default function SignUpPage() {
       try {
         const available = await checkUserName(userName.trim())
         setUserNameAvailable(available)
+        setCheckError('')
       } catch {
         setUserNameAvailable(null)
         setCheckError('用户名检查失败，请重试')

--- a/ui/src/pages/SignUpPage.tsx
+++ b/ui/src/pages/SignUpPage.tsx
@@ -14,25 +14,34 @@ export default function SignUpPage() {
   const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
-    if (!userName.trim()) {
+    const trimmed = userName.trim()
+    if (!trimmed) {
       setUserNameAvailable(null)
       setCheckError('')
+      setChecking(false)
       return
     }
+    let cancelled = false
     setChecking(true)
     setCheckError('')
     const timer = setTimeout(async () => {
       try {
-        const available = await checkUserName(userName.trim())
+        const available = await checkUserName(trimmed)
+        if (cancelled) return
         setUserNameAvailable(available)
         setCheckError('')
       } catch {
+        if (cancelled) return
         setUserNameAvailable(null)
         setCheckError('用户名检查失败，请重试')
+      } finally {
+        if (!cancelled) setChecking(false)
       }
-      setChecking(false)
     }, 400)
-    return () => clearTimeout(timer)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
   }, [userName])
 
   const canSubmit = userName.trim() && firstName.trim() && lastName.trim() && userNameAvailable === true && !submitting

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -18,6 +18,7 @@ export default function StatsPage() {
   const [stats, setStats] = useState<PlayerStats[]>([])
   const [players, setPlayers] = useState<Player[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.quarter}`)
 
@@ -30,18 +31,19 @@ export default function StatsPage() {
       year = y
       quarter = q
     }
-    fetchStats(mode, year, quarter).then(s => {
-      setStats(s.sort((a, b) => b.totalRP - a.totalRP || b.totalScore - a.totalScore))
-      setLoading(false)
-    })
+    fetchStats(mode, year, quarter)
+      .then(s => {
+        setStats(s.sort((a, b) => b.totalRP - a.totalRP || b.totalScore - a.totalScore))
+        setLoading(false)
+      })
+      .catch(e => { setError(e.message); setLoading(false) })
   }
 
   const loadPlayers = () => {
     setLoading(true)
-    fetchPlayers().then(p => {
-      setPlayers(p)
-      setLoading(false)
-    })
+    fetchPlayers()
+      .then(p => { setPlayers(p); setLoading(false) })
+      .catch(e => { setError(e.message); setLoading(false) })
   }
 
   useEffect(() => {
@@ -55,6 +57,7 @@ export default function StatsPage() {
   const selectedSeason = seasons.find(s => `${s.year}-${s.quarter}` === seasonKey)
 
   if (loading) return <div className="empty-state"><p>加载中...</p></div>
+  if (error) return <div className="empty-state"><p>加载失败：{error}</p></div>
 
   const totalGames = activeStats.length > 0 ? Math.max(...activeStats.map(s => s.gamesPlayed)) : 0
   const topScorer = activeStats[0]
@@ -143,8 +146,8 @@ export default function StatsPage() {
                     <th style={{ textAlign: 'right' }}>场次</th>
                     <th style={{ textAlign: 'right' }}>胜场</th>
                     <th style={{ textAlign: 'right' }}>积分(RP)</th>
-                    <th style={{ textAlign: 'right' }} className="hide-mobile">总分</th>
-                    <th style={{ textAlign: 'right' }} className="hide-mobile">均分</th>
+                    <th style={{ textAlign: 'right' }}>总分</th>
+                    <th style={{ textAlign: 'right' }}>均分</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -160,8 +163,8 @@ export default function StatsPage() {
                       <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums', fontWeight: 'bold', color: 'var(--primary)' }}>
                         {s.totalRP > 0 ? `+${s.totalRP.toFixed(1)}` : s.totalRP.toFixed(1)}
                       </td>
-                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums', opacity: 0.8 }} className="hide-mobile">{s.totalScore}</td>
-                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }} className="hide-mobile">
+                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums', opacity: 0.8 }}>{s.totalScore}</td>
+                      <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
                         {s.avgScore.toFixed(1)}
                       </td>
                     </tr>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -23,6 +23,7 @@ export default function StatsPage() {
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.quarter}`)
 
   const loadStats = (mode: GameModeKey, sKey: string) => {
+    setError('')
     setLoading(true)
     let year: number | undefined
     let quarter: number | undefined
@@ -40,6 +41,7 @@ export default function StatsPage() {
   }
 
   const loadPlayers = () => {
+    setError('')
     setLoading(true)
     fetchPlayers()
       .then(p => { setPlayers(p); setLoading(false) })

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -57,7 +57,7 @@ export interface AddRoundData {
   roundType?: 'WIN' | 'DRAWN_GAME'; // default WIN
   winnerId?: number;
   score?: number;             // for Guobiao
-  han?: number;               // for Riichi (han) / Dongbei (fan)
+  fan?: number;               // for Riichi / Dongbei (番)
   fu?: number;                // for Riichi
   dealerId?: number;          // for Riichi/Dongbei: table dealer
   honba?: number;             // for Riichi: 本場 count
@@ -67,7 +67,7 @@ export interface AddRoundData {
   tenpaiPlayerIds?: number[]; // for drawn games
 }
 
-export const HAN_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+export const FAN_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 export const FU_OPTIONS = [20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110];
 
 export interface PlayerStats {


### PR DESCRIPTION
## Summary

Full codebase review and fix pass covering scoring logic, security, naming consistency, error handling, and mobile responsiveness.

### Scoring & Logic
- Fix tied-score winner detection — all tied-first players now get win credit
- Fix 不求人 for 七对+zimo; fix 幺九刻 double-subtraction with wind group fans
- Consolidate RP constants (factor, origin, uma) into `GameMode` enum as single source of truth
- Add 3-player game support with `[15, 0, -15]` uma distribution
- Fix Riichi drawn game pool: `(playerCount-1)*1000` instead of hardcoded 3000
- Show 25000-based totals for Riichi mode; hide RP when no rounds played

### Naming Alignment
- Merge `qiangGang` into `gangShang` — one field for all gang-related wins
- Rename `zimo` → `isSelfDraw` across entire guobiao engine
- Rename `han` → `fan` across backend DTO and frontend

### Security & Validation
- Add `@Min` validation on fan/fu/honba/kyoutaku in `AddRoundRequest`
- Pessimistic locking on session for `addRound`/`deleteRound` (prevent race conditions)
- Catch duplicate username DB constraint gracefully
- Wrap `GameMode.valueOf()` in try-catch (returns 400 for invalid values)
- Remove unprotected `DELETE /api/players/{id}` — now admin-only
- Remove Groovy/Gradle formatting from Spotless

### Frontend Error Handling
- Add `handleResponse()` helper — checks `res.ok` for all API calls
- Add try/catch + error display to all pages
- Add submitting state to prevent double-click on round submission
- Add 404 catch-all route

### UI / Mobile
- Remove `text-transform: uppercase` from `<th>` (was uppercasing player names)
- Even column distribution with `minWidth` for mobile horizontal scroll
- Fix 合计 vertical wrapping, fan-item mobile scroll, select-inline overflow

### Guobiao Tests (243/243 passing)
- Fix test parsers: multi-suit tokens, pipe separator, suit alias mapping
- Fix 11 wrong test expectations per GB/T 16491-2008 rules

## Test plan
- [ ] `./gradlew build` passes (Java compile + Spotless)
- [ ] `cd ui && npm run build` — no TypeScript errors
- [ ] `cd ui && npm run test:run` — 243/243 tests passing
- [ ] Create 3-player and 4-player Riichi sessions — verify uma and 25000-base totals
- [ ] Verify admin settings validation rejects non-numeric values
- [ ] Verify long usernames (e.g. "MonkeyAlwaysKing") display correctly on mobile
- [ ] Verify API errors show user-friendly messages (not stack traces)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 404 page for unmatched routes.

* **Improvements**
  * Unified API error handling with clearer user-facing messages.
  * UI pages now surface error states, show loading indicators, and disable buttons during requests.
  * Renamed scoring input/labels from “han” to “fan”, renamed self-draw option to isSelfDraw, and removed the qiangGang option.

* **Behavior Changes**
  * Player deletion endpoint removed.
  * RP and some scoring/ payout calculations adjusted, affecting displayed rankings and session totals.

* **Validation**
  * Invalid game-mode requests return 400 errors.
  * Fan/fu and related inputs enforce minimum/non-negative constraints.

* **Tests**
  * Tests updated to match renamed options and scoring changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->