### PR TITLE
chore: remove one-time backfill from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,18 +64,6 @@ jobs:
             docker stop mahjong 2>/dev/null || true
             docker rm mahjong 2>/dev/null || true
 
-            # One-time backfill: set participationBonus for existing sessions
-            docker run --rm \
-              -v mahjong-data:/app/data \
-              -e DB_USER="${{ secrets.DB_USERNAME }}" \
-              -e DB_PASS="${{ secrets.DB_PASSWORD }}" \
-              "$IMAGE:latest" \
-              sh -c 'java -cp /app/app.jar \
-                -Dloader.main=org.h2.tools.Shell \
-                org.springframework.boot.loader.launch.PropertiesLauncher \
-                -url "jdbc:h2:file:/app/data/mahjong-omakase" -user "$DB_USER" -password "$DB_PASS" \
-                -sql "UPDATE GAME_SESSIONS SET PARTICIPATION_BONUS = 5.0 WHERE PARTICIPATION_BONUS = 0;"'
-
             docker run -d \
               --name mahjong \
               --restart always \


### PR DESCRIPTION
## Summary
- Remove the one-time H2 backfill step from the deploy workflow now that the participationBonus migration has been applied on the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a database backfill step from the deployment workflow that previously executed during container transitions. The deployment process now directly proceeds to stopping and restarting containers with the same configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->