### PR TITLE
feat: change season to monthly and enhance stats page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Landing page with quick access to start a game
 - Support for 自摸 and 点炮
 
 ### Stats & Leaderboard
-- Quarterly seasons: 春之赛季, 夏之赛季, 秋之赛季, 冬之赛季
+- Monthly seasons: 1月, 2月, 3月, ..., 12月
 - 🏆 赛季冠军 and 👑 最多胜场 highlights
 - Filter leaderboard by game mode
 - Player profiles with individual game history

--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -39,7 +39,14 @@ public class StatsController {
 
     LocalDateTime start = null;
     LocalDateTime end = null;
-    if (year != null && month != null) {
+    if (year != null || month != null) {
+      if (year == null || month == null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Both year and month must be provided");
+      }
+      if (month < 1 || month > 12) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Month must be between 1 and 12");
+      }
       start = LocalDateTime.of(year, month, 1, 0, 0);
       end = start.plusMonths(1);
     }
@@ -52,7 +59,14 @@ public class StatsController {
       @RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month) {
     LocalDateTime start = null;
     LocalDateTime end = null;
-    if (year != null && month != null) {
+    if (year != null || month != null) {
+      if (year == null || month == null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Both year and month must be provided");
+      }
+      if (month < 1 || month > 12) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Month must be between 1 and 12");
+      }
       start = LocalDateTime.of(year, month, 1, 0, 0);
       end = start.plusMonths(1);
     }

--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -27,7 +27,7 @@ public class StatsController {
   public List<PlayerStatsResponse> getStats(
       @RequestParam(required = false) String gameMode,
       @RequestParam(required = false) Integer year,
-      @RequestParam(required = false) Integer quarter) {
+      @RequestParam(required = false) Integer month) {
     GameMode mode = null;
     if (gameMode != null && !gameMode.isEmpty()) {
       try {
@@ -39,17 +39,23 @@ public class StatsController {
 
     LocalDateTime start = null;
     LocalDateTime end = null;
-    if (year != null && quarter != null) {
-      int startMonth = (quarter - 1) * 3 + 1;
-      start = LocalDateTime.of(year, startMonth, 1, 0, 0);
-      end = start.plusMonths(3);
+    if (year != null && month != null) {
+      start = LocalDateTime.of(year, month, 1, 0, 0);
+      end = start.plusMonths(1);
     }
 
     return gameService.getPlayerStats(mode, start, end);
   }
 
   @GetMapping("/best-rounds")
-  public List<com.mahjong.omakase.dto.BestRoundResponse> getBestRounds() {
-    return gameService.getBestRounds();
+  public List<com.mahjong.omakase.dto.BestRoundResponse> getBestRounds(
+      @RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month) {
+    LocalDateTime start = null;
+    LocalDateTime end = null;
+    if (year != null && month != null) {
+      start = LocalDateTime.of(year, month, 1, 0, 0);
+      end = start.plusMonths(1);
+    }
+    return gameService.getBestRounds(start, end);
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -9,6 +9,7 @@ public class PlayerStatsResponse {
   private double avgScore;
   private int wins;
   private double totalRP;
+  private double baseRP;
 
   public Long getPlayerId() {
     return playerId;
@@ -72,5 +73,13 @@ public class PlayerStatsResponse {
 
   public void setTotalRP(double totalRP) {
     this.totalRP = totalRP;
+  }
+
+  public double getBaseRP() {
+    return baseRP;
+  }
+
+  public void setBaseRP(double baseRP) {
+    this.baseRP = baseRP;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -13,10 +13,14 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
 
   @org.springframework.data.jpa.repository.Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s WHERE s.createdAt >= :start AND s.createdAt < :end")
-  Integer findMaxFanCountByDateRange(java.time.LocalDateTime start, java.time.LocalDateTime end);
+  Integer findMaxFanCountByDateRange(
+      @org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
+      @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
 
   @org.springframework.data.jpa.repository.Query(
       "SELECT r FROM Round r JOIN r.gameSession s WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end")
   java.util.List<Round> findByFanCountAndDateRange(
-      Integer fanCount, java.time.LocalDateTime start, java.time.LocalDateTime end);
+      @org.springframework.data.repository.query.Param("fanCount") Integer fanCount,
+      @org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
+      @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -10,4 +10,13 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
   Integer findMaxFanCount();
 
   java.util.List<Round> findByFanCount(Integer fanCount);
+
+  @org.springframework.data.jpa.repository.Query(
+      "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s WHERE s.createdAt >= :start AND s.createdAt < :end")
+  Integer findMaxFanCountByDateRange(java.time.LocalDateTime start, java.time.LocalDateTime end);
+
+  @org.springframework.data.jpa.repository.Query(
+      "SELECT r FROM Round r JOIN r.gameSession s WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end")
+  java.util.List<Round> findByFanCountAndDateRange(
+      Integer fanCount, java.time.LocalDateTime start, java.time.LocalDateTime end);
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -332,11 +332,24 @@ public class GameService {
     log.info("Completed session id={}", sessionId);
   }
 
-  public List<BestRoundResponse> getBestRounds() {
-    Integer maxFan = roundRepo.findMaxFanCount();
+  public List<BestRoundResponse> getBestRounds(LocalDateTime start, LocalDateTime end) {
+    Integer maxFan;
+    if (start != null && end != null) {
+      maxFan = roundRepo.findMaxFanCountByDateRange(start, end);
+    } else {
+      maxFan = roundRepo.findMaxFanCount();
+    }
+
     if (maxFan == null || maxFan == 0) return Collections.emptyList();
 
-    return roundRepo.findByFanCount(maxFan).stream()
+    List<Round> bestRounds;
+    if (start != null && end != null) {
+      bestRounds = roundRepo.findByFanCountAndDateRange(maxFan, start, end);
+    } else {
+      bestRounds = roundRepo.findByFanCount(maxFan);
+    }
+
+    return bestRounds.stream()
         .map(
             round -> {
               Map<Long, Integer> scores =
@@ -482,6 +495,7 @@ public class GameService {
               double bonusRP = totalBonusPerPlayer.getOrDefault(p.getId(), 0.0);
               double totalRPVal = baseRP + bonusRP;
               stat.setTotalRP(totalRPVal);
+              stat.setBaseRP(baseRP);
               int games = gamesPlayed.getOrDefault(p.getId(), 0);
               stat.setAvgScore(games > 0 ? totalRPVal / games : 0);
               return stat;

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -94,13 +94,13 @@ export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
   return handleResponse(res)
 }
 
-export async function fetchBestRounds(year?: number, month?: number): Promise<BestRound[]> {
+export async function fetchBestRounds(year?: number, month?: number, signal?: AbortSignal): Promise<BestRound[]> {
   const params = new URLSearchParams()
   if (year != null && month != null) {
     params.set('year', String(year))
     params.set('month', String(month))
   }
   const qs = params.toString()
-  const res = await fetch(`${API}/stats/best-rounds${qs ? `?${qs}` : ''}`)
+  const res = await fetch(`${API}/stats/best-rounds${qs ? `?${qs}` : ''}`, { signal })
   return handleResponse<BestRound[]>(res)
 }

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -77,12 +77,12 @@ export async function completeSession(id: number): Promise<void> {
   }
 }
 
-export async function fetchStats(gameMode?: string, year?: number, quarter?: number): Promise<PlayerStats[]> {
+export async function fetchStats(gameMode?: string, year?: number, month?: number): Promise<PlayerStats[]> {
   const params = new URLSearchParams()
   if (gameMode) params.set('gameMode', gameMode)
-  if (year != null && quarter != null) {
+  if (year != null && month != null) {
     params.set('year', String(year))
-    params.set('quarter', String(quarter))
+    params.set('month', String(month))
   }
   const qs = params.toString()
   const res = await fetch(`${API}/stats${qs ? `?${qs}` : ''}`)
@@ -94,7 +94,13 @@ export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
   return handleResponse(res)
 }
 
-export async function fetchBestRounds(): Promise<BestRound[]> {
-  const res = await fetch(`${API}/stats/best-rounds`)
+export async function fetchBestRounds(year?: number, month?: number): Promise<BestRound[]> {
+  const params = new URLSearchParams()
+  if (year != null && month != null) {
+    params.set('year', String(year))
+    params.set('month', String(month))
+  }
+  const qs = params.toString()
+  const res = await fetch(`${API}/stats/best-rounds${qs ? `?${qs}` : ''}`)
   return handleResponse<BestRound[]>(res)
 }

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -82,29 +82,41 @@ export default function StatsPage() {
   }, [gameMode, seasonKey, tab])
 
   useEffect(() => {
+    const controller = new AbortController()
     if (tab === 'games') {
       setBestRoundsError('')
       fetchBestRounds()
-        .then(setBestRounds)
-        .catch((e) => setBestRoundsError(e.message))
+        .then((data) => {
+          if (!controller.signal.aborted) setBestRounds(data)
+        })
+        .catch((e) => {
+          if (!controller.signal.aborted) setBestRoundsError(e.message)
+        })
     }
+    return () => controller.abort()
   }, [tab])
 
   useEffect(() => {
+    const controller = new AbortController()
     if (tab === 'games' && seasonKey !== 'all') {
       setMonthlyBestRoundsError('')
       setMonthlyBestRounds([])
       const [y, m] = seasonKey.split('-').map(Number)
       fetchBestRounds(y, m)
-        .then(setMonthlyBestRounds)
+        .then((data) => {
+          if (!controller.signal.aborted) setMonthlyBestRounds(data)
+        })
         .catch((e) => {
-          setMonthlyBestRoundsError(e.message)
-          setMonthlyBestRounds([])
+          if (!controller.signal.aborted) {
+            setMonthlyBestRoundsError(e.message)
+            setMonthlyBestRounds([])
+          }
         })
     } else {
       setMonthlyBestRounds([])
       setMonthlyBestRoundsError('')
     }
+    return () => controller.abort()
   }, [tab, seasonKey])
 
   const abbr = (s: PlayerStats) => abbrName(s.displayName)
@@ -307,7 +319,7 @@ export default function StatsPage() {
             </div>
           )}
 
-          {bestRounds.length > 0 && (
+          {(bestRounds.length > 0 || !!bestRoundsError) && (
             <div className="card best-hand-card">
               <div className="best-hand-header">
                 <span className="best-hand-crown">👑</span>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -85,7 +85,7 @@ export default function StatsPage() {
     const controller = new AbortController()
     if (tab === 'games') {
       setBestRoundsError('')
-      fetchBestRounds()
+      fetchBestRounds(undefined, undefined, controller.signal)
         .then((data) => {
           if (!controller.signal.aborted) setBestRounds(data)
         })
@@ -102,7 +102,7 @@ export default function StatsPage() {
       setMonthlyBestRoundsError('')
       setMonthlyBestRounds([])
       const [y, m] = seasonKey.split('-').map(Number)
-      fetchBestRounds(y, m)
+      fetchBestRounds(y, m, controller.signal)
         .then((data) => {
           if (!controller.signal.aborted) setMonthlyBestRounds(data)
         })

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -298,8 +298,8 @@ export default function StatsPage() {
                 </div>
               )}
               <div className="best-hand-list">
-                {monthlyBestRounds.map((round, idx) => (
-                  <div key={idx} className="best-hand-item">
+                {monthlyBestRounds.map((round) => (
+                  <div key={`${round.sessionId}-${round.roundNumber}`} className="best-hand-item">
                     <div className="best-hand-meta">
                       <span className="best-hand-fan-count">{round.fanCount} 番</span>
                       <span className="best-hand-players">
@@ -327,8 +327,8 @@ export default function StatsPage() {
               </div>
               {bestRoundsError && <p className="error-text">加载历史最高和牌失败: {bestRoundsError}</p>}
               <div className="best-hand-list">
-                {bestRounds.map((round, idx) => (
-                  <div key={idx} className="best-hand-item">
+                {bestRounds.map((round) => (
+                  <div key={`${round.sessionId}-${round.roundNumber}`} className="best-hand-item">
                     <div className="best-hand-meta">
                       <span className="best-hand-fan-count">{round.fanCount} 番</span>
                       <span className="best-hand-players">

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -87,18 +87,23 @@ export default function StatsPage() {
       fetchBestRounds()
         .then(setBestRounds)
         .catch((e) => setBestRoundsError(e.message))
+    }
+  }, [tab])
 
+  useEffect(() => {
+    if (tab === 'games' && seasonKey !== 'all') {
       setMonthlyBestRoundsError('')
-      let year: number | undefined
-      let month: number | undefined
-      if (seasonKey !== 'all') {
-        const [y, m] = seasonKey.split('-').map(Number)
-        year = y
-        month = m
-      }
-      fetchBestRounds(year, month)
+      setMonthlyBestRounds([])
+      const [y, m] = seasonKey.split('-').map(Number)
+      fetchBestRounds(y, m)
         .then(setMonthlyBestRounds)
-        .catch((e) => setMonthlyBestRoundsError(e.message))
+        .catch((e) => {
+          setMonthlyBestRoundsError(e.message)
+          setMonthlyBestRounds([])
+        })
+    } else {
+      setMonthlyBestRounds([])
+      setMonthlyBestRoundsError('')
     }
   }, [tab, seasonKey])
 
@@ -268,13 +273,18 @@ export default function StatsPage() {
             </div>
           )}
 
-          {monthlyBestRounds.length > 0 && seasonKey !== 'all' && (
+          {seasonKey !== 'all' && (
             <div className="card best-hand-card">
               <div className="best-hand-header">
                 <span className="best-hand-crown">🌟</span>
                 <h2>{selectedSeason?.label}最高和牌</h2>
               </div>
               {monthlyBestRoundsError && <p className="error-text">加载月度最高和牌失败: {monthlyBestRoundsError}</p>}
+              {!monthlyBestRoundsError && monthlyBestRounds.length === 0 && (
+                <div className="empty-state" style={{ padding: '20px 0' }}>
+                  <p>本月无记录</p>
+                </div>
+              )}
               <div className="best-hand-list">
                 {monthlyBestRounds.map((round, idx) => (
                   <div key={idx} className="best-hand-item">

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -32,21 +32,23 @@ export default function StatsPage() {
   const [error, setError] = useState('')
   const [bestRounds, setBestRounds] = useState<BestRound[]>([])
   const [bestRoundsError, setBestRoundsError] = useState('')
+  const [monthlyBestRounds, setMonthlyBestRounds] = useState<BestRound[]>([])
+  const [monthlyBestRoundsError, setMonthlyBestRoundsError] = useState('')
 
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
-  const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.quarter}`)
+  const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.month}`)
 
   const loadStats = (mode: GameModeKey, sKey: string) => {
     setError('')
     setLoading(true)
     let year: number | undefined
-    let quarter: number | undefined
+    let month: number | undefined
     if (sKey !== 'all') {
-      const [y, q] = sKey.split('-').map(Number)
+      const [y, m] = sKey.split('-').map(Number)
       year = y
-      quarter = q
+      month = m
     }
-    fetchStats(mode, year, quarter)
+    fetchStats(mode, year, month)
       .then((s) => {
         setStats(s.sort((a, b) => b.totalRP - a.totalRP || b.totalScore - a.totalScore))
         setLoading(false)
@@ -85,13 +87,25 @@ export default function StatsPage() {
       fetchBestRounds()
         .then(setBestRounds)
         .catch((e) => setBestRoundsError(e.message))
+
+      setMonthlyBestRoundsError('')
+      let year: number | undefined
+      let month: number | undefined
+      if (seasonKey !== 'all') {
+        const [y, m] = seasonKey.split('-').map(Number)
+        year = y
+        month = m
+      }
+      fetchBestRounds(year, month)
+        .then(setMonthlyBestRounds)
+        .catch((e) => setMonthlyBestRoundsError(e.message))
     }
-  }, [tab])
+  }, [tab, seasonKey])
 
   const abbr = (s: PlayerStats) => abbrName(s.displayName)
 
   const activeStats = stats.filter((s) => s.gamesPlayed > 0)
-  const selectedSeason = seasons.find((s) => `${s.year}-${s.quarter}` === seasonKey)
+  const selectedSeason = seasons.find((s) => `${s.year}-${s.month}` === seasonKey)
 
   if (loading)
     return (
@@ -133,7 +147,7 @@ export default function StatsPage() {
               <h2>赛季</h2>
               <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">
                 {seasons.map((s) => (
-                  <option key={`${s.year}-${s.quarter}`} value={`${s.year}-${s.quarter}`}>
+                  <option key={`${s.year}-${s.month}`} value={`${s.year}-${s.month}`}>
                     {s.label}
                   </option>
                 ))}
@@ -206,6 +220,10 @@ export default function StatsPage() {
                         积分(RP)
                         <div className="th-subtitle">含局数奖励</div>
                       </th>
+                      <th style={{ textAlign: 'right' }}>
+                        纯积分
+                        <div className="th-subtitle">刨除奖励</div>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -232,10 +250,49 @@ export default function StatsPage() {
                         >
                           {s.totalRP > 0 ? `+${s.totalRP.toFixed(1)}` : s.totalRP.toFixed(1)}
                         </td>
+                        <td
+                          style={{
+                            textAlign: 'right',
+                            fontVariantNumeric: 'tabular-nums',
+                            color: 'var(--text-secondary)',
+                            fontSize: '0.9rem',
+                          }}
+                        >
+                          {s.baseRP > 0 ? `+${s.baseRP.toFixed(1)}` : s.baseRP.toFixed(1)}
+                        </td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
+              </div>
+            </div>
+          )}
+
+          {monthlyBestRounds.length > 0 && seasonKey !== 'all' && (
+            <div className="card best-hand-card">
+              <div className="best-hand-header">
+                <span className="best-hand-crown">🌟</span>
+                <h2>{selectedSeason?.label}最高和牌</h2>
+              </div>
+              {monthlyBestRoundsError && <p className="error-text">加载月度最高和牌失败: {monthlyBestRoundsError}</p>}
+              <div className="best-hand-list">
+                {monthlyBestRounds.map((round, idx) => (
+                  <div key={idx} className="best-hand-item">
+                    <div className="best-hand-meta">
+                      <span className="best-hand-fan-count">{round.fanCount} 番</span>
+                      <span className="best-hand-players">
+                        <span className="winner-label">赢家:</span> {round.winnerName}
+                        <span className="win-type-label ml-2">({round.dealInPlayerId != null ? '点炮' : '自摸'})</span>
+                        <span className="session-link-label ml-2">
+                          <Link to={`/session/${round.sessionId}`}>查看对局</Link>
+                        </span>
+                      </span>
+                    </div>
+                    <div className="best-hand-display">
+                      <MahjongHand hand={round.winHand} details={round.fanDetails} />
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}
@@ -246,7 +303,7 @@ export default function StatsPage() {
                 <span className="best-hand-crown">👑</span>
                 <h2>历史最高和牌</h2>
               </div>
-              {bestRoundsError && <p className="error-text">加载最高和牌失败: {bestRoundsError}</p>}
+              {bestRoundsError && <p className="error-text">加载历史最高和牌失败: {bestRoundsError}</p>}
               <div className="best-hand-list">
                 {bestRounds.map((round, idx) => (
                   <div key={idx} className="best-hand-item">
@@ -254,13 +311,7 @@ export default function StatsPage() {
                       <span className="best-hand-fan-count">{round.fanCount} 番</span>
                       <span className="best-hand-players">
                         <span className="winner-label">赢家:</span> {round.winnerName}
-                        {round.dealInPlayerId != null ? (
-                          <>
-                            <span className="loser-label ml-2">输家:</span> {round.dealInPlayerName || '?'}
-                          </>
-                        ) : (
-                          <span className="zimo-label ml-2">(自摸)</span>
-                        )}
+                        <span className="win-type-label ml-2">({round.dealInPlayerId != null ? '点炮' : '自摸'})</span>
                         <span className="session-link-label ml-2">
                           <Link to={`/session/${round.sessionId}`}>查看对局</Link>
                         </span>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -89,39 +89,48 @@ export interface PlayerStats {
   gamesPlayed: number
   totalScore: number
   totalRP: number
+  baseRP: number
   avgScore: number
   wins: number
 }
 
 export interface Season {
   year: number
-  quarter: number
+  month: number
   label: string
 }
 
-const SEASON_NAMES: Record<number, string> = {
-  1: '春之赛季',
-  2: '夏之赛季',
-  3: '秋之赛季',
-  4: '冬之赛季',
+const MONTH_NAMES: Record<number, string> = {
+  1: '1月',
+  2: '2月',
+  3: '3月',
+  4: '4月',
+  5: '5月',
+  6: '6月',
+  7: '7月',
+  8: '8月',
+  9: '9月',
+  10: '10月',
+  11: '11月',
+  12: '12月',
 }
 
 export function getCurrentSeason(): Season {
   const now = new Date()
-  const quarter = Math.ceil((now.getMonth() + 1) / 3)
-  return { year: now.getFullYear(), quarter, label: `${now.getFullYear()} ${SEASON_NAMES[quarter]}` }
+  const month = now.getMonth() + 1
+  return { year: now.getFullYear(), month, label: `${now.getFullYear()} ${MONTH_NAMES[month]}` }
 }
 
 export function getAvailableSeasons(startYear: number = 2026): Season[] {
   const seasons: Season[] = []
   const now = new Date()
   const currentYear = now.getFullYear()
-  const currentQuarter = Math.ceil((now.getMonth() + 1) / 3)
+  const currentMonth = now.getMonth() + 1
 
   for (let y = currentYear; y >= startYear; y--) {
-    const maxQ = y === currentYear ? currentQuarter : 4
-    for (let q = maxQ; q >= 1; q--) {
-      seasons.push({ year: y, quarter: q, label: `${y} ${SEASON_NAMES[q]}` })
+    const maxM = y === currentYear ? currentMonth : 12
+    for (let m = maxM; m >= 1; m--) {
+      seasons.push({ year: y, month: m, label: `${y} ${MONTH_NAMES[m]}` })
     }
   }
   return seasons


### PR DESCRIPTION
This PR introduces several enhancements to the statistics tracking and display:
- Changed the season cycle from quarterly to monthly.
- Added a 'Best Hand of the Month' section to the stats page.
- Added a 'Pure RP' column to the leaderboard to show points without the participation bonus.
- Updated documentation to reflect the monthly season change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Season filtering moved from quarters to months (1月–12月)
  * Best rounds can be filtered by specific month and year; shows a month-specific “最高和牌” card

* **Improvements**
  * Added base RP column ("纯积分") to player statistics
  * Unified win-type labeling in best-rounds display
  * Updated README season options and history error message ("加载历史最高和牌失败: ...")
<!-- end of auto-generated comment: release notes by coderabbit.ai -->