### PR TITLE
feat: filter best hand by game mode

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -62,7 +62,18 @@ public class StatsController {
 
   @GetMapping("/best-rounds")
   public List<com.mahjong.omakase.dto.BestRoundResponse> getBestRounds(
-      @RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) String gameMode,
+      @RequestParam(required = false) Integer year,
+      @RequestParam(required = false) Integer month) {
+    GameMode mode = null;
+    if (gameMode != null && !gameMode.isEmpty()) {
+      try {
+        mode = GameMode.valueOf(gameMode);
+      } catch (IllegalArgumentException e) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid game mode: " + gameMode);
+      }
+    }
+
     LocalDateTime start = null;
     LocalDateTime end = null;
     if (year != null || month != null) {
@@ -76,6 +87,6 @@ public class StatsController {
       start = LocalDateTime.of(year, month, 1, 0, 0);
       end = start.plusMonths(1);
     }
-    return gameService.getBestRounds(start, end);
+    return gameService.getBestRounds(mode, start, end);
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -1,26 +1,57 @@
 package com.mahjong.omakase.repository;
 
+import com.mahjong.omakase.model.GameMode;
 import com.mahjong.omakase.model.Round;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoundRepository extends JpaRepository<Round, Long> {
   int countByGameSessionId(Long gameSessionId);
 
-  @org.springframework.data.jpa.repository.Query("SELECT MAX(r.fanCount) FROM Round r")
+  @Query("SELECT MAX(r.fanCount) FROM Round r")
   Integer findMaxFanCount();
 
-  java.util.List<Round> findByFanCount(Integer fanCount);
+  @Query("SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.gameMode = :mode")
+  Integer findMaxFanCountByMode(@Param("mode") GameMode mode);
 
-  @org.springframework.data.jpa.repository.Query(
-      "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s WHERE s.createdAt >= :start AND s.createdAt < :end")
+  List<Round> findByFanCount(Integer fanCount);
+
+  @Query("SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode")
+  List<Round> findByFanCountAndMode(
+      @Param("fanCount") Integer fanCount, @Param("mode") GameMode mode);
+
+  @Query(
+      "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
+          + " WHERE s.createdAt >= :start AND s.createdAt < :end")
   Integer findMaxFanCountByDateRange(
-      @org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
-      @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
+      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
-  @org.springframework.data.jpa.repository.Query(
-      "SELECT r FROM Round r JOIN r.gameSession s WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end")
-  java.util.List<Round> findByFanCountAndDateRange(
-      @org.springframework.data.repository.query.Param("fanCount") Integer fanCount,
-      @org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
-      @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
+  @Query(
+      "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
+          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end")
+  Integer findMaxFanCountByModeAndDateRange(
+      @Param("mode") GameMode mode,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+
+  @Query(
+      "SELECT r FROM Round r JOIN r.gameSession s"
+          + " WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end")
+  List<Round> findByFanCountAndDateRange(
+      @Param("fanCount") Integer fanCount,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+
+  @Query(
+      "SELECT r FROM Round r JOIN r.gameSession s"
+          + " WHERE r.fanCount = :fanCount AND s.gameMode = :mode"
+          + " AND s.createdAt >= :start AND s.createdAt < :end")
+  List<Round> findByFanCountAndModeAndDateRange(
+      @Param("fanCount") Integer fanCount,
+      @Param("mode") GameMode mode,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -332,9 +332,17 @@ public class GameService {
     log.info("Completed session id={}", sessionId);
   }
 
-  public List<BestRoundResponse> getBestRounds(LocalDateTime start, LocalDateTime end) {
+  public List<BestRoundResponse> getBestRounds(
+      GameMode gameMode, LocalDateTime start, LocalDateTime end) {
+    boolean hasMode = gameMode != null;
+    boolean hasDate = start != null && end != null;
+
     Integer maxFan;
-    if (start != null && end != null) {
+    if (hasMode && hasDate) {
+      maxFan = roundRepo.findMaxFanCountByModeAndDateRange(gameMode, start, end);
+    } else if (hasMode) {
+      maxFan = roundRepo.findMaxFanCountByMode(gameMode);
+    } else if (hasDate) {
       maxFan = roundRepo.findMaxFanCountByDateRange(start, end);
     } else {
       maxFan = roundRepo.findMaxFanCount();
@@ -343,7 +351,11 @@ public class GameService {
     if (maxFan == null || maxFan == 0) return Collections.emptyList();
 
     List<Round> bestRounds;
-    if (start != null && end != null) {
+    if (hasMode && hasDate) {
+      bestRounds = roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, start, end);
+    } else if (hasMode) {
+      bestRounds = roundRepo.findByFanCountAndMode(maxFan, gameMode);
+    } else if (hasDate) {
       bestRounds = roundRepo.findByFanCountAndDateRange(maxFan, start, end);
     } else {
       bestRounds = roundRepo.findByFanCount(maxFan);

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -99,8 +99,14 @@ export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
   return handleResponse(res)
 }
 
-export async function fetchBestRounds(year?: number, month?: number, signal?: AbortSignal): Promise<BestRound[]> {
+export async function fetchBestRounds(
+  gameMode?: string,
+  year?: number,
+  month?: number,
+  signal?: AbortSignal
+): Promise<BestRound[]> {
   const params = new URLSearchParams()
+  if (gameMode) params.set('gameMode', gameMode)
   if (year != null && month != null) {
     params.set('year', String(year))
     params.set('month', String(month))

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -107,7 +107,7 @@ export default function StatsPage() {
     const controller = new AbortController()
     if (tab === 'games') {
       setBestRoundsError('')
-      fetchBestRounds(undefined, undefined, controller.signal)
+      fetchBestRounds(gameMode, undefined, undefined, controller.signal)
         .then((data) => {
           if (!controller.signal.aborted) setBestRounds(data)
         })
@@ -116,7 +116,7 @@ export default function StatsPage() {
         })
     }
     return () => controller.abort()
-  }, [tab])
+  }, [tab, gameMode])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -124,7 +124,7 @@ export default function StatsPage() {
       setMonthlyBestRoundsError('')
       setMonthlyBestRounds([])
       const [y, m] = seasonKey.split('-').map(Number)
-      fetchBestRounds(y, m, controller.signal)
+      fetchBestRounds(gameMode, y, m, controller.signal)
         .then((data) => {
           if (!controller.signal.aborted) setMonthlyBestRounds(data)
         })
@@ -139,7 +139,7 @@ export default function StatsPage() {
       setMonthlyBestRoundsError('')
     }
     return () => controller.abort()
-  }, [tab, seasonKey])
+  }, [tab, seasonKey, gameMode])
 
   const abbr = (s: PlayerStats) => abbrName(s.displayName)
 


### PR DESCRIPTION
## Summary
- Add `gameMode` param to `GET /api/stats/best-rounds` endpoint
- Add per-mode repository queries for max fan count lookup
- Frontend passes selected game mode to both monthly and all-time best hand fetches
- Best hands now re-fetch when game mode changes

## Test plan
- [ ] Select 国标麻将 — best hand section shows only Guobiao hands
- [ ] Switch to 立直麻将 — best hand updates to show only Riichi hands
- [ ] Switch to 东北麻将 — best hand updates accordingly
- [ ] Monthly best hand also filters by mode
- [ ] "全部赛季" with a specific mode still filters correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Best rounds statistics can now be filtered by game mode via optional query parameter
  * Game mode filtering applies to both overall historical and monthly statistics views
  * Invalid game mode values return a 400 error response

<!-- end of auto-generated comment: release notes by coderabbit.ai -->