### PR TITLE
chore: remove one-time H2 migration from deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,17 +64,6 @@ jobs:
             docker stop mahjong 2>/dev/null || true
             docker rm mahjong 2>/dev/null || true
 
-            # One-time fix: repair NOT NULL constraint and backfill participationBonus
-            docker run --rm \
-              --entrypoint sh \
-              -v mahjong-data:/app/data \
-              "$IMAGE:latest" \
-              -c 'java -cp /app/app.jar \
-                -Dloader.main=org.h2.tools.Shell \
-                org.springframework.boot.loader.launch.PropertiesLauncher \
-                -url "jdbc:h2:file:/app/data/mahjong-omakase" -user sa -password "" \
-                -sql "ALTER TABLE GAME_SESSIONS ALTER COLUMN PARTICIPATION_BONUS SET DEFAULT 0; ALTER TABLE GAME_SESSIONS ALTER COLUMN PARTICIPATION_BONUS SET NULL; UPDATE GAME_SESSIONS SET PARTICIPATION_BONUS = 5.0 WHERE PARTICIPATION_BONUS = 0 OR PARTICIPATION_BONUS IS NULL;"'
-
             docker run -d \
               --name mahjong \
               --restart always \


### PR DESCRIPTION
## Summary
- Remove the one-time participationBonus migration script from the deploy workflow
- Migration has been successfully applied on the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified deployment workflow by removing custom database migration steps. Deployment now proceeds directly to container startup with persisted data volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->