### PR TITLE
feat: make prevalent wind mutable and persisted

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -40,6 +40,16 @@ public class AddRoundRequest {
   @Min(value = 0, message = "Fan count must be non-negative")
   private Integer fanCount;
 
+  private Integer prevalentWind;
+
+  public Integer getPrevalentWind() {
+    return prevalentWind;
+  }
+
+  public void setPrevalentWind(Integer prevalentWind) {
+    this.prevalentWind = prevalentWind;
+  }
+
   public Integer getFanCount() {
     return fanCount;
   }

--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -1,6 +1,7 @@
 package com.mahjong.omakase.dto;
 
 import com.mahjong.omakase.model.RoundType;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
@@ -40,6 +41,8 @@ public class AddRoundRequest {
   @Min(value = 0, message = "Fan count must be non-negative")
   private Integer fanCount;
 
+  @Min(value = 1, message = "Prevalent wind must be between 1 and 4")
+  @Max(value = 4, message = "Prevalent wind must be between 1 and 4")
   private Integer prevalentWind;
 
   public Integer getPrevalentWind() {

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -69,6 +69,7 @@ public class SessionDetailResponse {
     private Integer fanCount;
     private Long dealInPlayerId;
     private String dealInPlayerName;
+    private Integer prevalentWind;
 
     public RoundInfo(
         int roundNumber,
@@ -78,7 +79,8 @@ public class SessionDetailResponse {
         String fanDetails,
         Integer fanCount,
         Long dealInPlayerId,
-        String dealInPlayerName) {
+        String dealInPlayerName,
+        Integer prevalentWind) {
       this.roundNumber = roundNumber;
       this.scores = scores;
       this.winnerId = winnerId;
@@ -87,6 +89,7 @@ public class SessionDetailResponse {
       this.fanCount = fanCount;
       this.dealInPlayerId = dealInPlayerId;
       this.dealInPlayerName = dealInPlayerName;
+      this.prevalentWind = prevalentWind;
     }
 
     public int getRoundNumber() {
@@ -119,6 +122,10 @@ public class SessionDetailResponse {
 
     public String getDealInPlayerName() {
       return dealInPlayerName;
+    }
+
+    public Integer getPrevalentWind() {
+      return prevalentWind;
     }
   }
 

--- a/server/src/main/java/com/mahjong/omakase/model/Round.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Round.java
@@ -32,6 +32,15 @@ public class Round {
   private Integer fanCount;
 
   private Long dealInPlayerId;
+  private Integer prevalentWind;
+
+  public Integer getPrevalentWind() {
+    return prevalentWind;
+  }
+
+  public void setPrevalentWind(Integer prevalentWind) {
+    this.prevalentWind = prevalentWind;
+  }
 
   public Long getDealInPlayerId() {
     return dealInPlayerId;

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -220,7 +220,8 @@ public class GameService {
                       round.getFanDetails(),
                       round.getFanCount(),
                       round.getDealInPlayerId(),
-                      dealInName);
+                      dealInName,
+                      round.getPrevalentWind());
                 })
             .collect(Collectors.toList()));
 
@@ -294,7 +295,8 @@ public class GameService {
         request.getWinHand(),
         request.getFanDetails(),
         request.getFanCount(),
-        request.isSelfDraw() ? null : request.getDealInPlayerId());
+        request.isSelfDraw() ? null : request.getDealInPlayerId(),
+        request.getPrevalentWind());
   }
 
   public void deleteRound(Long sessionId, int roundNumber) {
@@ -544,7 +546,8 @@ public class GameService {
       String winHand,
       String fanDetails,
       Integer fanCount,
-      Long dealInId) {
+      Long dealInId,
+      Integer prevalentWind) {
     Round round = new Round();
     round.setGameSession(session);
     round.setRoundNumber(roundNumber);
@@ -553,6 +556,7 @@ public class GameService {
     round.setFanDetails(fanDetails);
     round.setFanCount(fanCount);
     round.setDealInPlayerId(dealInId);
+    round.setPrevalentWind(prevalentWind);
 
     round = roundRepo.save(round);
 

--- a/ui/src/components/GuobiaoCalculator.tsx
+++ b/ui/src/components/GuobiaoCalculator.tsx
@@ -274,41 +274,30 @@ export const GuobiaoCalculator: React.FC<GuobiaoCalculatorProps> = ({
   return (
     <div className="guobiao-inline-calculator">
       <div className="calc-top-row">
-        {initialOptions ? (
-          <div className="mini-option">
-            <span className="mini-opt-label">场况:</span>
-            <span className="mini-opt-val">
-              {['东', '南', '西', '北'][options.quanfeng - 1]}圈 · {['东', '南', '西', '北'][options.menfeng - 1]}风
-            </span>
-          </div>
-        ) : (
-          <>
-            <div className="mini-option">
-              <span className="mini-opt-label">圈:</span>
-              {[1, 2, 3, 4].map((v) => (
-                <button
-                  key={v}
-                  className={`micro-btn ${options.quanfeng === v ? 'active' : ''}`}
-                  onClick={() => setOptions({ ...options, quanfeng: v })}
-                >
-                  {['东', '南', '西', '北'][v - 1]}
-                </button>
-              ))}
-            </div>
-            <div className="mini-option">
-              <span className="mini-opt-label">门:</span>
-              {[1, 2, 3, 4].map((v) => (
-                <button
-                  key={v}
-                  className={`micro-btn ${options.menfeng === v ? 'active' : ''}`}
-                  onClick={() => setOptions({ ...options, menfeng: v })}
-                >
-                  {['东', '南', '西', '北'][v - 1]}
-                </button>
-              ))}
-            </div>
-          </>
-        )}
+        <div className="mini-option">
+          <span className="mini-opt-label">圈:</span>
+          {[1, 2, 3, 4].map((v) => (
+            <button
+              key={v}
+              className={`micro-btn ${options.quanfeng === v ? 'active' : ''}`}
+              onClick={() => setOptions({ ...options, quanfeng: v })}
+            >
+              {['东', '南', '西', '北'][v - 1]}
+            </button>
+          ))}
+        </div>
+        <div className="mini-option">
+          <span className="mini-opt-label">门:</span>
+          {[1, 2, 3, 4].map((v) => (
+            <button
+              key={v}
+              className={`micro-btn ${options.menfeng === v ? 'active' : ''}`}
+              onClick={() => setOptions({ ...options, menfeng: v })}
+            >
+              {['东', '南', '西', '北'][v - 1]}
+            </button>
+          ))}
+        </div>
         <div className="mini-option">
           <span className="mini-opt-label">花:</span>
           <div className="hua-stepper">

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -797,6 +797,44 @@ tr:hover td {
   white-space: nowrap;
 }
 
+.wind-selector-mini {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 12px;
+  vertical-align: middle;
+}
+
+.wind-chip {
+  padding: 2px 8px;
+  background: var(--sol-base2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  color: var(--text-light);
+  line-height: 1.2;
+}
+
+.wind-chip:hover {
+  background: var(--border);
+}
+
+.wind-chip.active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.hand-num-info {
+  margin-left: 8px;
+  font-size: 0.8rem;
+  color: var(--text-light);
+  font-weight: 500;
+}
+
 /* Best Hand Card */
 .best-hand-card {
   margin-top: 24px;

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -28,6 +28,7 @@ export default function SessionPage() {
   const [winHand, setWinHand] = useState<string>('')
   const [fanDetails, setFanDetails] = useState<string>('')
   const [fanCount, setFanCount] = useState<number>(0)
+  const [manualQuanfeng, setManualQuanfeng] = useState<number | null>(null)
   const [error, setError] = useState('')
 
   const handleCalcScoreSelect = useCallback((s: number | null, hand?: string, details?: string, fCount?: number) => {
@@ -80,6 +81,7 @@ export default function SessionPage() {
     setWinHand('')
     setFanDetails('')
     setFanCount(0)
+    setManualQuanfeng(null)
     setCalcResetCount((prev) => prev + 1)
   }
 
@@ -160,6 +162,7 @@ export default function SessionPage() {
           winHand,
           fanDetails,
           fanCount: fanCount || parseInt(score),
+          prevalentWind: gbWinds?.quanfeng,
         })
       }
 
@@ -232,7 +235,27 @@ export default function SessionPage() {
   const getGuobiaoWinds = () => {
     if (!isGuobiao) return null
     const handIdx = session.rounds.length + 1
-    const qf = (Math.floor((handIdx - 1) / 4) % 4) + 1
+
+    let qf: number
+    if (manualQuanfeng !== null) {
+      qf = manualQuanfeng
+    } else if (session.rounds.length > 0) {
+      const lastRound = session.rounds[session.rounds.length - 1]
+      // Use the stored prevalent wind from the last round, or fall back to calculation
+      const lastQf = lastRound.prevalentWind || (Math.floor((session.rounds.length - 1) / 4) % 4) + 1
+
+      if (handIdx > 1 && (handIdx - 1) % 4 === 0) {
+        // Every 4 rounds, the wind should increment (e.g. 5th, 9th, 13th round)
+        qf = (lastQf % 4) + 1
+      } else {
+        // Otherwise stay the same as the previous round
+        qf = lastQf
+      }
+    } else {
+      // First round default
+      qf = (Math.floor((handIdx - 1) / 4) % 4) + 1
+    }
+
     const dealerSeat = ((handIdx - 1) % 4) + 1
     return { quanfeng: qf, dealerSeat, handIdx }
   }
@@ -254,9 +277,10 @@ export default function SessionPage() {
 
   const getWindName = (w: number) => ['东', '南', '西', '北'][w - 1] + '风'
 
-  const getRoundWind = (roundNum: number) => {
+  const getRoundWind = (round: RoundInfo) => {
     if (!isGuobiao) return null
-    const qf = (Math.floor((roundNum - 1) / 4) % 4) + 1
+    const roundNum = round.roundNumber
+    const qf = round.prevalentWind || (Math.floor((roundNum - 1) / 4) % 4) + 1
     const hand = ((roundNum - 1) % 4) + 1
     return { qf, hand, name: `${['东', '南', '西', '北'][qf - 1]}${hand}` }
   }
@@ -421,7 +445,7 @@ export default function SessionPage() {
                       <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
                         <div className="round-info-cell">
                           {(() => {
-                            const rw = getRoundWind(round.roundNumber)
+                            const rw = getRoundWind(round)
                             return rw ? (
                               <div
                                 style={{
@@ -679,9 +703,19 @@ export default function SessionPage() {
                     <label>
                       分数
                       {gbWinds && (
-                        <span className="gb-wind-info">
-                          ({getWindName(gbWinds.quanfeng)} 第{((gbWinds.handIdx - 1) % 4) + 1}局)
-                        </span>
+                        <div className="wind-selector-mini">
+                          {[1, 2, 3, 4].map((w) => (
+                            <button
+                              key={w}
+                              type="button"
+                              className={`wind-chip ${gbWinds.quanfeng === w ? 'active' : ''}`}
+                              onClick={() => setManualQuanfeng(w)}
+                            >
+                              {['东', '南', '西', '北'][w - 1]}
+                            </button>
+                          ))}
+                          <span className="hand-num-info">第{((gbWinds.handIdx - 1) % 4) + 1}局</span>
+                        </div>
                       )}
                     </label>
                     <div className="score-input-row">

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -42,6 +42,7 @@ export interface RoundInfo {
   fanCount?: number
   dealInPlayerId?: number | null
   dealInPlayerName?: string | null
+  prevalentWind?: number
 }
 
 export interface SessionDetail {
@@ -75,6 +76,7 @@ export interface AddRoundData {
   winHand?: string
   fanDetails?: string
   fanCount?: number
+  prevalentWind?: number
 }
 
 export const FAN_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]


### PR DESCRIPTION
This PR adds the ability to manually override the prevalent wind (Quanfeng) on the session page for Guobiao Mahjong. The wind is now persisted in the database per round to ensure manual overrides stick across page refreshes and follow the correct cycle logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive prevalent-wind chips (东/南/西/北) for score entry with manual override and reset behavior
  * Chosen/precomputed prevalent wind is saved with each round and used when computing/displaying round winds
  * Session history now shows prevalent wind per past round

* **Style**
  * New styling for wind selector chips with active state indicators
<!-- end of auto-generated comment: release notes by coderabbit.ai -->