### PR TITLE
feat: Enhance Guobiao scoring with best hand highlights and UI refinements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,12 @@ spotless {
 
   format 'frontend', {
     target fileTree('ui/src') { include '**/*.ts', '**/*.tsx', '**/*.css' }
-    prettier().config(['singleQuote': true, 'semi': false, 'printWidth': 120])
+    def isWindows = System.getProperty('os.name').toLowerCase().contains('win')
+    def nodeVersion = '18.20.4'
+    def npmBin = isWindows ? 'npm.cmd' : 'bin/npm'
+    def nodeDirName = "node-v${nodeVersion}-${isWindows ? 'win-x64' : 'linux-x64'}"
+    def npmExec = file("${projectDir}/.gradle/nodejs/${nodeDirName}/${npmBin}")
+    prettier().npmExecutable(npmExec.absolutePath).config(['singleQuote': true, 'semi': false, 'printWidth': 120])
     trimTrailingWhitespace()
     endWithNewline()
   }

--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -47,4 +47,10 @@ public class StatsController {
 
     return gameService.getPlayerStats(mode, start, end);
   }
+
+  @GetMapping("/best-rounds")
+  public List<com.mahjong.omakase.dto.BestRoundResponse> getBestRounds() {
+    return gameService.getBestRounds();
+  }
 }
+

--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -53,4 +53,3 @@ public class StatsController {
     return gameService.getBestRounds();
   }
 }
-

--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -36,6 +36,8 @@ public class AddRoundRequest {
   private String winHand;
 
   private String fanDetails;
+
+  @Min(value = 0, message = "Fan count must be non-negative")
   private Integer fanCount;
 
   public Integer getFanCount() {

--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -33,6 +33,36 @@ public class AddRoundRequest {
 
   private List<Long> tenpaiPlayerIds; // for drawn games
 
+  private String winHand;
+
+  private String fanDetails;
+  private Integer fanCount;
+
+  public Integer getFanCount() {
+    return fanCount;
+  }
+
+  public void setFanCount(Integer fanCount) {
+    this.fanCount = fanCount;
+  }
+
+
+  public String getWinHand() {
+    return winHand;
+  }
+
+  public void setWinHand(String winHand) {
+    this.winHand = winHand;
+  }
+
+  public String getFanDetails() {
+    return fanDetails;
+  }
+
+  public void setFanDetails(String fanDetails) {
+    this.fanDetails = fanDetails;
+  }
+
   public String getRoundType() {
     return roundType;
   }

--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -46,7 +46,6 @@ public class AddRoundRequest {
     this.fanCount = fanCount;
   }
 
-
   public String getWinHand() {
     return winHand;
   }

--- a/server/src/main/java/com/mahjong/omakase/dto/BestRoundResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/BestRoundResponse.java
@@ -1,0 +1,51 @@
+package com.mahjong.omakase.dto;
+
+import java.util.Map;
+
+public class BestRoundResponse {
+  private Long sessionId;
+  private int roundNumber;
+  private Long winnerId;
+  private String winnerName;
+  private String winHand;
+  private String fanDetails;
+  private Integer fanCount;
+  private Map<Long, Integer> scores;
+  private Long dealInPlayerId;
+  private String dealInPlayerName;
+
+  public BestRoundResponse(
+      Long sessionId,
+      int roundNumber,
+      Long winnerId,
+      String winnerName,
+      String winHand,
+      String fanDetails,
+      Integer fanCount,
+      Map<Long, Integer> scores,
+      Long dealInPlayerId,
+      String dealInPlayerName) {
+    this.sessionId = sessionId;
+    this.roundNumber = roundNumber;
+    this.winnerId = winnerId;
+    this.winnerName = winnerName;
+    this.winHand = winHand;
+    this.fanDetails = fanDetails;
+    this.fanCount = fanCount;
+    this.scores = scores;
+    this.dealInPlayerId = dealInPlayerId;
+    this.dealInPlayerName = dealInPlayerName;
+  }
+
+  // Getters
+  public Long getSessionId() { return sessionId; }
+  public int getRoundNumber() { return roundNumber; }
+  public Long getWinnerId() { return winnerId; }
+  public String getWinnerName() { return winnerName; }
+  public String getWinHand() { return winHand; }
+  public String getFanDetails() { return fanDetails; }
+  public Integer getFanCount() { return fanCount; }
+  public Map<Long, Integer> getScores() { return scores; }
+  public Long getDealInPlayerId() { return dealInPlayerId; }
+  public String getDealInPlayerName() { return dealInPlayerName; }
+}

--- a/server/src/main/java/com/mahjong/omakase/dto/BestRoundResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/BestRoundResponse.java
@@ -38,14 +38,43 @@ public class BestRoundResponse {
   }
 
   // Getters
-  public Long getSessionId() { return sessionId; }
-  public int getRoundNumber() { return roundNumber; }
-  public Long getWinnerId() { return winnerId; }
-  public String getWinnerName() { return winnerName; }
-  public String getWinHand() { return winHand; }
-  public String getFanDetails() { return fanDetails; }
-  public Integer getFanCount() { return fanCount; }
-  public Map<Long, Integer> getScores() { return scores; }
-  public Long getDealInPlayerId() { return dealInPlayerId; }
-  public String getDealInPlayerName() { return dealInPlayerName; }
+  public Long getSessionId() {
+    return sessionId;
+  }
+
+  public int getRoundNumber() {
+    return roundNumber;
+  }
+
+  public Long getWinnerId() {
+    return winnerId;
+  }
+
+  public String getWinnerName() {
+    return winnerName;
+  }
+
+  public String getWinHand() {
+    return winHand;
+  }
+
+  public String getFanDetails() {
+    return fanDetails;
+  }
+
+  public Integer getFanCount() {
+    return fanCount;
+  }
+
+  public Map<Long, Integer> getScores() {
+    return scores;
+  }
+
+  public Long getDealInPlayerId() {
+    return dealInPlayerId;
+  }
+
+  public String getDealInPlayerName() {
+    return dealInPlayerName;
+  }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -63,10 +63,24 @@ public class SessionDetailResponse {
   public static class RoundInfo {
     private int roundNumber;
     private Map<Long, Integer> scores;
+    private Long winnerId;
+    private String winHand;
+    private String fanDetails;
+    private Integer fanCount;
 
-    public RoundInfo(int roundNumber, Map<Long, Integer> scores) {
+    public RoundInfo(
+        int roundNumber,
+        Map<Long, Integer> scores,
+        Long winnerId,
+        String winHand,
+        String fanDetails,
+        Integer fanCount) {
       this.roundNumber = roundNumber;
       this.scores = scores;
+      this.winnerId = winnerId;
+      this.winHand = winHand;
+      this.fanDetails = fanDetails;
+      this.fanCount = fanCount;
     }
 
     public int getRoundNumber() {
@@ -76,7 +90,24 @@ public class SessionDetailResponse {
     public Map<Long, Integer> getScores() {
       return scores;
     }
+
+    public Long getWinnerId() {
+      return winnerId;
+    }
+
+    public String getWinHand() {
+      return winHand;
+    }
+
+    public String getFanDetails() {
+      return fanDetails;
+    }
+
+    public Integer getFanCount() {
+      return fanCount;
+    }
   }
+
 
   public Long getId() {
     return id;

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -108,7 +108,6 @@ public class SessionDetailResponse {
     }
   }
 
-
   public Long getId() {
     return id;
   }

--- a/server/src/main/java/com/mahjong/omakase/model/Round.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Round.java
@@ -31,6 +31,16 @@ public class Round {
 
   private Integer fanCount;
 
+  private Long dealInPlayerId;
+
+  public Long getDealInPlayerId() {
+    return dealInPlayerId;
+  }
+
+  public void setDealInPlayerId(Long dealInPlayerId) {
+    this.dealInPlayerId = dealInPlayerId;
+  }
+
   public Integer getFanCount() {
     return fanCount;
   }

--- a/server/src/main/java/com/mahjong/omakase/model/Round.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Round.java
@@ -21,6 +21,49 @@ public class Round {
   @OneToMany(mappedBy = "round", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<RoundScore> scores = new ArrayList<>();
 
+  private Long winnerId;
+
+  @Column(columnDefinition = "TEXT")
+  private String winHand;
+
+  @Column(columnDefinition = "TEXT")
+  private String fanDetails;
+
+  private Integer fanCount;
+
+  public Integer getFanCount() {
+    return fanCount;
+  }
+
+  public void setFanCount(Integer fanCount) {
+    this.fanCount = fanCount;
+  }
+
+
+  public Long getWinnerId() {
+    return winnerId;
+  }
+
+  public void setWinnerId(Long winnerId) {
+    this.winnerId = winnerId;
+  }
+
+  public String getWinHand() {
+    return winHand;
+  }
+
+  public void setWinHand(String winHand) {
+    this.winHand = winHand;
+  }
+
+  public String getFanDetails() {
+    return fanDetails;
+  }
+
+  public void setFanDetails(String fanDetails) {
+    this.fanDetails = fanDetails;
+  }
+
   public Long getId() {
     return id;
   }

--- a/server/src/main/java/com/mahjong/omakase/model/Round.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Round.java
@@ -39,7 +39,6 @@ public class Round {
     this.fanCount = fanCount;
   }
 
-
   public Long getWinnerId() {
     return winnerId;
   }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -5,4 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoundRepository extends JpaRepository<Round, Long> {
   int countByGameSessionId(Long gameSessionId);
+
+  @org.springframework.data.jpa.repository.Query("SELECT MAX(r.fanCount) FROM Round r")
+  Integer findMaxFanCount();
+
+  java.util.List<Round> findByFanCount(Integer fanCount);
 }
+

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -11,4 +11,3 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
 
   java.util.List<Round> findByFanCount(Integer fanCount);
 }
-

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -278,7 +278,8 @@ public class GameService {
         request.getWinnerId(),
         request.getWinHand(),
         request.getFanDetails(),
-        request.getFanCount());
+        request.getFanCount(),
+        request.isSelfDraw() ? null : request.getDealInPlayerId());
   }
 
   public void deleteRound(Long sessionId, int roundNumber) {
@@ -323,6 +324,7 @@ public class GameService {
             round -> {
               Map<Long, Integer> scores =
                   round.getScores().stream()
+                      .filter(rs -> rs.getPlayer() != null)
                       .collect(
                           Collectors.toMap(rs -> rs.getPlayer().getId(), RoundScore::getScore));
 
@@ -335,17 +337,7 @@ public class GameService {
                       : null;
 
               // Find deal-in player
-              Long dealInId =
-                  scores.entrySet().stream()
-                      .filter(e -> e.getValue() < 0 && !e.getKey().equals(round.getWinnerId()))
-                      .findFirst() // Simplification: assume first negative that isn't winner
-                      .map(Map.Entry::getKey)
-                      .orElse(null);
-              // Note: For Guobiao, multiple players can have negative scores if it's self-draw.
-              // So we only set dealInPlayerId if it's a discard win.
-              // We can check if more than 1 player has negative scores.
-              long numNegative = scores.values().stream().filter(v -> v < 0).count();
-              if (numNegative > 1) dealInId = null; // Self-draw
+              Long dealInId = round.getDealInPlayerId();
 
               String dealInName =
                   dealInId != null
@@ -536,7 +528,8 @@ public class GameService {
       Long winnerId,
       String winHand,
       String fanDetails,
-      Integer fanCount) {
+      Integer fanCount,
+      Long dealInId) {
     Round round = new Round();
     round.setGameSession(session);
     round.setRoundNumber(roundNumber);
@@ -544,6 +537,7 @@ public class GameService {
     round.setWinHand(winHand);
     round.setFanDetails(fanDetails);
     round.setFanCount(fanCount);
+    round.setDealInPlayerId(dealInId);
 
     round = roundRepo.save(round);
 

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -206,7 +206,6 @@ public class GameService {
                       round.getWinHand(),
                       round.getFanDetails(),
                       round.getFanCount());
-
                 })
             .collect(Collectors.toList()));
 
@@ -280,7 +279,6 @@ public class GameService {
         request.getWinHand(),
         request.getFanDetails(),
         request.getFanCount());
-
   }
 
   public void deleteRound(Long sessionId, int roundNumber) {
@@ -330,7 +328,10 @@ public class GameService {
 
               String winnerName =
                   round.getWinnerId() != null
-                      ? playerRepo.findById(round.getWinnerId()).map(Player::getUserName).orElse("?")
+                      ? playerRepo
+                          .findById(round.getWinnerId())
+                          .map(Player::getUserName)
+                          .orElse("?")
                       : null;
 
               // Find deal-in player
@@ -367,7 +368,6 @@ public class GameService {
   }
 
   public List<PlayerStatsResponse> getPlayerStats(
-
       GameMode gameMode, LocalDateTime start, LocalDateTime end) {
     List<Player> players = playerRepo.findAll();
     boolean hasDateRange = start != null && end != null;

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -199,7 +199,14 @@ public class GameService {
                           .filter(rs -> rs.getPlayer() != null)
                           .collect(
                               Collectors.toMap(rs -> rs.getPlayer().getId(), RoundScore::getScore));
-                  return new SessionDetailResponse.RoundInfo(round.getRoundNumber(), scores);
+                  return new SessionDetailResponse.RoundInfo(
+                      round.getRoundNumber(),
+                      scores,
+                      round.getWinnerId(),
+                      round.getWinHand(),
+                      round.getFanDetails(),
+                      round.getFanCount());
+
                 })
             .collect(Collectors.toList()));
 
@@ -265,7 +272,15 @@ public class GameService {
         request.getParsedRoundType(),
         session.getGameMode());
 
-    saveRoundScores(session, nextRoundNumber, computedScores);
+    saveRoundScores(
+        session,
+        nextRoundNumber,
+        computedScores,
+        request.getWinnerId(),
+        request.getWinHand(),
+        request.getFanDetails(),
+        request.getFanCount());
+
   }
 
   public void deleteRound(Long sessionId, int roundNumber) {
@@ -301,7 +316,58 @@ public class GameService {
     log.info("Completed session id={}", sessionId);
   }
 
+  public List<BestRoundResponse> getBestRounds() {
+    Integer maxFan = roundRepo.findMaxFanCount();
+    if (maxFan == null || maxFan == 0) return Collections.emptyList();
+
+    return roundRepo.findByFanCount(maxFan).stream()
+        .map(
+            round -> {
+              Map<Long, Integer> scores =
+                  round.getScores().stream()
+                      .collect(
+                          Collectors.toMap(rs -> rs.getPlayer().getId(), RoundScore::getScore));
+
+              String winnerName =
+                  round.getWinnerId() != null
+                      ? playerRepo.findById(round.getWinnerId()).map(Player::getUserName).orElse("?")
+                      : null;
+
+              // Find deal-in player
+              Long dealInId =
+                  scores.entrySet().stream()
+                      .filter(e -> e.getValue() < 0 && !e.getKey().equals(round.getWinnerId()))
+                      .findFirst() // Simplification: assume first negative that isn't winner
+                      .map(Map.Entry::getKey)
+                      .orElse(null);
+              // Note: For Guobiao, multiple players can have negative scores if it's self-draw.
+              // So we only set dealInPlayerId if it's a discard win.
+              // We can check if more than 1 player has negative scores.
+              long numNegative = scores.values().stream().filter(v -> v < 0).count();
+              if (numNegative > 1) dealInId = null; // Self-draw
+
+              String dealInName =
+                  dealInId != null
+                      ? playerRepo.findById(dealInId).map(Player::getUserName).orElse("?")
+                      : null;
+
+              return new BestRoundResponse(
+                  round.getGameSession().getId(),
+                  round.getRoundNumber(),
+                  round.getWinnerId(),
+                  winnerName,
+                  round.getWinHand(),
+                  round.getFanDetails(),
+                  round.getFanCount(),
+                  scores,
+                  dealInId,
+                  dealInName);
+            })
+        .collect(Collectors.toList());
+  }
+
   public List<PlayerStatsResponse> getPlayerStats(
+
       GameMode gameMode, LocalDateTime start, LocalDateTime end) {
     List<Player> players = playerRepo.findAll();
     boolean hasDateRange = start != null && end != null;
@@ -464,10 +530,21 @@ public class GameService {
   }
 
   private void saveRoundScores(
-      GameSession session, int roundNumber, Map<Long, Integer> computedScores) {
+      GameSession session,
+      int roundNumber,
+      Map<Long, Integer> computedScores,
+      Long winnerId,
+      String winHand,
+      String fanDetails,
+      Integer fanCount) {
     Round round = new Round();
     round.setGameSession(session);
     round.setRoundNumber(roundNumber);
+    round.setWinnerId(winnerId);
+    round.setWinHand(winHand);
+    round.setFanDetails(fanDetails);
+    round.setFanCount(fanCount);
+
     round = roundRepo.save(round);
 
     for (Map.Entry<Long, Integer> entry : computedScores.entrySet()) {

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -93,3 +93,9 @@ export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
   const res = await fetch(`${API}/players/${id}/detail`)
   return handleResponse(res)
 }
+
+export async function fetchBestRounds(): Promise<any[]> {
+  const res = await fetch(`${API}/stats/best-rounds`)
+  return handleResponse(res)
+}
+

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -98,4 +98,3 @@ export async function fetchBestRounds(): Promise<any[]> {
   const res = await fetch(`${API}/stats/best-rounds`)
   return handleResponse(res)
 }
-

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -1,4 +1,4 @@
-import { Player, GameSession, SessionDetail, PlayerStats, PlayerDetail, AddRoundData } from '../types'
+import { Player, GameSession, SessionDetail, PlayerStats, PlayerDetail, AddRoundData, BestRound } from '../types'
 
 const API = '/api'
 
@@ -94,7 +94,7 @@ export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
   return handleResponse(res)
 }
 
-export async function fetchBestRounds(): Promise<any[]> {
+export async function fetchBestRounds(): Promise<BestRound[]> {
   const res = await fetch(`${API}/stats/best-rounds`)
-  return handleResponse(res)
+  return handleResponse<BestRound[]>(res)
 }

--- a/ui/src/components/GuobiaoCalculator.tsx
+++ b/ui/src/components/GuobiaoCalculator.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react'
+import React, { useState, useMemo, useEffect, useCallback, Fragment } from 'react'
 import { Tile } from '../logic/guobiao/tiles'
 import { Meld, GameOptions, CalcResult } from '../logic/guobiao/types'
 import { calculateBestScore } from '../logic/guobiao/fan'
@@ -122,7 +122,7 @@ const TileComponent: React.FC<{
 }
 
 interface GuobiaoCalculatorProps {
-  onSelectScore: (score: number | null) => void
+  onSelectScore: (score: number | null, hand?: string, fanDetails?: string, fanCount?: number) => void
   initialOptions?: Partial<GameOptions>
   resetTrigger?: number
   isSelfDraw: boolean
@@ -228,11 +228,31 @@ export const GuobiaoCalculator: React.FC<GuobiaoCalculatorProps> = ({
 
   useEffect(() => {
     if (currentCount === 14 && huResult && huResult.totalScore >= 8) {
-      onSelectScore(huResult.totalScore)
+      // Serialize hand
+      const lastTile = concealedTiles.length > 0 ? concealedTiles[concealedTiles.length - 1] : undefined
+      let handStr = ''
+      if (lastTile) {
+        const others = concealedTiles.slice(0, -1).sort((a, b) => a.compareTo(b))
+        const concealedStr = others.map((t) => t.toString()).join('')
+        const winTileStr = `^${lastTile.toString()}`
+        const meldsStr = melds
+          .map((m) => {
+            const tStr = m.tiles.map((t) => t.toString()).join('')
+            return m.isOpen ? `[${tStr}]` : `(${tStr})`
+          })
+          .join('')
+        handStr = concealedStr + winTileStr + meldsStr
+      }
+
+      // Serialize fan details
+      const fanDetailsStr = huResult.fans.map((f) => `${f.name}(${f.score}${f.count && f.count > 1 ? `x${f.count}` : ''})`).join(', ')
+
+      onSelectScore(huResult.totalScore, handStr, fanDetailsStr, huResult.totalScore)
+
     } else {
       onSelectScore(null)
     }
-  }, [huResult, onSelectScore, currentCount])
+  }, [huResult, onSelectScore, currentCount, concealedTiles, melds])
 
   const tingResults = useMemo(() => {
     if (currentCount !== 13) return []

--- a/ui/src/components/GuobiaoCalculator.tsx
+++ b/ui/src/components/GuobiaoCalculator.tsx
@@ -245,10 +245,11 @@ export const GuobiaoCalculator: React.FC<GuobiaoCalculatorProps> = ({
       }
 
       // Serialize fan details
-      const fanDetailsStr = huResult.fans.map((f) => `${f.name}(${f.score}${f.count && f.count > 1 ? `x${f.count}` : ''})`).join(', ')
+      const fanDetailsStr = huResult.fans
+        .map((f) => `${f.name}(${f.score}${f.count && f.count > 1 ? `x${f.count}` : ''})`)
+        .join(', ')
 
       onSelectScore(huResult.totalScore, handStr, fanDetailsStr, huResult.totalScore)
-
     } else {
       onSelectScore(null)
     }

--- a/ui/src/components/MahjongHand.tsx
+++ b/ui/src/components/MahjongHand.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+
+interface Props {
+  hand?: string
+  details?: string
+}
+
+export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
+  if (!hand) return null
+
+  const TILE_MAP: Record<string, string> = {
+    '1m': 'Man1', '2m': 'Man2', '3m': 'Man3', '4m': 'Man4', '5m': 'Man5', '6m': 'Man6', '7m': 'Man7', '8m': 'Man8', '9m': 'Man9',
+    '1p': 'Pin1', '2p': 'Pin2', '3p': 'Pin3', '4p': 'Pin4', '5p': 'Pin5', '6p': 'Pin6', '7p': 'Pin7', '8p': 'Pin8', '9p': 'Pin9',
+    '1s': 'Sou1', '2s': 'Sou2', '3s': 'Sou3', '4s': 'Sou4', '5s': 'Sou5', '6s': 'Sou6', '7s': 'Sou7', '8s': 'Sou8', '9s': 'Sou9',
+    '1z': 'Ton', '2z': 'Nan', '3z': 'Shaa', '4z': 'Pei', '5z': 'Haku', '6z': 'Hatsu', '7z': 'Chun'
+  }
+
+  const elements: React.ReactNode[] = []
+  let i = 0
+  let currentGroup: { tile: string; isWin: boolean }[] = []
+  let inGroup = false
+  let isGroupOpen = true
+
+  while (i < hand.length) {
+    const char = hand[i]
+    if (char === '[' || char === '(') {
+      if (currentGroup.length > 0) {
+        elements.push(
+          <div key={`group-${elements.length}`} className="mahjong-group">
+            {currentGroup.map((g, idx) => (
+              <img
+                key={idx}
+                src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${TILE_MAP[g.tile]}.svg`}
+                alt={g.tile}
+                className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
+              />
+            ))}
+          </div>
+        )
+        currentGroup = []
+      }
+      inGroup = true
+      isGroupOpen = char === '['
+      i++
+    } else if (char === ']' || char === ')') {
+      elements.push(
+        <div key={`group-${elements.length}`} className={`mahjong-group ${!isGroupOpen ? 'highlighted-group' : ''}`}>
+          {currentGroup.map((g, idx) => (
+            <img
+              key={idx}
+              src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${TILE_MAP[g.tile]}.svg`}
+              alt={g.tile}
+              className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
+            />
+          ))}
+        </div>
+      )
+      currentGroup = []
+      inGroup = false
+      i++
+    } else if (char === '^') {
+      i++
+      const tile = hand.substring(i, i + 2)
+      currentGroup.push({ tile, isWin: true })
+      i += 2
+    } else {
+      const tile = hand.substring(i, i + 2)
+      if (TILE_MAP[tile]) {
+        currentGroup.push({ tile, isWin: false })
+      }
+      i += 2
+    }
+  }
+
+  // Final flush for concealed
+  if (currentGroup.length > 0) {
+    elements.push(
+      <div key={`group-last`} className="mahjong-group">
+        {currentGroup.map((g, idx) => (
+          <img
+            key={idx}
+            src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${TILE_MAP[g.tile]}.svg`}
+            alt={g.tile}
+            className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mahjong-hand-container">
+      <div className="mahjong-hand">{elements}</div>
+      {details && <div className="fan-details">{details}</div>}
+    </div>
+  )
+}

--- a/ui/src/components/MahjongHand.tsx
+++ b/ui/src/components/MahjongHand.tsx
@@ -40,9 +40,9 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
     '2z': 'Nan',
     '3z': 'Shaa',
     '4z': 'Pei',
-    '5z': 'Haku',
+    '5z': 'Chun',
     '6z': 'Hatsu',
-    '7z': 'Chun',
+    '7z': 'Haku',
   }
 
   const elements: React.ReactNode[] = []

--- a/ui/src/components/MahjongHand.tsx
+++ b/ui/src/components/MahjongHand.tsx
@@ -5,50 +5,49 @@ interface Props {
   details?: string
 }
 
+const TILE_MAP: Record<string, string> = {
+  '1m': 'Man1',
+  '2m': 'Man2',
+  '3m': 'Man3',
+  '4m': 'Man4',
+  '5m': 'Man5',
+  '6m': 'Man6',
+  '7m': 'Man7',
+  '8m': 'Man8',
+  '9m': 'Man9',
+  '1p': 'Pin1',
+  '2p': 'Pin2',
+  '3p': 'Pin3',
+  '4p': 'Pin4',
+  '5p': 'Pin5',
+  '6p': 'Pin6',
+  '7p': 'Pin7',
+  '8p': 'Pin8',
+  '9p': 'Pin9',
+  '1s': 'Sou1',
+  '2s': 'Sou2',
+  '3s': 'Sou3',
+  '4s': 'Sou4',
+  '5s': 'Sou5',
+  '6s': 'Sou6',
+  '7s': 'Sou7',
+  '8s': 'Sou8',
+  '9s': 'Sou9',
+  '1z': 'Ton',
+  '2z': 'Nan',
+  '3z': 'Shaa',
+  '4z': 'Pei',
+  '5z': 'Chun',
+  '6z': 'Hatsu',
+  '7z': 'Haku',
+}
+
 export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
   if (!hand) return null
-
-  const TILE_MAP: Record<string, string> = {
-    '1m': 'Man1',
-    '2m': 'Man2',
-    '3m': 'Man3',
-    '4m': 'Man4',
-    '5m': 'Man5',
-    '6m': 'Man6',
-    '7m': 'Man7',
-    '8m': 'Man8',
-    '9m': 'Man9',
-    '1p': 'Pin1',
-    '2p': 'Pin2',
-    '3p': 'Pin3',
-    '4p': 'Pin4',
-    '5p': 'Pin5',
-    '6p': 'Pin6',
-    '7p': 'Pin7',
-    '8p': 'Pin8',
-    '9p': 'Pin9',
-    '1s': 'Sou1',
-    '2s': 'Sou2',
-    '3s': 'Sou3',
-    '4s': 'Sou4',
-    '5s': 'Sou5',
-    '6s': 'Sou6',
-    '7s': 'Sou7',
-    '8s': 'Sou8',
-    '9s': 'Sou9',
-    '1z': 'Ton',
-    '2z': 'Nan',
-    '3z': 'Shaa',
-    '4z': 'Pei',
-    '5z': 'Chun',
-    '6z': 'Hatsu',
-    '7z': 'Haku',
-  }
 
   const elements: React.ReactNode[] = []
   let i = 0
   let currentGroup: { tile: string; isWin: boolean }[] = []
-  let inGroup = false
   let isGroupOpen = true
 
   while (i < hand.length) {
@@ -61,7 +60,7 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
               <img
                 key={idx}
                 src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${
-                  TILE_MAP[g.tile]
+                  TILE_MAP[g.tile] || 'Back'
                 }.svg`}
                 alt={g.tile}
                 className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
@@ -71,7 +70,6 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
         )
         currentGroup = []
       }
-      inGroup = true
       isGroupOpen = char === '['
       i++
     } else if (char === ']' || char === ')') {
@@ -81,7 +79,7 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
             <img
               key={idx}
               src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${
-                TILE_MAP[g.tile]
+                TILE_MAP[g.tile] || 'Back'
               }.svg`}
               alt={g.tile}
               className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
@@ -90,7 +88,6 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
         </div>
       )
       currentGroup = []
-      inGroup = false
       i++
     } else if (char === '^') {
       i++
@@ -114,7 +111,7 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
           <img
             key={idx}
             src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${
-              TILE_MAP[g.tile]
+              TILE_MAP[g.tile] || 'Back'
             }.svg`}
             alt={g.tile}
             className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}

--- a/ui/src/components/MahjongHand.tsx
+++ b/ui/src/components/MahjongHand.tsx
@@ -9,10 +9,40 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
   if (!hand) return null
 
   const TILE_MAP: Record<string, string> = {
-    '1m': 'Man1', '2m': 'Man2', '3m': 'Man3', '4m': 'Man4', '5m': 'Man5', '6m': 'Man6', '7m': 'Man7', '8m': 'Man8', '9m': 'Man9',
-    '1p': 'Pin1', '2p': 'Pin2', '3p': 'Pin3', '4p': 'Pin4', '5p': 'Pin5', '6p': 'Pin6', '7p': 'Pin7', '8p': 'Pin8', '9p': 'Pin9',
-    '1s': 'Sou1', '2s': 'Sou2', '3s': 'Sou3', '4s': 'Sou4', '5s': 'Sou5', '6s': 'Sou6', '7s': 'Sou7', '8s': 'Sou8', '9s': 'Sou9',
-    '1z': 'Ton', '2z': 'Nan', '3z': 'Shaa', '4z': 'Pei', '5z': 'Haku', '6z': 'Hatsu', '7z': 'Chun'
+    '1m': 'Man1',
+    '2m': 'Man2',
+    '3m': 'Man3',
+    '4m': 'Man4',
+    '5m': 'Man5',
+    '6m': 'Man6',
+    '7m': 'Man7',
+    '8m': 'Man8',
+    '9m': 'Man9',
+    '1p': 'Pin1',
+    '2p': 'Pin2',
+    '3p': 'Pin3',
+    '4p': 'Pin4',
+    '5p': 'Pin5',
+    '6p': 'Pin6',
+    '7p': 'Pin7',
+    '8p': 'Pin8',
+    '9p': 'Pin9',
+    '1s': 'Sou1',
+    '2s': 'Sou2',
+    '3s': 'Sou3',
+    '4s': 'Sou4',
+    '5s': 'Sou5',
+    '6s': 'Sou6',
+    '7s': 'Sou7',
+    '8s': 'Sou8',
+    '9s': 'Sou9',
+    '1z': 'Ton',
+    '2z': 'Nan',
+    '3z': 'Shaa',
+    '4z': 'Pei',
+    '5z': 'Haku',
+    '6z': 'Hatsu',
+    '7z': 'Chun',
   }
 
   const elements: React.ReactNode[] = []
@@ -30,7 +60,9 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
             {currentGroup.map((g, idx) => (
               <img
                 key={idx}
-                src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${TILE_MAP[g.tile]}.svg`}
+                src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${
+                  TILE_MAP[g.tile]
+                }.svg`}
                 alt={g.tile}
                 className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
               />
@@ -48,7 +80,9 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
           {currentGroup.map((g, idx) => (
             <img
               key={idx}
-              src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${TILE_MAP[g.tile]}.svg`}
+              src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${
+                TILE_MAP[g.tile]
+              }.svg`}
               alt={g.tile}
               className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
             />
@@ -79,7 +113,9 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
         {currentGroup.map((g, idx) => (
           <img
             key={idx}
-            src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${TILE_MAP[g.tile]}.svg`}
+            src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${
+              TILE_MAP[g.tile]
+            }.svg`}
             alt={g.tile}
             className={`mahjong-tile ${g.isWin ? 'highlighted-tile' : ''}`}
           />

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,18 +1,60 @@
 :root {
-  --primary: #1a472a;
-  --primary-light: #2d6a4f;
-  --accent: #d4a017;
-  --bg: #f5f1eb;
+  /* Solarized Palette */
+  --sol-base03: #002b36;
+  --sol-base02: #073642;
+  --sol-base01: #586e75;
+  --sol-base00: #657b83;
+  --sol-base0: #839496;
+  --sol-base1: #93a1a1;
+  --sol-base2: #eee8d5;
+  --sol-base3: #fdf6e3;
+  --sol-yellow: #b58900;
+  --sol-orange: #cb4b16;
+  --sol-red: #dc322f;
+  --sol-magenta: #d33682;
+  --sol-violet: #6c71c4;
+  --sol-blue: #268bd2;
+  --sol-cyan: #2aa198;
+  --sol-green: #859900;
+  
+  /* Mahjong Tile Inspired Colors */
+  --mj-red: #b33939;   /* Rich Character Red */
+  --mj-green: #218c74; /* Deep Bamboo Green */
+  --mj-gold: #d4a017;
+
+
+  --primary: var(--sol-base02);
+  --primary-light: var(--sol-base01);
+  --accent: var(--sol-yellow);
+  --bg: var(--sol-base3);
   --card: #ffffff;
-  --text: #1a1a1a;
-  --text-light: #666666;
-  --border: #e0d8cf;
-  --danger: #c0392b;
-  --success: #27ae60;
+  --text: var(--sol-base01);
+  --text-light: var(--sol-base0);
+  --border: var(--sol-base2);
+  --danger: var(--sol-red);
+  --success: var(--sol-green);
   --radius: 12px;
-  --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.03);
 }
+
+/* Rank Tags */
+.rank-tag {
+  font-weight: 800;
+  font-size: 0.9rem;
+}
+.rank-tag-1 { color: #b58900; } /* Gold */
+.rank-tag-2 { color: #839496; } /* Silver/Base0 */
+.rank-tag-3 { color: #cb4b16; } /* Bronze/Orange */
+.rank-tag-4 { color: var(--sol-base01); }
+
+/* Rank Circles (Legacy, will remove if unused) */
+
+
+
+
+
+
 
 html {
   scroll-behavior: smooth;
@@ -744,15 +786,77 @@ tr:hover td {
 }
 
 .round-wind-tag {
-  font-size: 0.6rem;
-  background: var(--bg);
-  color: var(--accent);
-  padding: 1px 4px;
+  font-size: 0.85rem;
+  background: var(--sol-base2);
+  color: var(--sol-yellow);
+  padding: 2px 6px;
   border-radius: 4px;
-  border: 1px solid rgba(212, 160, 23, 0.3);
-  font-weight: 800;
+  border: 1px solid var(--sol-base1);
+  font-weight: 700;
   white-space: nowrap;
 }
+
+/* Best Hand Card */
+.best-hand-card {
+  margin-top: 24px;
+}
+
+.best-hand-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  color: var(--sol-yellow);
+}
+
+.best-hand-crown {
+  font-size: 1.8rem;
+}
+
+.best-hand-item {
+  padding: 16px;
+  background: var(--sol-base3);
+  border: 1px solid var(--sol-base2);
+  border-radius: 12px;
+  margin-bottom: 16px;
+}
+
+.best-hand-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px dashed var(--sol-base2);
+}
+
+.best-hand-fan-count {
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: var(--sol-orange);
+}
+
+.best-hand-players {
+  font-size: 0.95rem;
+  color: var(--sol-base01);
+}
+
+.winner-label { color: var(--mj-green); font-weight: 800; }
+.loser-label { color: var(--mj-red); font-weight: 800; }
+
+.zimo-label { color: var(--sol-blue); font-style: italic; }
+.session-link-label a { color: var(--sol-cyan); text-decoration: underline; font-size: 0.85rem; }
+.ml-2 { margin-left: 8px; }
+
+
+.best-hand-display {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+
+
 
 .win-type-selector {
   display: flex;
@@ -1515,6 +1619,71 @@ tr:hover td {
   padding-bottom: 8px;
   flex-wrap: wrap;
 }
+
+.score-winner {
+  background: rgba(181, 137, 0, 0.12) !important;
+  font-weight: 600;
+}
+
+
+.hand-details-row {
+  background: rgba(238, 232, 213, 0.3) !important;
+}
+
+
+.hand-details-cell {
+  padding: 8px 12px !important;
+  border-top: none !important;
+}
+
+.hand-info-box {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hand-tiles-display {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.mahjong-tile.highlighted-tile {
+  border-color: var(--accent);
+  border-width: 2px;
+  box-shadow: 0 0 8px rgba(212, 160, 23, 0.5);
+}
+
+
+.hand-fan-list {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  font-style: italic;
+}
+
+.round-info-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hand-toggle-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  transition: transform 0.2s;
+}
+
+.hand-toggle-btn.open {
+  transform: rotate(90deg);
+}
+
 .mini-option {
   display: flex;
   align-items: center;
@@ -1898,18 +2067,21 @@ tr:hover td {
 }
 
 .quick-player-btn.winner {
-  background-color: #859900 !important; /* Solarized Green */
-  color: #fff !important;
-  border-color: #859900 !important;
-  font-weight: 800;
+  background-color: rgba(133, 153, 0, 0.12) !important;
+  color: var(--sol-green) !important;
+  border-color: var(--sol-green) !important;
+  font-weight: 700;
+  box-shadow: 0 0 0 1px var(--sol-green);
 }
 
 .quick-player-btn.loser {
-  background-color: #dc322f !important; /* Solarized Red */
-  color: #fff !important;
-  border-color: #dc322f !important;
-  font-weight: 800;
+  background-color: rgba(220, 50, 47, 0.12) !important;
+  color: var(--sol-red) !important;
+  border-color: var(--sol-red) !important;
+  font-weight: 700;
+  box-shadow: 0 0 0 1px var(--sol-red);
 }
+
 
 .quick-player-btn.win-type-btn {
   font-weight: 700;
@@ -1917,18 +2089,17 @@ tr:hover td {
 }
 
 .quick-player-btn.zimo {
-  border-color: var(--primary);
-  color: var(--primary);
-  background: rgba(26, 71, 42, 0.05);
+  border-color: var(--sol-blue);
+  color: var(--sol-blue);
+  background: rgba(38, 139, 210, 0.08);
 }
 
 .quick-player-btn.dianpao {
-  background-color: #f0f0f0;
-  color: #93a1a1;
-  border-color: #d0d0d0;
-  box-shadow: none;
-  cursor: default;
+  border-color: var(--sol-orange);
+  color: var(--sol-orange);
+  background: rgba(203, 75, 22, 0.08);
 }
+
 
 .quick-player-btn .btn-name {
   font-size: 0.9rem;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -16,12 +16,11 @@
   --sol-blue: #268bd2;
   --sol-cyan: #2aa198;
   --sol-green: #859900;
-  
+
   /* Mahjong Tile Inspired Colors */
-  --mj-red: #b33939;   /* Rich Character Red */
+  --mj-red: #b33939; /* Rich Character Red */
   --mj-green: #218c74; /* Deep Bamboo Green */
   --mj-gold: #d4a017;
-
 
   --primary: var(--sol-base02);
   --primary-light: var(--sol-base01);
@@ -43,18 +42,20 @@
   font-weight: 800;
   font-size: 0.9rem;
 }
-.rank-tag-1 { color: #b58900; } /* Gold */
-.rank-tag-2 { color: #839496; } /* Silver/Base0 */
-.rank-tag-3 { color: #cb4b16; } /* Bronze/Orange */
-.rank-tag-4 { color: var(--sol-base01); }
+.rank-tag-1 {
+  color: #b58900;
+} /* Gold */
+.rank-tag-2 {
+  color: #839496;
+} /* Silver/Base0 */
+.rank-tag-3 {
+  color: #cb4b16;
+} /* Bronze/Orange */
+.rank-tag-4 {
+  color: var(--sol-base01);
+}
 
 /* Rank Circles (Legacy, will remove if unused) */
-
-
-
-
-
-
 
 html {
   scroll-behavior: smooth;
@@ -841,22 +842,33 @@ tr:hover td {
   color: var(--sol-base01);
 }
 
-.winner-label { color: var(--mj-green); font-weight: 800; }
-.loser-label { color: var(--mj-red); font-weight: 800; }
+.winner-label {
+  color: var(--mj-green);
+  font-weight: 800;
+}
+.loser-label {
+  color: var(--mj-red);
+  font-weight: 800;
+}
 
-.zimo-label { color: var(--sol-blue); font-style: italic; }
-.session-link-label a { color: var(--sol-cyan); text-decoration: underline; font-size: 0.85rem; }
-.ml-2 { margin-left: 8px; }
-
+.zimo-label {
+  color: var(--sol-blue);
+  font-style: italic;
+}
+.session-link-label a {
+  color: var(--sol-cyan);
+  text-decoration: underline;
+  font-size: 0.85rem;
+}
+.ml-2 {
+  margin-left: 8px;
+}
 
 .best-hand-display {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-
-
-
 
 .win-type-selector {
   display: flex;
@@ -1625,11 +1637,9 @@ tr:hover td {
   font-weight: 600;
 }
 
-
 .hand-details-row {
   background: rgba(238, 232, 213, 0.3) !important;
 }
-
 
 .hand-details-cell {
   padding: 8px 12px !important;
@@ -1654,7 +1664,6 @@ tr:hover td {
   border-width: 2px;
   box-shadow: 0 0 8px rgba(212, 160, 23, 0.5);
 }
-
 
 .hand-fan-list {
   font-size: 0.8rem;
@@ -2082,7 +2091,6 @@ tr:hover td {
   box-shadow: 0 0 0 1px var(--sol-red);
 }
 
-
 .quick-player-btn.win-type-btn {
   font-weight: 700;
   border-width: 2px;
@@ -2099,7 +2107,6 @@ tr:hover td {
   color: var(--sol-orange);
   background: rgba(203, 75, 22, 0.08);
 }
-
 
 .quick-player-btn .btn-name {
   font-size: 0.9rem;

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, Fragment } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { fetchSessionDetail, addRound, deleteRound, completeSession } from '../api'
 import { SessionDetail, PlayerInfo, RoundInfo, FAN_OPTIONS, FU_OPTIONS } from '../types'
@@ -804,10 +804,11 @@ export default function SessionPage() {
                 {sortedPlayers.map((p, i) => {
                   const val = session.totalScores[p.id] || 0
                   const rp = rankMap[p.id]?.rp ?? 0
+                  const rank = rankMap[p.id]?.rank ?? i + 1
                   return (
                     <tr key={p.id}>
                       <td>
-                        <span className={`rank-tag rank-tag-${i + 1}`}>#{i + 1}</span>
+                        <span className={`rank-tag rank-tag-${rank}`}>#{rank}</span>
                       </td>
                       <td>{p.userName}</td>
                       <td
@@ -853,7 +854,7 @@ export default function SessionPage() {
               const loser = payerIds.length === 1 ? session.players.find((p) => p.id === payerIds[0]) : null
 
               return (
-                <div key={idx} className="best-hand-item">
+                <div key={round.roundNumber} className="best-hand-item">
                   <div className="best-hand-meta">
                     <span className="best-hand-fan-count">{round.effectiveFan} 番</span>
                     <span className="best-hand-players">

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback, Fragment } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { fetchSessionDetail, addRound, deleteRound, completeSession } from '../api'
-import { SessionDetail, PlayerInfo, FAN_OPTIONS, FU_OPTIONS } from '../types'
+import { SessionDetail, PlayerInfo, RoundInfo, FAN_OPTIONS, FU_OPTIONS } from '../types'
 import { calculateRanks } from '../logic/ranking'
 import { GuobiaoCalculator } from '../components/GuobiaoCalculator'
+import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
 
 export default function SessionPage() {
@@ -24,17 +25,28 @@ export default function SessionPage() {
   const [isCalcOpen, setIsCalcOpen] = useState(false)
   const [calcResetCount, setCalcResetCount] = useState(0)
   const [submitting, setSubmitting] = useState(false)
+  const [winHand, setWinHand] = useState<string>('')
+  const [fanDetails, setFanDetails] = useState<string>('')
+  const [fanCount, setFanCount] = useState<number>(0)
   const [error, setError] = useState('')
 
-  const handleCalcScoreSelect = useCallback((s: number | null) => {
+
+  const handleCalcScoreSelect = useCallback((s: number | null, hand?: string, details?: string, fCount?: number) => {
     if (s !== null) {
       setScore(String(s))
+      setWinHand(hand || '')
+      setFanDetails(details || '')
+      setFanCount(fCount || 0)
     } else {
       setScore('')
+      setWinHand('')
+      setFanDetails('')
+      setFanCount(0)
     }
   }, [])
 
   const load = async () => {
+
     const detail = await fetchSessionDetail(Number(id))
     setSession(detail)
     setError('')
@@ -128,6 +140,7 @@ export default function SessionPage() {
           honba: parseInt(honba) || 0,
           kyoutaku: parseInt(kyoutaku) || 0,
           dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
+          fanCount: parseInt(fan),
         })
       } else if (isDongbei) {
         await addRound(session.id, {
@@ -136,14 +149,19 @@ export default function SessionPage() {
           dealerId: Number(dealerId),
           bimenPlayerIds,
           dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
+          fanCount: parseInt(fan),
         })
       } else {
         await addRound(session.id, {
           winnerId: Number(winnerId),
           score: parseInt(score),
           dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
+          winHand,
+          fanDetails,
+          fanCount: fanCount || parseInt(score),
         })
       }
+
       resetForm()
       await load()
     } catch (e: any) {
@@ -184,6 +202,28 @@ export default function SessionPage() {
   const sortedPlayers = [...session.players].sort(
     (a, b) => (session.totalScores[b.id] || 0) - (session.totalScores[a.id] || 0)
   )
+
+  // Find max fan hand(s)
+  const parseFanCount = (r: RoundInfo) => {
+    if (r.fanCount) return r.fanCount
+    if (!r.fanDetails) return 0
+    // Fallback: parse from "Name(Score)" or "Name(ScorexCount)"
+    const matches = r.fanDetails.match(/\((\d+)(x\d+)?\)/g)
+    if (!matches) return 0
+    return matches.reduce((sum: number, m: string) => {
+      const score = parseInt(m.match(/\d+/)?.[0] || '0')
+      const multMatch = m.match(/x(\d+)/)
+      const mult = multMatch ? parseInt(multMatch[1]) : 1
+      return sum + score * mult
+    }, 0)
+
+  }
+
+  const roundsWithFan = session.rounds.map(r => ({ ...r, effectiveFan: parseFanCount(r) }))
+  const maxFan = roundsWithFan.reduce((max, r) => Math.max(max, r.effectiveFan), 0)
+  const bestRounds = maxFan > 0 ? roundsWithFan.filter((r) => r.effectiveFan === maxFan) : []
+
+
 
   const rankings = calculateRanks(
     session.players.map((p) => ({ playerId: p.id, score: session.totalScores[p.id] || 0 })),
@@ -361,11 +401,13 @@ export default function SessionPage() {
           <table>
             <thead>
               <tr>
-                <th>局</th>
+                <th style={{ textAlign: 'center', width: '60px' }}>局</th>
                 {session.players.map((p) => (
                   <th key={p.id} style={playerColStyle}>
                     <div className="player-header-cell">
-                      <span className="player-rank">#{rankMap[p.id]?.rank}</span>
+                      <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>
+                        #{rankMap[p.id]?.rank}
+                      </span>
                       <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
                         {p.userName}
                       </span>
@@ -377,43 +419,73 @@ export default function SessionPage() {
             </thead>
             <tbody>
               {session.rounds.map((round) => {
-                const rw = getRoundWind(round.roundNumber)
-                return (
-                  <tr key={round.roundNumber}>
-                    <td>
-                      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2px' }}>
-                        <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>R{round.roundNumber}</span>
-                        {rw && <span className="round-wind-tag">{rw.name}</span>}
-                      </div>
-                    </td>
-                    {session.players.map((p) => {
-                      const val = round.scores[p.id] ?? 0
-                      return (
-                        <td
-                          key={p.id}
-                          className={`score-cell${val > 0 ? ' score-positive' : val < 0 ? ' score-negative' : ''}`}
-                          style={{ textAlign: 'center' }}
-                        >
-                          {val > 0 ? `+${val}` : val}
+                  return (
+                    <React.Fragment key={round.roundNumber}>
+                      <tr>
+                        <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
+                          <div className="round-info-cell">
+                            {(() => {
+                              const rw = getRoundWind(round.roundNumber)
+                              return rw ? (
+                                <div
+                                  style={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    alignItems: 'center',
+                                    gap: '2px',
+                                    width: '100%',
+                                  }}
+                                >
+                                  <span className="round-wind-tag">{rw.name}</span>
+                                </div>
+                              ) : (
+                                <strong>#{round.roundNumber}</strong>
+                              )
+                            })()}
+                          </div>
                         </td>
-                      )
-                    })}
-                    {session.status === 'IN_PROGRESS' && (
-                      <td>
-                        <button
-                          className="delete-btn"
-                          onClick={() => handleDeleteRound(round.roundNumber)}
-                          disabled={submitting}
-                        >
-                          &times;
-                        </button>
-                      </td>
-                    )}
-                  </tr>
-                )
-              })}
+                        {session.players.map((p) => {
+                          const val = round.scores[p.id] || 0
+                          const isWinner = round.winnerId === p.id
+                          return (
+                            <td
+                              key={p.id}
+                              className={`score-cell${val > 0 ? ' score-positive' : val < 0 ? ' score-negative' : ''}${
+                                isWinner ? ' score-winner' : ''
+                              }`}
+                              style={{ textAlign: 'center' }}
+                            >
+                              {val > 0 ? `+${val}` : val}
+                            </td>
+                          )
+                        })}
+                        {session.status === 'IN_PROGRESS' && (
+                          <td>
+                            <button
+                              className="delete-btn"
+                              onClick={() => handleDeleteRound(round.roundNumber)}
+                              disabled={submitting}
+                            >
+                              &times;
+                            </button>
+                          </td>
+                        )}
+                      </tr>
+                      {round.winHand && (
+                        <tr className="hand-details-row">
+                          <td
+                            colSpan={session.players.length + (session.status === 'IN_PROGRESS' ? 2 : 1)}
+                            className="hand-details-cell"
+                          >
+                            <MahjongHand hand={round.winHand} details={round.fanDetails} />
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  )
+                })}
               <tr className="total-row">
-                <td style={{ whiteSpace: 'nowrap' }}>
+                <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
                   <strong>合计</strong>
                 </td>
                 {session.players.map((p) => {
@@ -738,7 +810,11 @@ export default function SessionPage() {
                   const rp = rankMap[p.id]?.rp ?? 0
                   return (
                     <tr key={p.id}>
-                      <td className={i < 3 ? `rank-${i + 1}` : ''}>#{i + 1}</td>
+                      <td>
+                        <span className={`rank-tag rank-tag-${i + 1}`}>
+                          #{i + 1}
+                        </span>
+                      </td>
                       <td>{p.userName}</td>
                       <td
                         style={{
@@ -767,6 +843,47 @@ export default function SessionPage() {
           </div>
         </div>
       )}
+
+
+      {bestRounds.length > 0 && (
+        <div className="card best-hand-card">
+          <div className="best-hand-header">
+            <span className="best-hand-crown">👑</span>
+            <h2>最高番和牌</h2>
+          </div>
+          <div className="best-hand-list">
+            {bestRounds.map((round, idx) => {
+              const winner = session.players.find((p) => p.id === round.winnerId)
+              const loserId = Object.entries(round.scores).find(
+                ([pid, s]) => s < 0 && Number(pid) !== round.winnerId
+              )?.[0]
+              const loser = loserId ? session.players.find((p) => p.id === Number(loserId)) : null
+
+              return (
+                <div key={idx} className="best-hand-item">
+                  <div className="best-hand-meta">
+                    <span className="best-hand-fan-count">{round.effectiveFan} 番</span>
+                    <span className="best-hand-players">
+                      <span className="winner-label">赢家:</span> {winner?.userName}
+                      {loser ? (
+                        <>
+                          <span className="loser-label ml-2">输家:</span> {loser.userName}
+                        </>
+                      ) : (
+                        <span className="zimo-label ml-2">(自摸)</span>
+                      )}
+                    </span>
+                  </div>
+                  <div className="best-hand-display">
+                    <MahjongHand hand={round.winHand} details={round.fanDetails} />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
     </>
   )
 }
+

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -30,7 +30,6 @@ export default function SessionPage() {
   const [fanCount, setFanCount] = useState<number>(0)
   const [error, setError] = useState('')
 
-
   const handleCalcScoreSelect = useCallback((s: number | null, hand?: string, details?: string, fCount?: number) => {
     if (s !== null) {
       setScore(String(s))
@@ -46,7 +45,6 @@ export default function SessionPage() {
   }, [])
 
   const load = async () => {
-
     const detail = await fetchSessionDetail(Number(id))
     setSession(detail)
     setError('')
@@ -216,14 +214,11 @@ export default function SessionPage() {
       const mult = multMatch ? parseInt(multMatch[1]) : 1
       return sum + score * mult
     }, 0)
-
   }
 
-  const roundsWithFan = session.rounds.map(r => ({ ...r, effectiveFan: parseFanCount(r) }))
+  const roundsWithFan = session.rounds.map((r) => ({ ...r, effectiveFan: parseFanCount(r) }))
   const maxFan = roundsWithFan.reduce((max, r) => Math.max(max, r.effectiveFan), 0)
   const bestRounds = maxFan > 0 ? roundsWithFan.filter((r) => r.effectiveFan === maxFan) : []
-
-
 
   const rankings = calculateRanks(
     session.players.map((p) => ({ playerId: p.id, score: session.totalScores[p.id] || 0 })),
@@ -405,9 +400,7 @@ export default function SessionPage() {
                 {session.players.map((p) => (
                   <th key={p.id} style={playerColStyle}>
                     <div className="player-header-cell">
-                      <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>
-                        #{rankMap[p.id]?.rank}
-                      </span>
+                      <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>#{rankMap[p.id]?.rank}</span>
                       <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
                         {p.userName}
                       </span>
@@ -419,71 +412,71 @@ export default function SessionPage() {
             </thead>
             <tbody>
               {session.rounds.map((round) => {
-                  return (
-                    <React.Fragment key={round.roundNumber}>
-                      <tr>
-                        <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
-                          <div className="round-info-cell">
-                            {(() => {
-                              const rw = getRoundWind(round.roundNumber)
-                              return rw ? (
-                                <div
-                                  style={{
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    alignItems: 'center',
-                                    gap: '2px',
-                                    width: '100%',
-                                  }}
-                                >
-                                  <span className="round-wind-tag">{rw.name}</span>
-                                </div>
-                              ) : (
-                                <strong>#{round.roundNumber}</strong>
-                              )
-                            })()}
-                          </div>
-                        </td>
-                        {session.players.map((p) => {
-                          const val = round.scores[p.id] || 0
-                          const isWinner = round.winnerId === p.id
-                          return (
-                            <td
-                              key={p.id}
-                              className={`score-cell${val > 0 ? ' score-positive' : val < 0 ? ' score-negative' : ''}${
-                                isWinner ? ' score-winner' : ''
-                              }`}
-                              style={{ textAlign: 'center' }}
-                            >
-                              {val > 0 ? `+${val}` : val}
-                            </td>
-                          )
-                        })}
-                        {session.status === 'IN_PROGRESS' && (
-                          <td>
-                            <button
-                              className="delete-btn"
-                              onClick={() => handleDeleteRound(round.roundNumber)}
-                              disabled={submitting}
-                            >
-                              &times;
-                            </button>
-                          </td>
-                        )}
-                      </tr>
-                      {round.winHand && (
-                        <tr className="hand-details-row">
+                return (
+                  <React.Fragment key={round.roundNumber}>
+                    <tr>
+                      <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
+                        <div className="round-info-cell">
+                          {(() => {
+                            const rw = getRoundWind(round.roundNumber)
+                            return rw ? (
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  flexDirection: 'column',
+                                  alignItems: 'center',
+                                  gap: '2px',
+                                  width: '100%',
+                                }}
+                              >
+                                <span className="round-wind-tag">{rw.name}</span>
+                              </div>
+                            ) : (
+                              <strong>#{round.roundNumber}</strong>
+                            )
+                          })()}
+                        </div>
+                      </td>
+                      {session.players.map((p) => {
+                        const val = round.scores[p.id] || 0
+                        const isWinner = round.winnerId === p.id
+                        return (
                           <td
-                            colSpan={session.players.length + (session.status === 'IN_PROGRESS' ? 2 : 1)}
-                            className="hand-details-cell"
+                            key={p.id}
+                            className={`score-cell${val > 0 ? ' score-positive' : val < 0 ? ' score-negative' : ''}${
+                              isWinner ? ' score-winner' : ''
+                            }`}
+                            style={{ textAlign: 'center' }}
                           >
-                            <MahjongHand hand={round.winHand} details={round.fanDetails} />
+                            {val > 0 ? `+${val}` : val}
                           </td>
-                        </tr>
+                        )
+                      })}
+                      {session.status === 'IN_PROGRESS' && (
+                        <td>
+                          <button
+                            className="delete-btn"
+                            onClick={() => handleDeleteRound(round.roundNumber)}
+                            disabled={submitting}
+                          >
+                            &times;
+                          </button>
+                        </td>
                       )}
-                    </React.Fragment>
-                  )
-                })}
+                    </tr>
+                    {round.winHand && (
+                      <tr className="hand-details-row">
+                        <td
+                          colSpan={session.players.length + (session.status === 'IN_PROGRESS' ? 2 : 1)}
+                          className="hand-details-cell"
+                        >
+                          <MahjongHand hand={round.winHand} details={round.fanDetails} />
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                )
+              })}
               <tr className="total-row">
                 <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
                   <strong>合计</strong>
@@ -811,9 +804,7 @@ export default function SessionPage() {
                   return (
                     <tr key={p.id}>
                       <td>
-                        <span className={`rank-tag rank-tag-${i + 1}`}>
-                          #{i + 1}
-                        </span>
+                        <span className={`rank-tag rank-tag-${i + 1}`}>#{i + 1}</span>
                       </td>
                       <td>{p.userName}</td>
                       <td
@@ -843,7 +834,6 @@ export default function SessionPage() {
           </div>
         </div>
       )}
-
 
       {bestRounds.length > 0 && (
         <div className="card best-hand-card">
@@ -886,4 +876,3 @@ export default function SessionPage() {
     </>
   )
 }
-

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -77,6 +77,9 @@ export default function SessionPage() {
     setTenpaiPlayerIds([])
     setHonba('0')
     setKyoutaku('0')
+    setWinHand('')
+    setFanDetails('')
+    setFanCount(0)
     setCalcResetCount((prev) => prev + 1)
   }
 

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -847,10 +847,10 @@ export default function SessionPage() {
           <div className="best-hand-list">
             {bestRounds.map((round, idx) => {
               const winner = session.players.find((p) => p.id === round.winnerId)
-              const loserId = Object.entries(round.scores).find(
-                ([pid, s]) => s < 0 && Number(pid) !== round.winnerId
-              )?.[0]
-              const loser = loserId ? session.players.find((p) => p.id === Number(loserId)) : null
+              const payerIds = Object.entries(round.scores)
+                .filter(([pid, s]) => s < 0 && Number(pid) !== round.winnerId)
+                .map(([pid]) => Number(pid))
+              const loser = payerIds.length === 1 ? session.players.find((p) => p.id === payerIds[0]) : null
 
               return (
                 <div key={idx} className="best-hand-item">

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
-import { fetchStats, fetchPlayers } from '../api'
+import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { PlayerStats, Player, GameModeKey, GAME_MODES, Season, getCurrentSeason, getAvailableSeasons } from '../types'
+import { fetchStats, fetchPlayers, fetchBestRounds } from '../api'
+import { MahjongHand } from '../components/MahjongHand'
+
 
 type Tab = 'games' | 'players'
 
@@ -20,6 +22,8 @@ export default function StatsPage() {
   const [players, setPlayers] = useState<Player[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [bestRounds, setBestRounds] = useState<any[]>([])
+
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.quarter}`)
 
@@ -59,9 +63,14 @@ export default function StatsPage() {
   }
 
   useEffect(() => {
-    if (tab === 'games') loadStats(gameMode, seasonKey)
-    else loadPlayers()
+    if (tab === 'games') {
+      loadStats(gameMode, seasonKey)
+      fetchBestRounds().then(setBestRounds).catch(console.error)
+    } else {
+      loadPlayers()
+    }
   }, [gameMode, seasonKey, tab])
+
 
   const abbr = (s: PlayerStats) => abbrName(s.displayName)
 
@@ -214,8 +223,44 @@ export default function StatsPage() {
               </div>
             </div>
           )}
+
+
+          {bestRounds.length > 0 && (
+            <div className="card best-hand-card">
+              <div className="best-hand-header">
+                <span className="best-hand-crown">👑</span>
+                <h2>历史最高和牌</h2>
+              </div>
+              <div className="best-hand-list">
+                {bestRounds.map((round, idx) => (
+                  <div key={idx} className="best-hand-item">
+                    <div className="best-hand-meta">
+                      <span className="best-hand-fan-count">{round.fanCount} 番</span>
+                      <span className="best-hand-players">
+                        <span className="winner-label">赢家:</span> {round.winnerName}
+                        {round.dealInPlayerName ? (
+                          <>
+                            <span className="loser-label ml-2">输家:</span> {round.dealInPlayerName}
+                          </>
+                        ) : (
+                          <span className="zimo-label ml-2">(自摸)</span>
+                        )}
+                        <span className="session-link-label ml-2">
+                          <Link to={`/session/${round.sessionId}`}>查看对局</Link>
+                        </span>
+                      </span>
+                    </div>
+                    <div className="best-hand-display">
+                      <MahjongHand hand={round.winHand} details={round.fanDetails} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </>
       )}
+
 
       {tab === 'players' && (
         <>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams, Link } from 'react-router-dom'
-import { PlayerStats, Player, GameModeKey, GAME_MODES, Season, getCurrentSeason, getAvailableSeasons } from '../types'
+import {
+  PlayerStats,
+  Player,
+  GameModeKey,
+  GAME_MODES,
+  Season,
+  getCurrentSeason,
+  getAvailableSeasons,
+  BestRound,
+} from '../types'
 import { fetchStats, fetchPlayers, fetchBestRounds } from '../api'
 import { MahjongHand } from '../components/MahjongHand'
 
@@ -21,7 +30,8 @@ export default function StatsPage() {
   const [players, setPlayers] = useState<Player[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
-  const [bestRounds, setBestRounds] = useState<any[]>([])
+  const [bestRounds, setBestRounds] = useState<BestRound[]>([])
+  const [bestRoundsError, setBestRoundsError] = useState('')
 
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.quarter}`)
@@ -64,11 +74,19 @@ export default function StatsPage() {
   useEffect(() => {
     if (tab === 'games') {
       loadStats(gameMode, seasonKey)
-      fetchBestRounds().then(setBestRounds).catch(console.error)
     } else {
       loadPlayers()
     }
   }, [gameMode, seasonKey, tab])
+
+  useEffect(() => {
+    if (tab === 'games') {
+      setBestRoundsError('')
+      fetchBestRounds()
+        .then(setBestRounds)
+        .catch((e) => setBestRoundsError(e.message))
+    }
+  }, [tab])
 
   const abbr = (s: PlayerStats) => abbrName(s.displayName)
 
@@ -228,6 +246,7 @@ export default function StatsPage() {
                 <span className="best-hand-crown">👑</span>
                 <h2>历史最高和牌</h2>
               </div>
+              {bestRoundsError && <p className="error-text">加载最高和牌失败: {bestRoundsError}</p>}
               <div className="best-hand-list">
                 {bestRounds.map((round, idx) => (
                   <div key={idx} className="best-hand-item">

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -4,7 +4,6 @@ import { PlayerStats, Player, GameModeKey, GAME_MODES, Season, getCurrentSeason,
 import { fetchStats, fetchPlayers, fetchBestRounds } from '../api'
 import { MahjongHand } from '../components/MahjongHand'
 
-
 type Tab = 'games' | 'players'
 
 const seasons = getAvailableSeasons()
@@ -70,7 +69,6 @@ export default function StatsPage() {
       loadPlayers()
     }
   }, [gameMode, seasonKey, tab])
-
 
   const abbr = (s: PlayerStats) => abbrName(s.displayName)
 
@@ -224,7 +222,6 @@ export default function StatsPage() {
             </div>
           )}
 
-
           {bestRounds.length > 0 && (
             <div className="card best-hand-card">
               <div className="best-hand-header">
@@ -260,7 +257,6 @@ export default function StatsPage() {
           )}
         </>
       )}
-
 
       {tab === 'players' && (
         <>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -36,6 +36,10 @@ export interface PlayerInfo {
 export interface RoundInfo {
   roundNumber: number
   scores: Record<number, number>
+  winnerId?: number
+  winHand?: string
+  fanDetails?: string
+  fanCount?: number
 }
 
 export interface SessionDetail {
@@ -66,7 +70,11 @@ export interface AddRoundData {
   bimenPlayerIds?: number[] // for Dongbei: 闭门 players
   dealInPlayerId?: number | null // null = 自摸
   tenpaiPlayerIds?: number[] // for drawn games
+  winHand?: string
+  fanDetails?: string
+  fanCount?: number
 }
+
 
 export const FAN_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
 export const FU_OPTIONS = [20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110]

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -140,3 +140,15 @@ export interface PlayerDetail {
   lastName: string
   games: PlayerGameEntry[]
 }
+export interface BestRound {
+  sessionId: number
+  roundNumber: number
+  winnerId: number
+  winnerName: string
+  winHand: string
+  fanDetails: string
+  fanCount: number
+  scores: Record<number, number>
+  dealInPlayerId: number | null
+  dealInPlayerName: string | null
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -75,7 +75,6 @@ export interface AddRoundData {
   fanCount?: number
 }
 
-
 export const FAN_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
 export const FU_OPTIONS = [20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110]
 


### PR DESCRIPTION
### Description
This PR enhances the Guobiao Mahjong scoring system with automated best hand tracking and several UI/UX refinements.

### Key Changes
- **Best Hand Highlights**: Implemented a 'Best Hand' section on both the session page and the global statistics page to display the highest-scoring hands (fan count, details, and tile visuals).
- **Data Persistence**: Added \anCount\ to the \Round\ entity to reliably track scores.
- **UI Refinements**:
  - Simplified rank visualization using \#1\, \#2\, etc. with Gold/Silver/Bronze colored text.
  - Aligned scoreboard columns (centered Round/Wind/Total column).
  - Updated player labels in highlights to use Mahjong-inspired colors (Man-tile Red and Sou-tile Green).
- **Architecture**: Extracted hand rendering into a reusable \MahjongHand\ component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track and view "best rounds" (highest fan counts) across sessions; stats page shows a "Best Rounds" card with winner, loser/self-draw labels, fan counts, session links, and hand previews.
  * Record and display detailed win metadata when adding rounds: winning hand, fan breakdown, and fan count.
  * Visual hand display component rendering tile graphics with highlighted winning tile.
  * Calculator and API additions to pass/fetch hand, fan details, and fan count.
* **Style**
  * New theme variables and UI styles for Best Hand Card, rank tags, and button variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->