### PR TITLE
fix: use boxed Double for participationBonus nullable DDL

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
@@ -22,7 +22,8 @@ public class SessionSummaryResponse {
     r.playerCount = session.getPlayerCount();
     r.status = session.getStatus().name();
     r.createdAt = session.getCreatedAt();
-    r.participationBonus = session.getParticipationBonus();
+    r.participationBonus =
+        session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0;
     return r;
   }
 

--- a/server/src/main/java/com/mahjong/omakase/model/GameSession.java
+++ b/server/src/main/java/com/mahjong/omakase/model/GameSession.java
@@ -29,7 +29,7 @@ public class GameSession {
   @Column(nullable = false)
   private LocalDateTime createdAt = LocalDateTime.now();
 
-  private double participationBonus;
+  private Double participationBonus;
 
   @JsonIgnore
   @OneToMany(mappedBy = "gameSession", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -104,11 +104,11 @@ public class GameSession {
     this.rounds = rounds;
   }
 
-  public double getParticipationBonus() {
+  public Double getParticipationBonus() {
     return participationBonus;
   }
 
-  public void setParticipationBonus(double participationBonus) {
+  public void setParticipationBonus(Double participationBonus) {
     this.participationBonus = participationBonus;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -212,7 +212,8 @@ public class GameService {
     resp.setRpFactor(session.getGameMode().getRpFactor());
     resp.setRpOrigin(session.getGameMode().getRpOrigin());
     resp.setUmaDist(session.getGameMode().getUmaDist(session.getPlayerCount()));
-    resp.setParticipationBonus(session.getParticipationBonus());
+    resp.setParticipationBonus(
+        session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0);
 
     return resp;
   }
@@ -346,7 +347,9 @@ public class GameService {
       if (!sessionScores.isEmpty()) {
         for (Object[] row : sessionScores) {
           if (row[0] != null) {
-            totalBonusPerPlayer.merge((Long) row[0], session.getParticipationBonus(), Double::sum);
+            double bonus =
+                session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0;
+            totalBonusPerPlayer.merge((Long) row[0], bonus, Double::sum);
           }
         }
         List<Object[]> sorted = new ArrayList<>(sessionScores);


### PR DESCRIPTION
## Summary
- Change `private double participationBonus` to `private Double participationBonus` in `GameSession` entity
- Java primitive `double` always generates `NOT NULL` in Hibernate DDL — this was the root cause of the deploy failure, not the `@Column` annotation
- Null-safe all read sites in `GameService` and `SessionSummaryResponse`

## Test plan
- [ ] Deploy and verify no DDL errors in logs
- [ ] Verify stats page shows correct RP values
- [ ] Create a new session and verify participationBonus is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced participation bonus data integrity throughout the application by improving how bonus values are processed and displayed. Session summaries and player statistics now consistently show accurate and complete bonus information. This ensures bonus values are properly available in session details, player performance metrics, and statistical aggregations across the entire platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->