### PR TITLE
fix: make participationBonus nullable for H2 DDL migration

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/model/GameSession.java
+++ b/server/src/main/java/com/mahjong/omakase/model/GameSession.java
@@ -29,7 +29,6 @@ public class GameSession {
   @Column(nullable = false)
   private LocalDateTime createdAt = LocalDateTime.now();
 
-  @Column(nullable = false)
   private double participationBonus;
 
   @JsonIgnore


### PR DESCRIPTION
## Summary
- Remove `@Column(nullable = false)` from `participationBonus` field in `GameSession` entity
- Hibernate `ddl-auto: update` fails when adding a `NOT NULL` column to a table with existing rows that have no value for it
- The field is always set explicitly in `createSession()`, so the constraint is unnecessary

## Test plan
- [ ] Deploy and verify the app starts without DDL errors
- [ ] Verify new sessions still get the correct participationBonus value

🤖 Generated with [Claude Code](https://claude.com/claude-code)