### PR TITLE
fix: repair H2 NOT NULL constraint on participationBonus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
             docker stop mahjong 2>/dev/null || true
             docker rm mahjong 2>/dev/null || true
 
-            # One-time backfill: set participationBonus for existing sessions
+            # One-time fix: repair NOT NULL constraint and backfill participationBonus
             docker run --rm \
               -v mahjong-data:/app/data \
               -e DB_USER="${{ secrets.DB_USERNAME }}" \
@@ -74,7 +74,7 @@ jobs:
                 -Dloader.main=org.h2.tools.Shell \
                 org.springframework.boot.loader.launch.PropertiesLauncher \
                 -url "jdbc:h2:file:/app/data/mahjong-omakase" -user "$DB_USER" -password "$DB_PASS" \
-                -sql "UPDATE GAME_SESSIONS SET PARTICIPATION_BONUS = 5.0 WHERE PARTICIPATION_BONUS = 0;"'
+                -sql "ALTER TABLE GAME_SESSIONS ALTER COLUMN PARTICIPATION_BONUS SET DEFAULT 0; ALTER TABLE GAME_SESSIONS ALTER COLUMN PARTICIPATION_BONUS SET NULL; UPDATE GAME_SESSIONS SET PARTICIPATION_BONUS = 5.0 WHERE PARTICIPATION_BONUS = 0 OR PARTICIPATION_BONUS IS NULL;"'
 
             docker run -d \
               --name mahjong \


### PR DESCRIPTION
## Summary
- The previous deploy created `PARTICIPATION_BONUS` column with `NOT NULL` constraint, causing Hibernate DDL migration to fail even after removing `@Column(nullable = false)` in code
- This one-time deploy step runs before the app starts to:
  1. Set a default value on the column
  2. Drop the `NOT NULL` constraint
  3. Backfill existing rows with 5.0
- **Remove this migration block after successful deploy**

## Test plan
- [ ] Merge and verify deploy completes without DDL errors
- [ ] Verify app starts and sessions show correct participationBonus values

🤖 Generated with [Claude Code](https://claude.com/claude-code)