### PR TITLE
Fix Guobiao win type display

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -67,6 +67,8 @@ public class SessionDetailResponse {
     private String winHand;
     private String fanDetails;
     private Integer fanCount;
+    private Long dealInPlayerId;
+    private String dealInPlayerName;
 
     public RoundInfo(
         int roundNumber,
@@ -74,13 +76,17 @@ public class SessionDetailResponse {
         Long winnerId,
         String winHand,
         String fanDetails,
-        Integer fanCount) {
+        Integer fanCount,
+        Long dealInPlayerId,
+        String dealInPlayerName) {
       this.roundNumber = roundNumber;
       this.scores = scores;
       this.winnerId = winnerId;
       this.winHand = winHand;
       this.fanDetails = fanDetails;
       this.fanCount = fanCount;
+      this.dealInPlayerId = dealInPlayerId;
+      this.dealInPlayerName = dealInPlayerName;
     }
 
     public int getRoundNumber() {
@@ -105,6 +111,14 @@ public class SessionDetailResponse {
 
     public Integer getFanCount() {
       return fanCount;
+    }
+
+    public Long getDealInPlayerId() {
+      return dealInPlayerId;
+    }
+
+    public String getDealInPlayerName() {
+      return dealInPlayerName;
     }
   }
 

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -199,13 +199,25 @@ public class GameService {
                           .filter(rs -> rs.getPlayer() != null)
                           .collect(
                               Collectors.toMap(rs -> rs.getPlayer().getId(), RoundScore::getScore));
+
+                  String dealInName = null;
+                  if (round.getDealInPlayerId() != null) {
+                    dealInName =
+                        playerRepo
+                            .findById(round.getDealInPlayerId())
+                            .map(Player::getUserName)
+                            .orElse("?");
+                  }
+
                   return new SessionDetailResponse.RoundInfo(
                       round.getRoundNumber(),
                       scores,
                       round.getWinnerId(),
                       round.getWinHand(),
                       round.getFanDetails(),
-                      round.getFanCount());
+                      round.getFanCount(),
+                      round.getDealInPlayerId(),
+                      dealInName);
                 })
             .collect(Collectors.toList()));
 

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -190,6 +190,13 @@ public class GameService {
                         gsp.getSeat()))
             .collect(Collectors.toList()));
 
+    Map<Long, String> playerNameMap =
+        session.getPlayers().stream()
+            .filter(gsp -> gsp.getPlayer() != null)
+            .collect(
+                Collectors.toMap(
+                    gsp -> gsp.getPlayer().getId(), gsp -> gsp.getPlayer().getUserName()));
+
     resp.setRounds(
         session.getRounds().stream()
             .map(
@@ -202,11 +209,7 @@ public class GameService {
 
                   String dealInName = null;
                   if (round.getDealInPlayerId() != null) {
-                    dealInName =
-                        playerRepo
-                            .findById(round.getDealInPlayerId())
-                            .map(Player::getUserName)
-                            .orElse("?");
+                    dealInName = playerNameMap.getOrDefault(round.getDealInPlayerId(), "?");
                   }
 
                   return new SessionDetailResponse.RoundInfo(

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -848,10 +848,9 @@ export default function SessionPage() {
           <div className="best-hand-list">
             {bestRounds.map((round, idx) => {
               const winner = session.players.find((p) => p.id === round.winnerId)
-              const payerIds = Object.entries(round.scores)
-                .filter(([pid, s]) => s < 0 && Number(pid) !== round.winnerId)
-                .map(([pid]) => Number(pid))
-              const loser = payerIds.length === 1 ? session.players.find((p) => p.id === payerIds[0]) : null
+              const loser = round.dealInPlayerId
+                ? session.players.find((p) => p.id === round.dealInPlayerId)
+                : null
 
               return (
                 <div key={round.roundNumber} className="best-hand-item">

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -848,7 +848,8 @@ export default function SessionPage() {
           <div className="best-hand-list">
             {bestRounds.map((round, idx) => {
               const winner = session.players.find((p) => p.id === round.winnerId)
-              const loser = round.dealInPlayerId ? session.players.find((p) => p.id === round.dealInPlayerId) : null
+              const loser =
+                round.dealInPlayerId != null ? session.players.find((p) => p.id === round.dealInPlayerId) : null
 
               return (
                 <div key={round.roundNumber} className="best-hand-item">
@@ -856,9 +857,9 @@ export default function SessionPage() {
                     <span className="best-hand-fan-count">{round.effectiveFan} 番</span>
                     <span className="best-hand-players">
                       <span className="winner-label">赢家:</span> {winner?.userName}
-                      {loser ? (
+                      {round.dealInPlayerId != null ? (
                         <>
-                          <span className="loser-label ml-2">输家:</span> {loser.userName}
+                          <span className="loser-label ml-2">输家:</span> {loser?.userName || '?'}
                         </>
                       ) : (
                         <span className="zimo-label ml-2">(自摸)</span>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -848,9 +848,7 @@ export default function SessionPage() {
           <div className="best-hand-list">
             {bestRounds.map((round, idx) => {
               const winner = session.players.find((p) => p.id === round.winnerId)
-              const loser = round.dealInPlayerId
-                ? session.players.find((p) => p.id === round.dealInPlayerId)
-                : null
+              const loser = round.dealInPlayerId ? session.players.find((p) => p.id === round.dealInPlayerId) : null
 
               return (
                 <div key={round.roundNumber} className="best-hand-item">

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -254,9 +254,9 @@ export default function StatsPage() {
                       <span className="best-hand-fan-count">{round.fanCount} 番</span>
                       <span className="best-hand-players">
                         <span className="winner-label">赢家:</span> {round.winnerName}
-                        {round.dealInPlayerName ? (
+                        {round.dealInPlayerId != null ? (
                           <>
-                            <span className="loser-label ml-2">输家:</span> {round.dealInPlayerName}
+                            <span className="loser-label ml-2">输家:</span> {round.dealInPlayerName || '?'}
                           </>
                         ) : (
                           <span className="zimo-label ml-2">(自摸)</span>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -40,6 +40,8 @@ export interface RoundInfo {
   winHand?: string
   fanDetails?: string
   fanCount?: number
+  dealInPlayerId?: number | null
+  dealInPlayerName?: string | null
 }
 
 export interface SessionDetail {


### PR DESCRIPTION
Fixes the issue where Guobiao winning hands were always displayed as self-draw by including explicit deal-in information in the API and updating the UI logic to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deal-in player tracking to sessions; round details now include both deal-in player ID and resolved name.
  * UIs use deal-in metadata to determine and display the losing player more reliably in summaries and stats.
* **Bug Fixes**
  * Graceful fallback to "?" when deal-in player information is missing or cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->