### PR TITLE
feat: dynamic seasons with 节气 names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Landing page with quick access to start a game
 - Support for 自摸 and 点炮
 
 ### Stats & Leaderboard
-- Monthly seasons: 1月, 2月, 3月, ..., 12月
+- Monthly seasons with 节气-inspired names (大寒, 立春, 春分, 清明, ...)
 - 🏆 赛季冠军 and 👑 最多胜场 highlights
 - Filter leaderboard by game mode
 - Player profiles with individual game history

--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -5,6 +5,7 @@ import com.mahjong.omakase.model.GameMode;
 import com.mahjong.omakase.service.GameService;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,6 +53,11 @@ public class StatsController {
     }
 
     return gameService.getPlayerStats(mode, start, end);
+  }
+
+  @GetMapping("/seasons")
+  public List<Map<String, Integer>> getActiveSeasons() {
+    return gameService.getActiveSeasons();
   }
 
   @GetMapping("/best-rounds")

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
@@ -17,4 +17,8 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT s FROM GameSession s WHERE s.id = :id")
   Optional<GameSession> findByIdForUpdate(@Param("id") Long id);
+
+  @Query(
+      "SELECT DISTINCT YEAR(s.createdAt) AS y, MONTH(s.createdAt) AS m FROM GameSession s ORDER BY y DESC, m DESC")
+  List<Object[]> findDistinctSeasons();
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
@@ -19,6 +19,7 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
   Optional<GameSession> findByIdForUpdate(@Param("id") Long id);
 
   @Query(
-      "SELECT DISTINCT YEAR(s.createdAt) AS y, MONTH(s.createdAt) AS m FROM GameSession s ORDER BY y DESC, m DESC")
+      "SELECT DISTINCT YEAR(s.createdAt) AS y, MONTH(s.createdAt) AS m"
+          + " FROM GameSession s WHERE s.rounds IS NOT EMPTY ORDER BY y DESC, m DESC")
   List<Object[]> findDistinctSeasons();
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -394,8 +394,8 @@ public class GameService {
         .map(
             row -> {
               Map<String, Integer> m = new LinkedHashMap<>();
-              m.put("year", (Integer) row[0]);
-              m.put("month", (Integer) row[1]);
+              m.put("year", ((Number) row[0]).intValue());
+              m.put("month", ((Number) row[1]).intValue());
               return m;
             })
         .collect(Collectors.toList());

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -389,6 +389,18 @@ public class GameService {
         .collect(Collectors.toList());
   }
 
+  public List<Map<String, Integer>> getActiveSeasons() {
+    return sessionRepo.findDistinctSeasons().stream()
+        .map(
+            row -> {
+              Map<String, Integer> m = new LinkedHashMap<>();
+              m.put("year", (Integer) row[0]);
+              m.put("month", (Integer) row[1]);
+              return m;
+            })
+        .collect(Collectors.toList());
+  }
+
   public List<PlayerStatsResponse> getPlayerStats(
       GameMode gameMode, LocalDateTime start, LocalDateTime end) {
     List<Player> players = playerRepo.findAll();

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -77,6 +77,11 @@ export async function completeSession(id: number): Promise<void> {
   }
 }
 
+export async function fetchActiveSeasons(): Promise<{ year: number; month: number }[]> {
+  const res = await fetch(`${API}/stats/seasons`)
+  return handleResponse(res)
+}
+
 export async function fetchStats(gameMode?: string, year?: number, month?: number): Promise<PlayerStats[]> {
   const params = new URLSearchParams()
   if (gameMode) params.set('gameMode', gameMode)

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -74,13 +74,25 @@ export default function StatsPage() {
   }
 
   useEffect(() => {
-    fetchActiveSeasons().then((data) => {
-      const list = data.map((s) => ({ year: s.year, month: s.month, label: getSeasonLabel(s.year, s.month) }))
-      setSeasons(list)
-      if (list.length > 0 && !list.some((s) => `${s.year}-${s.month}` === seasonKey)) {
-        setSeasonKey(`${list[0].year}-${list[0].month}`)
-      }
-    })
+    let mounted = true
+    fetchActiveSeasons()
+      .then((data) => {
+        if (!mounted) return
+        const list = data.map((s) => ({ year: s.year, month: s.month, label: getSeasonLabel(s.year, s.month) }))
+        setSeasons(list)
+        if (list.length > 0) {
+          setSeasonKey((prev) =>
+            list.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${list[0].year}-${list[0].month}`
+          )
+        }
+      })
+      .catch((e) => {
+        if (!mounted) return
+        setError(e.message)
+      })
+    return () => {
+      mounted = false
+    }
   }, [])
 
   useEffect(() => {

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -7,15 +7,14 @@ import {
   GAME_MODES,
   Season,
   getCurrentSeason,
-  getAvailableSeasons,
+  getSeasonLabel,
   BestRound,
 } from '../types'
-import { fetchStats, fetchPlayers, fetchBestRounds } from '../api'
+import { fetchStats, fetchPlayers, fetchBestRounds, fetchActiveSeasons } from '../api'
 import { MahjongHand } from '../components/MahjongHand'
 
 type Tab = 'games' | 'players'
 
-const seasons = getAvailableSeasons()
 const currentSeason = getCurrentSeason()
 
 import { statFontSize } from '../utils/fontSize'
@@ -34,6 +33,7 @@ export default function StatsPage() {
   const [bestRoundsError, setBestRoundsError] = useState('')
   const [monthlyBestRounds, setMonthlyBestRounds] = useState<BestRound[]>([])
   const [monthlyBestRoundsError, setMonthlyBestRoundsError] = useState('')
+  const [seasons, setSeasons] = useState<Season[]>([])
 
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.month}`)
@@ -72,6 +72,16 @@ export default function StatsPage() {
         setLoading(false)
       })
   }
+
+  useEffect(() => {
+    fetchActiveSeasons().then((data) => {
+      const list = data.map((s) => ({ year: s.year, month: s.month, label: getSeasonLabel(s.year, s.month) }))
+      setSeasons(list)
+      if (list.length > 0 && !list.some((s) => `${s.year}-${s.month}` === seasonKey)) {
+        setSeasonKey(`${list[0].year}-${list[0].month}`)
+      }
+    })
+  }, [])
 
   useEffect(() => {
     if (tab === 'games') {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -99,40 +99,29 @@ export interface Season {
   label: string
 }
 
-const MONTH_NAMES: Record<number, string> = {
-  1: '1月',
-  2: '2月',
-  3: '3月',
-  4: '4月',
-  5: '5月',
-  6: '6月',
-  7: '7月',
-  8: '8月',
-  9: '9月',
-  10: '10月',
-  11: '11月',
-  12: '12月',
+const SEASON_NAMES: Record<number, string> = {
+  1: '大寒赛季',
+  2: '立春赛季',
+  3: '春分赛季',
+  4: '清明赛季',
+  5: '立夏赛季',
+  6: '夏至赛季',
+  7: '大暑赛季',
+  8: '立秋赛季',
+  9: '秋分赛季',
+  10: '霜降赛季',
+  11: '立冬赛季',
+  12: '冬至赛季',
+}
+
+export function getSeasonLabel(year: number, month: number): string {
+  return `${year} ${SEASON_NAMES[month]}`
 }
 
 export function getCurrentSeason(): Season {
   const now = new Date()
   const month = now.getMonth() + 1
-  return { year: now.getFullYear(), month, label: `${now.getFullYear()} ${MONTH_NAMES[month]}` }
-}
-
-export function getAvailableSeasons(startYear: number = 2026): Season[] {
-  const seasons: Season[] = []
-  const now = new Date()
-  const currentYear = now.getFullYear()
-  const currentMonth = now.getMonth() + 1
-
-  for (let y = currentYear; y >= startYear; y--) {
-    const maxM = y === currentYear ? currentMonth : 12
-    for (let m = maxM; m >= 1; m--) {
-      seasons.push({ year: y, month: m, label: `${y} ${MONTH_NAMES[m]}` })
-    }
-  }
-  return seasons
+  return { year: now.getFullYear(), month, label: getSeasonLabel(now.getFullYear(), month) }
 }
 
 export interface PlayerGameEntry {


### PR DESCRIPTION
## Summary
- Add `GET /api/stats/seasons` endpoint that returns only months with recorded games
- Replace hardcoded month list (1月–12月) with DB-driven season dropdown
- Rename season labels with 节气-inspired names (大寒赛季, 立春赛季, 春分赛季, ...)
- Remove `getAvailableSeasons()` (now dead code) and export new `getSeasonLabel()` utility

## Test plan
- [ ] Visit stats page — dropdown should only show months that have games
- [ ] Verify season labels display as `2026 清明赛季` format
- [ ] Select "全部赛季" — should still show all-time stats
- [ ] Verify `curl localhost:8080/api/stats/seasons` returns correct year-month pairs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stats & Leaderboard now fetch active seasons from the server so the season list is always current.
  * Season dropdown automatically updates to the latest available season when needed.

* **Documentation**
  * README updated to use 节气-inspired seasonal names for the Stats & Leaderboard.

* **Refactor**
  * Client now derives season labels from server-driven season data rather than a static local list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->