### PR TITLE
fix: use --entrypoint for migration container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,11 +66,12 @@ jobs:
 
             # One-time fix: repair NOT NULL constraint and backfill participationBonus
             docker run --rm \
+              --entrypoint sh \
               -v mahjong-data:/app/data \
               -e DB_USER="${{ secrets.DB_USERNAME }}" \
               -e DB_PASS="${{ secrets.DB_PASSWORD }}" \
               "$IMAGE:latest" \
-              sh -c 'java -cp /app/app.jar \
+              -c 'java -cp /app/app.jar \
                 -Dloader.main=org.h2.tools.Shell \
                 org.springframework.boot.loader.launch.PropertiesLauncher \
                 -url "jdbc:h2:file:/app/data/mahjong-omakase" -user "$DB_USER" -password "$DB_PASS" \


### PR DESCRIPTION
## Summary
- Add `--entrypoint sh` to the migration `docker run` so it runs the H2 Shell instead of booting the full Spring Boot app
- The Dockerfile's `ENTRYPOINT ["java", ...]` was overriding the `sh -c` command, causing the previous deploy to hang

## Test plan
- [ ] Deploy and verify migration runs H2 Shell SQL (not Spring Boot)
- [ ] Verify app starts after migration completes
- [ ] Remove the migration block after successful deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)