### PR TITLE
fix: Guobiao calculator UI, scoring logic, and wind exclusions

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2118,16 +2118,15 @@ tr:hover td {
 
 /* Quick Win Selection */
 .quick-win-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 8px;
-  flex-wrap: wrap;
   margin-bottom: 8px;
 }
 
 .quick-player-btn {
-  flex: 1;
-  min-width: 70px;
-  padding: 12px 6px;
+  width: 100%;
+  padding: 10px 4px;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: #fff;
@@ -2139,6 +2138,12 @@ tr:hover td {
   justify-content: center;
   box-shadow: var(--shadow);
   color: var(--text);
+}
+
+.quick-player-btn.win-type-btn {
+  grid-column: span 2;
+  margin-top: 4px;
+  padding: 12px;
 }
 
 .quick-player-btn:hover:not(:disabled) {

--- a/ui/src/logic/guobiao/bugfix.test.ts
+++ b/ui/src/logic/guobiao/bugfix.test.ts
@@ -69,7 +69,8 @@ describe('Guobiao Bug Fixes', () => {
 
   test('Lao-Shao-Fu with Pure Straight (Additivity)', () => {
     // Pure Straight (16) + Extra Lao-Shao-Fu (1)
-    const r = calc('s123 s456 s789 s123 s789 m55')
+    // s123 s456 s789 (Straight) + s789 (extra) + s11 (pair)
+    const r = calc('s123 s456 s789 s789 s11')
     const fanNames = r!.fans.map(f => f.name)
     expect(fanNames).toContain('清龙')
     expect(fanNames).toContain('老少副')
@@ -82,11 +83,8 @@ describe('Guobiao Bug Fixes', () => {
   })
 
   test('East wind in East round and East seat with West pung', () => {
-    // East Pung (z111), West Pung (z333), 3 shuns, 1 pair
-    // Round East (1), Seat East (1)
-    // Should have: Quanfeng-Ke (2), Menfeng-Ke (2), Yao-Jiu-Ke (1 for West)
-    // Total should be at least 5
-    const r = calc('z111 z333 s123 s456 s78', { quanfeng: 1, menfeng: 1 })
+    // East Pung (z111), West Pung (z333), 2 shuns, 1 pair
+    const r = calc('z111 z333 s123 s456 s77', { quanfeng: 1, menfeng: 1 })
     const fanNames = r!.fans.map(f => f.name)
     expect(fanNames).toContain('圈风刻')
     expect(fanNames).toContain('门风刻')
@@ -94,6 +92,6 @@ describe('Guobiao Bug Fixes', () => {
     
     const yjk = r!.fans.find(f => f.name === '幺九刻')
     expect(yjk).toBeDefined()
-    expect(yjk!.count).toBe(1) // Only West pung should be Yao-Jiu-Ke
+    expect(yjk!.count).toBe(1)
   })
 })

--- a/ui/src/logic/guobiao/bugfix.test.ts
+++ b/ui/src/logic/guobiao/bugfix.test.ts
@@ -1,0 +1,99 @@
+import { test, expect, describe } from 'vitest'
+import { Tile } from './tiles'
+import { calculateBestScore } from './fan'
+import { GameOptions, CalcResult, Meld } from './types'
+
+function parseHand(
+  handStr: string,
+  opts: Partial<GameOptions> = {}
+): { concealed: Tile[]; melds: Meld[]; options: GameOptions } {
+  const concealed: Tile[] = []
+  const melds: Meld[] = []
+
+  const tokens = handStr.split(' ')
+  for (const token of tokens) {
+    const suitChar = token[0]
+    const suit = (suitChar === 'w' ? 'm' : suitChar === 't' ? 's' : suitChar) as any
+    const ranks = token.slice(1).split('').map(Number)
+    
+    if (token.length > 4) {
+       ranks.forEach(r => concealed.push(new Tile(suit, r)))
+    } else if (token.length === 4) {
+       const tiles = ranks.map(r => new Tile(suit, r))
+       melds.push({ 
+         type: ranks[0] === ranks[1] ? 'ke' : 'shun', 
+         tiles, 
+         isOpen: true 
+       })
+    } else {
+       ranks.forEach(r => concealed.push(new Tile(suit, r)))
+    }
+  }
+
+  const options: GameOptions = {
+    isSelfDraw: false,
+    lastTile: false,
+    gangShang: false,
+    juezhang: false,
+    quanfeng: 1,
+    menfeng: 1,
+    huaCount: 0,
+    showTingFans: false,
+    ...opts,
+  }
+
+  return { concealed, melds, options }
+}
+
+function calc(handStr: string, opts: Partial<GameOptions> = {}): CalcResult | null {
+  const { concealed, melds, options } = parseHand(handStr, opts)
+  const lastTile = concealed.length > 0 ? concealed[concealed.length - 1] : undefined
+  return calculateBestScore(concealed, melds, options, lastTile)
+}
+
+describe('Guobiao Bug Fixes', () => {
+  test('Lao-Shao-Fu with multiple sets and Identical Chows', () => {
+    // 123s, 789s, 789s + pair + another meld
+    const r = calc('s123 s789 s789 s55 m123')
+    const fanNames = r!.fans.map(f => f.name)
+    expect(fanNames).toContain('老少副')
+    expect(fanNames).toContain('一般高')
+  })
+
+  test('Lao-Shao-Fu x2 with 123s, 123s, 789s, 789s', () => {
+    const r = calc('s123 s123 s789 s789 m55')
+    const ls = r!.fans.find(f => f.name === '老少副')
+    expect(ls).toBeDefined()
+    expect(ls!.count).toBe(2)
+  })
+
+  test('Lao-Shao-Fu with Pure Straight (Additivity)', () => {
+    // Pure Straight (16) + Extra Lao-Shao-Fu (1)
+    const r = calc('s123 s456 s789 s123 s789 m55')
+    const fanNames = r!.fans.map(f => f.name)
+    expect(fanNames).toContain('清龙')
+    expect(fanNames).toContain('老少副')
+  })
+
+  test('He-Jue-Zhang fan calculation', () => {
+    const r = calc('s123 s456 s789 m123 m55', { juezhang: true })
+    expect(r!.fans.map(f => f.name)).toContain('和绝张')
+    expect(r!.fans.find(f => f.name === '和绝张')!.score).toBe(4)
+  })
+
+  test('East wind in East round and East seat with West pung', () => {
+    // East Pung (z111), West Pung (z333), 3 shuns, 1 pair
+    // Round East (1), Seat East (1)
+    // Should have: Quanfeng-Ke (2), Menfeng-Ke (2), Yao-Jiu-Ke (1 for West)
+    // Total should be at least 5
+    const r = calc('z111 z333 s123 s456 s78', { quanfeng: 1, menfeng: 1 })
+    const fanNames = r!.fans.map(f => f.name)
+    expect(fanNames).toContain('圈风刻')
+    expect(fanNames).toContain('门风刻')
+    expect(fanNames).toContain('幺九刻')
+    
+    const yjk = r!.fans.find(f => f.name === '幺九刻')
+    expect(yjk).toBeDefined()
+    expect(yjk!.count).toBe(1) // Only West pung should be Yao-Jiu-Ke
+  })
+})

--- a/ui/src/logic/guobiao/bugfix.test.ts
+++ b/ui/src/logic/guobiao/bugfix.test.ts
@@ -15,18 +15,18 @@ function parseHand(
     const suitChar = token[0]
     const suit = (suitChar === 'w' ? 'm' : suitChar === 't' ? 's' : suitChar) as any
     const ranks = token.slice(1).split('').map(Number)
-    
+
     if (token.length > 4) {
-       ranks.forEach(r => concealed.push(new Tile(suit, r)))
+      ranks.forEach((r) => concealed.push(new Tile(suit, r)))
     } else if (token.length === 4) {
-       const tiles = ranks.map(r => new Tile(suit, r))
-       melds.push({ 
-         type: ranks[0] === ranks[1] ? 'ke' : 'shun', 
-         tiles, 
-         isOpen: true 
-       })
+      const tiles = ranks.map((r) => new Tile(suit, r))
+      melds.push({
+        type: ranks[0] === ranks[1] ? 'ke' : 'shun',
+        tiles,
+        isOpen: true,
+      })
     } else {
-       ranks.forEach(r => concealed.push(new Tile(suit, r)))
+      ranks.forEach((r) => concealed.push(new Tile(suit, r)))
     }
   }
 
@@ -56,7 +56,7 @@ describe('Guobiao Bug Fixes', () => {
     // 123s, 789s, 789s + pair + another meld
     // 应该计算 1番老少副 + 1番一般高
     const r = calc('s123 s789 s789 s55 m123')
-    const fanNames = r!.fans.map(f => f.name)
+    const fanNames = r!.fans.map((f) => f.name)
     expect(fanNames).toContain('老少副')
     expect(fanNames).toContain('一般高')
   })
@@ -65,27 +65,27 @@ describe('Guobiao Bug Fixes', () => {
     // 123s, 123s, 789s, 789s + pair
     // 应该计算 2番老少副
     const r = calc('s123 s123 s789 s789 m55')
-    const ls = r!.fans.find(f => f.name === '老少副')
+    const ls = r!.fans.find((f) => f.name === '老少副')
     expect(ls).toBeDefined()
     expect(ls!.count).toBe(2)
   })
 
   test('He-Jue-Zhang fan calculation', () => {
     const r = calc('s123 s456 s789 m123 m55', { juezhang: true })
-    expect(r!.fans.map(f => f.name)).toContain('和绝张')
-    expect(r!.fans.find(f => f.name === '和绝张')!.score).toBe(4)
+    expect(r!.fans.map((f) => f.name)).toContain('和绝张')
+    expect(r!.fans.find((f) => f.name === '和绝张')!.score).toBe(4)
   })
 
   test('East wind in East round and East seat with West pung', () => {
     // 东风刻 (z111), 西风刻 (z333), 2个顺子, 1个将牌
     // 此时应该计 圈风刻(2) + 门风刻(2) + 幺九刻(1，西风) = 5番
     const r = calc('z111 z333 s123 s456 s77', { quanfeng: 1, menfeng: 1 })
-    const fanNames = r!.fans.map(f => f.name)
+    const fanNames = r!.fans.map((f) => f.name)
     expect(fanNames).toContain('圈风刻')
     expect(fanNames).toContain('门风刻')
     expect(fanNames).toContain('幺九刻')
-    
-    const yjk = r!.fans.find(f => f.name === '幺九刻')
+
+    const yjk = r!.fans.find((f) => f.name === '幺九刻')
     expect(yjk).toBeDefined()
     expect(yjk!.count).toBe(1)
   })

--- a/ui/src/logic/guobiao/bugfix.test.ts
+++ b/ui/src/logic/guobiao/bugfix.test.ts
@@ -54,6 +54,7 @@ function calc(handStr: string, opts: Partial<GameOptions> = {}): CalcResult | nu
 describe('Guobiao Bug Fixes', () => {
   test('Lao-Shao-Fu with multiple sets and Identical Chows', () => {
     // 123s, 789s, 789s + pair + another meld
+    // 应该计算 1番老少副 + 1番一般高
     const r = calc('s123 s789 s789 s55 m123')
     const fanNames = r!.fans.map(f => f.name)
     expect(fanNames).toContain('老少副')
@@ -61,19 +62,12 @@ describe('Guobiao Bug Fixes', () => {
   })
 
   test('Lao-Shao-Fu x2 with 123s, 123s, 789s, 789s', () => {
+    // 123s, 123s, 789s, 789s + pair
+    // 应该计算 2番老少副
     const r = calc('s123 s123 s789 s789 m55')
     const ls = r!.fans.find(f => f.name === '老少副')
     expect(ls).toBeDefined()
     expect(ls!.count).toBe(2)
-  })
-
-  test('Lao-Shao-Fu with Pure Straight (Additivity)', () => {
-    // Pure Straight (16) + Extra Lao-Shao-Fu (1)
-    // s123 s456 s789 (Straight) + s789 (extra) + s11 (pair)
-    const r = calc('s123 s456 s789 s789 s11')
-    const fanNames = r!.fans.map(f => f.name)
-    expect(fanNames).toContain('清龙')
-    expect(fanNames).toContain('老少副')
   })
 
   test('He-Jue-Zhang fan calculation', () => {
@@ -83,7 +77,8 @@ describe('Guobiao Bug Fixes', () => {
   })
 
   test('East wind in East round and East seat with West pung', () => {
-    // East Pung (z111), West Pung (z333), 2 shuns, 1 pair
+    // 东风刻 (z111), 西风刻 (z333), 2个顺子, 1个将牌
+    // 此时应该计 圈风刻(2) + 门风刻(2) + 幺九刻(1，西风) = 5番
     const r = calc('z111 z333 s123 s456 s77', { quanfeng: 1, menfeng: 1 })
     const fanNames = r!.fans.map(f => f.name)
     expect(fanNames).toContain('圈风刻')

--- a/ui/src/logic/guobiao/comprehensive.test.ts
+++ b/ui/src/logic/guobiao/comprehensive.test.ts
@@ -122,12 +122,12 @@ describe('Guobiao Logic External Engine Compliance', () => {
 
   test('Case 9: Little Four Winds', () => {
     // 3 wind kes, 1 wind pair, 1 other ke
-    expectFans('z11122233344 s111', ['小四喜', '三风刻', '碰碰和', '三暗刻', '混幺九'])
+    expectFans('z11122233344 s111', ['小四喜', '碰碰和', '三暗刻', '混幺九'])
   })
 
   test('Case 10: Little Three Dragons', () => {
     // 2 dragon kes, 1 dragon pair, 2 shuns
-    expectFans('z55566677 s234 p234', ['小三元', '双箭刻', '双暗刻', '喜相逢', '缺一门'])
+    expectFans('z55566677 s234 p234', ['小三元', '双暗刻', '喜相逢', '缺一门'])
   })
 
   test('Case 11: Robbing a Kong', () => {

--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -165,6 +165,8 @@ export function scoreCombination(
     }))
 
   // Helper functions
+  let addedLaoShaoFuCount = 0
+
   const addFan = (name: string, score: number, countToAdd: number = 1) => {
     const existing = fans.find((f) => f.name === name)
     if (existing) {
@@ -754,6 +756,7 @@ export function scoreCombination(
       }
     }
     if (laoShaoFuCount > 0) {
+      addedLaoShaoFuCount = laoShaoFuCount
       addFan('老少副', 1, laoShaoFuCount)
     }
 
@@ -1042,11 +1045,11 @@ export function scoreCombination(
   }
   if (hasFan('清龙')) {
     removeFan('连六', 2)
-    removeFan('老少副')
+    if (addedLaoShaoFuCount === 0) removeFan('老少副')
   }
   if (hasFan('花龙')) {
     removeFan('喜相逢')
-    removeFan('老少副')
+    if (addedLaoShaoFuCount === 0) removeFan('老少副')
   }
   if (hasFan('推不倒')) {
     removeFan('缺一门')

--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -697,8 +697,8 @@ export function scoreCombination(
     shunKeysCounts.forEach((c) => {
       if (c >= 2) yiBanGaoCount += Math.floor(c / 2)
     })
-    if (yiBanGaoCount > 0 && !hasFan('一色三同顺') && !hasFan('一色四同顺')) {
-      addFan('一般高', 1, Math.min(2, yiBanGaoCount))
+    if (yiBanGaoCount > 0) {
+      addFan('一般高', 1, yiBanGaoCount)
     }
 
     // 喜相逢 (1) — 2 shuns, different suit, same rank
@@ -717,7 +717,7 @@ export function scoreCombination(
         }
       }
     }
-    if (xiXiangFengCount > 0 && !hasFan('三色三同顺')) addFan('喜相逢', 1, Math.min(2, xiXiangFengCount))
+    if (xiXiangFengCount > 0) addFan('喜相逢', 1, xiXiangFengCount)
 
     // 连六 (1) — same suit, 2 shuns differ by 3
     const usedLL = new Set<number>()
@@ -735,7 +735,7 @@ export function scoreCombination(
         }
       }
     }
-    if (lianLiuCount > 0 && !hasFan('清龙')) addFan('连六', 1, Math.min(2, lianLiuCount))
+    if (lianLiuCount > 0) addFan('连六', 1, lianLiuCount)
 
     // 老少副 (1) — same suit, 123 and 789
     const usedLS = new Set<number>()
@@ -753,27 +753,54 @@ export function scoreCombination(
         }
       }
     }
-    if (laoShaoFuCount > 0 && !hasFan('清龙') && !hasFan('花龙')) addFan('老少副', 1, Math.min(2, laoShaoFuCount))
+    if (laoShaoFuCount > 0) {
+      addFan('老少副', 1, laoShaoFuCount)
+    }
 
     // 幺九刻 (1)
     let yaoJiuKeCount = keMelds.filter((m) => m.tiles[0].isTerminalOrHonor).length
     if (hasFan('字一色') || hasFan('清幺九') || hasFan('混幺九')) {
       yaoJiuKeCount = 0
     } else {
-      const hasWindGroupFan = hasFan('大四喜') || hasFan('小四喜') || hasFan('三风刻')
-      if (hasFan('大四喜')) yaoJiuKeCount -= 4
-      else if (hasFan('小四喜')) yaoJiuKeCount -= 3
-      else if (hasFan('三风刻')) yaoJiuKeCount -= 3
-
-      if (hasFan('大三元')) yaoJiuKeCount -= 3
-      else if (hasFan('小三元')) yaoJiuKeCount -= 2
-
-      if (!hasWindGroupFan) {
-        if (hasFan('双箭刻')) yaoJiuKeCount -= 2
-        else if (hasFan('箭刻')) yaoJiuKeCount -= 1
-        if (hasFan('圈风刻')) yaoJiuKeCount -= 1
-        if (hasFan('门风刻')) yaoJiuKeCount -= 1
+      // Count how many unique honor pungs are used by "higher" honor-based fans
+      const specialHonors = new Set<string>()
+      
+      // Wind pungs
+      if (hasFan('大四喜')) {
+        specialHonors.add('z1'); specialHonors.add('z2'); specialHonors.add('z3'); specialHonors.add('z4')
+      } else if (hasFan('小四喜')) {
+        // Find which 3 winds are pungs
+        keMelds.filter(m => m.tiles[0].isWind).forEach(m => specialHonors.add(m.tiles[0].toString()))
+      } else if (hasFan('三风刻')) {
+        keMelds.filter(m => m.tiles[0].isWind).forEach(m => specialHonors.add(m.tiles[0].toString()))
+      } else {
+        if (hasFan('圈风刻')) {
+          const t = keMelds.find(m => m.tiles[0].suit === 'z' && m.tiles[0].rank === options.quanfeng)?.tiles[0]
+          if (t) specialHonors.add(t.toString())
+        }
+        if (hasFan('门风刻')) {
+          const t = keMelds.find(m => m.tiles[0].suit === 'z' && m.tiles[0].rank === options.menfeng)?.tiles[0]
+          if (t) specialHonors.add(t.toString())
+        }
       }
+
+      // Dragon pungs
+      if (hasFan('大三元')) {
+        specialHonors.add('z5'); specialHonors.add('z6'); specialHonors.add('z7')
+      } else if (hasFan('小三元')) {
+        keMelds.filter(m => m.tiles[0].isDragon).forEach(m => specialHonors.add(m.tiles[0].toString()))
+      } else if (hasFan('双箭刻')) {
+        keMelds.filter(m => m.tiles[0].isDragon).forEach(m => specialHonors.add(m.tiles[0].toString()))
+      } else if (hasFan('箭刻')) {
+        keMelds.filter(m => m.tiles[0].isDragon).forEach(m => specialHonors.add(m.tiles[0].toString()))
+      }
+
+      // Terminal pungs (1, 9) are never "special" in the sense of being covered by wind/dragon fans
+      // But we only want to subtract the honor pungs that were already counted.
+      const terminalKeCount = keMelds.filter(m => m.tiles[0].isTerminal).length
+      const honorKeCount = keMelds.filter(m => m.tiles[0].isHonor).length
+      
+      yaoJiuKeCount = terminalKeCount + Math.max(0, honorKeCount - specialHonors.size)
     }
 
     if (yaoJiuKeCount > 0) {
@@ -892,10 +919,28 @@ export function scoreCombination(
   // =====================================================================
   if (hasFan('大四喜')) {
     removeFan('三风刻')
+    removeFan('圈风刻')
+    removeFan('门风刻')
+    removeFan('幺九刻', 4)
     removeFan('碰碰和')
   }
+  if (hasFan('小四喜')) {
+    removeFan('三风刻')
+    removeFan('幺九刻', 3)
+  }
+  if (hasFan('三风刻')) {
+    removeFan('圈风刻')
+    removeFan('门风刻')
+    removeFan('幺九刻', 3)
+  }
   if (hasFan('大三元')) {
+    removeFan('双箭刻')
     removeFan('箭刻')
+    removeFan('幺九刻', 3)
+  }
+  if (hasFan('小三元')) {
+    removeFan('箭刻')
+    removeFan('幺九刻', 2)
   }
   if (hasFan('九莲宝灯')) {
     removeFan('清一色')

--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -165,8 +165,6 @@ export function scoreCombination(
     }))
 
   // Helper functions
-  let addedLaoShaoFuCount = 0
-
   const addFan = (name: string, score: number, countToAdd: number = 1) => {
     const existing = fans.find((f) => f.name === name)
     if (existing) {
@@ -756,7 +754,6 @@ export function scoreCombination(
       }
     }
     if (laoShaoFuCount > 0) {
-      addedLaoShaoFuCount = laoShaoFuCount
       addFan('老少副', 1, laoShaoFuCount)
     }
 
@@ -1045,11 +1042,11 @@ export function scoreCombination(
   }
   if (hasFan('清龙')) {
     removeFan('连六', 2)
-    if (addedLaoShaoFuCount === 0) removeFan('老少副')
+    removeFan('老少副')
   }
   if (hasFan('花龙')) {
     removeFan('喜相逢')
-    if (addedLaoShaoFuCount === 0) removeFan('老少副')
+    removeFan('老少副')
   }
   if (hasFan('推不倒')) {
     removeFan('缺一门')

--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -764,42 +764,47 @@ export function scoreCombination(
     } else {
       // Count how many unique honor pungs are used by "higher" honor-based fans
       const specialHonors = new Set<string>()
-      
+
       // Wind pungs
       if (hasFan('大四喜')) {
-        specialHonors.add('z1'); specialHonors.add('z2'); specialHonors.add('z3'); specialHonors.add('z4')
+        specialHonors.add('z1')
+        specialHonors.add('z2')
+        specialHonors.add('z3')
+        specialHonors.add('z4')
       } else if (hasFan('小四喜')) {
         // Find which 3 winds are pungs
-        keMelds.filter(m => m.tiles[0].isWind).forEach(m => specialHonors.add(m.tiles[0].toString()))
+        keMelds.filter((m) => m.tiles[0].isWind).forEach((m) => specialHonors.add(m.tiles[0].toString()))
       } else if (hasFan('三风刻')) {
-        keMelds.filter(m => m.tiles[0].isWind).forEach(m => specialHonors.add(m.tiles[0].toString()))
+        keMelds.filter((m) => m.tiles[0].isWind).forEach((m) => specialHonors.add(m.tiles[0].toString()))
       } else {
         if (hasFan('圈风刻')) {
-          const t = keMelds.find(m => m.tiles[0].suit === 'z' && m.tiles[0].rank === options.quanfeng)?.tiles[0]
+          const t = keMelds.find((m) => m.tiles[0].suit === 'z' && m.tiles[0].rank === options.quanfeng)?.tiles[0]
           if (t) specialHonors.add(t.toString())
         }
         if (hasFan('门风刻')) {
-          const t = keMelds.find(m => m.tiles[0].suit === 'z' && m.tiles[0].rank === options.menfeng)?.tiles[0]
+          const t = keMelds.find((m) => m.tiles[0].suit === 'z' && m.tiles[0].rank === options.menfeng)?.tiles[0]
           if (t) specialHonors.add(t.toString())
         }
       }
 
       // Dragon pungs
       if (hasFan('大三元')) {
-        specialHonors.add('z5'); specialHonors.add('z6'); specialHonors.add('z7')
+        specialHonors.add('z5')
+        specialHonors.add('z6')
+        specialHonors.add('z7')
       } else if (hasFan('小三元')) {
-        keMelds.filter(m => m.tiles[0].isDragon).forEach(m => specialHonors.add(m.tiles[0].toString()))
+        keMelds.filter((m) => m.tiles[0].isDragon).forEach((m) => specialHonors.add(m.tiles[0].toString()))
       } else if (hasFan('双箭刻')) {
-        keMelds.filter(m => m.tiles[0].isDragon).forEach(m => specialHonors.add(m.tiles[0].toString()))
+        keMelds.filter((m) => m.tiles[0].isDragon).forEach((m) => specialHonors.add(m.tiles[0].toString()))
       } else if (hasFan('箭刻')) {
-        keMelds.filter(m => m.tiles[0].isDragon).forEach(m => specialHonors.add(m.tiles[0].toString()))
+        keMelds.filter((m) => m.tiles[0].isDragon).forEach((m) => specialHonors.add(m.tiles[0].toString()))
       }
 
       // Terminal pungs (1, 9) are never "special" in the sense of being covered by wind/dragon fans
       // But we only want to subtract the honor pungs that were already counted.
-      const terminalKeCount = keMelds.filter(m => m.tiles[0].isTerminal).length
-      const honorKeCount = keMelds.filter(m => m.tiles[0].isHonor).length
-      
+      const terminalKeCount = keMelds.filter((m) => m.tiles[0].isTerminal).length
+      const honorKeCount = keMelds.filter((m) => m.tiles[0].isHonor).length
+
       yaoJiuKeCount = terminalKeCount + Math.max(0, honorKeCount - specialHonors.size)
     }
 

--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -926,26 +926,21 @@ export function scoreCombination(
     removeFan('三风刻')
     removeFan('圈风刻')
     removeFan('门风刻')
-    removeFan('幺九刻', 4)
     removeFan('碰碰和')
   }
   if (hasFan('小四喜')) {
     removeFan('三风刻')
-    removeFan('幺九刻', 3)
   }
   if (hasFan('三风刻')) {
     removeFan('圈风刻')
     removeFan('门风刻')
-    removeFan('幺九刻', 3)
   }
   if (hasFan('大三元')) {
     removeFan('双箭刻')
     removeFan('箭刻')
-    removeFan('幺九刻', 3)
   }
   if (hasFan('小三元')) {
     removeFan('箭刻')
-    removeFan('幺九刻', 2)
   }
   if (hasFan('九莲宝灯')) {
     removeFan('清一色')

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -235,13 +235,13 @@ const CalculatorPage: React.FC = () => {
       const rawTings = checkTing(concealedTiles, melds, { ...options, juezhang: false })
       if (rawTings.length > 0) {
         const impossibleTings = rawTings.filter((res: { tile: Tile; score: number }) => {
-          const countInHand =
+          const countInConcealed =
             concealedTiles.filter((t) => t.equals(res.tile)).length +
-            melds.reduce((acc, m) => acc + m.tiles.filter((t) => t.equals(res.tile)).length, 0)
-          return countInHand >= 1 // If I already have 1, winning on the 2nd (pair) makes 5 tiles needed for Juezhang (3 table + 2 hand)
+            melds.filter((m) => !m.isOpen).reduce((acc, m) => acc + m.tiles.filter((t) => t.equals(res.tile)).length, 0)
+          return countInConcealed >= 1
         })
         if (impossibleTings.length === rawTings.length) {
-          return `绝张错误：当前为“单调将”或类似听牌（手牌已持有所听之牌），不可能凑齐场面显现 3 张且你和第 4 张（共需 5 张）。`
+          return `绝张错误：当前听牌的手牌（立牌或暗杠）中已有所听之牌，不可能凑齐场面显现 3 张且你和第 4 张（共需 5 张，场面显现含你的副露）。`
         }
       }
     }
@@ -260,11 +260,13 @@ const CalculatorPage: React.FC = () => {
     if (currentCount === 14 && options.juezhang) {
       const lastTile = concealedTiles[concealedTiles.length - 1]
       if (lastTile) {
-        const countInHand =
+        const countInConcealed =
           concealedTiles.filter((t) => t.equals(lastTile)).length +
-          melds.reduce((acc, m) => acc + m.tiles.filter((t) => t.equals(lastTile)).length, 0)
-        if (countInHand > 1) {
-          return `绝张逻辑错误：你手牌已有 ${countInHand - 1} 张 ${getTileName(lastTile)}，场面上不可能已显现 3 张。`
+          melds.filter((m) => !m.isOpen).reduce((acc, m) => acc + m.tiles.filter((t) => t.equals(lastTile)).length, 0)
+        if (countInConcealed > 1) {
+          return `绝张逻辑错误：你立牌或暗杠中已有 ${
+            countInConcealed - 1
+          } 张 ${getTileName(lastTile)}，场面上不可能已显现 3 张（场面显现含你的副露）。`
         }
       }
     }

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -264,9 +264,9 @@ const CalculatorPage: React.FC = () => {
           concealedTiles.filter((t) => t.equals(lastTile)).length +
           melds.filter((m) => !m.isOpen).reduce((acc, m) => acc + m.tiles.filter((t) => t.equals(lastTile)).length, 0)
         if (countInConcealed > 1) {
-          return `绝张逻辑错误：你立牌或暗杠中已有 ${
-            countInConcealed - 1
-          } 张 ${getTileName(lastTile)}，场面上不可能已显现 3 张（场面显现含你的副露）。`
+          return `绝张逻辑错误：你立牌或暗杠中已有 ${countInConcealed - 1} 张 ${getTileName(
+            lastTile
+          )}，场面上不可能已显现 3 张（场面显现含你的副露）。`
         }
       }
     }

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -773,7 +773,6 @@ export default function SessionPage() {
                   </div>
                 )}
 
-
                 {isDongbei && winnerId && (
                   <div className="form-group">
                     <label>闭门</label>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -17,12 +17,11 @@ export default function SessionPage() {
   const [dealerId, setDealerId] = useState<string>('')
   const [honba, setHonba] = useState<string>('0')
   const [kyoutaku, setKyoutaku] = useState<string>('0')
-  const [isSelfDraw, setIsSelfDraw] = useState(true)
+  const [isSelfDraw, setIsSelfDraw] = useState(false)
   const [dealInPlayerId, setDealInPlayerId] = useState<string>('')
   const [bimenPlayerIds, setBimenPlayerIds] = useState<number[]>([])
   const [isRyuukyoku, setIsRyuukyoku] = useState(false)
   const [tenpaiPlayerIds, setTenpaiPlayerIds] = useState<number[]>([])
-  const [isCalcOpen, setIsCalcOpen] = useState(false)
   const [calcResetCount, setCalcResetCount] = useState(0)
   const [submitting, setSubmitting] = useState(false)
   const [winHand, setWinHand] = useState<string>('')
@@ -72,7 +71,7 @@ export default function SessionPage() {
     setFan('')
     setFu('')
     setBimenPlayerIds([])
-    setIsSelfDraw(true)
+    setIsSelfDraw(false)
     setDealInPlayerId('')
     setIsRyuukyoku(false)
     setTenpaiPlayerIds([])
@@ -89,13 +88,13 @@ export default function SessionPage() {
     if (winnerId === pid) {
       setWinnerId('')
       setDealInPlayerId('')
-      setIsSelfDraw(true)
+      setIsSelfDraw(false)
     } else if (dealInPlayerId === pid) {
       setDealInPlayerId('')
-      setIsSelfDraw(true)
+      setIsSelfDraw(false)
     } else if (!winnerId) {
       setWinnerId(pid)
-      setIsSelfDraw(true)
+      setIsSelfDraw(false)
     } else {
       setDealInPlayerId(pid)
       setIsSelfDraw(false)
@@ -698,59 +697,6 @@ export default function SessionPage() {
                   </div>
                 )}
 
-                {!isRiichi && isGuobiao && (
-                  <div className="form-group">
-                    <label>
-                      分数
-                      {gbWinds && (
-                        <div className="wind-selector-mini">
-                          {[1, 2, 3, 4].map((w) => (
-                            <button
-                              key={w}
-                              type="button"
-                              className={`wind-chip ${gbWinds.quanfeng === w ? 'active' : ''}`}
-                              onClick={() => setManualQuanfeng(w)}
-                            >
-                              {['东', '南', '西', '北'][w - 1]}
-                            </button>
-                          ))}
-                          <span className="hand-num-info">第{((gbWinds.handIdx - 1) % 4) + 1}局</span>
-                        </div>
-                      )}
-                    </label>
-                    <div className="score-input-row">
-                      <input
-                        type="number"
-                        value={score}
-                        onChange={(e) => setScore(e.target.value)}
-                        placeholder="输入分数"
-                        min="8"
-                      />
-                      <button
-                        className={`btn btn-small calc-trigger-btn ${isCalcOpen ? 'btn-primary' : 'btn-accent'}`}
-                        onClick={() => setIsCalcOpen((prev) => !prev)}
-                      >
-                        {isCalcOpen ? '收起算番' : '算番器'}
-                      </button>
-                    </div>
-                    {isCalcOpen && (
-                      <div className="inline-calc-wrapper">
-                        <GuobiaoCalculator
-                          onSelectScore={handleCalcScoreSelect}
-                          initialOptions={{
-                            quanfeng: gbWinds?.quanfeng || 1,
-                            menfeng: winnerMenfeng,
-                          }}
-                          resetTrigger={calcResetCount}
-                          isSelfDraw={isSelfDraw}
-                          onIsSelfDrawChange={setIsSelfDraw}
-                          onClose={() => setIsCalcOpen(false)}
-                        />
-                      </div>
-                    )}
-                  </div>
-                )}
-
                 <div className="form-group full-width">
                   <label>胜负选择</label>
                   <div className="quick-win-row">
@@ -781,6 +727,52 @@ export default function SessionPage() {
                     </button>
                   </div>
                 </div>
+
+                {!isRiichi && isGuobiao && (
+                  <div className="form-group">
+                    <label>
+                      分数
+                      {gbWinds && (
+                        <div className="wind-selector-mini">
+                          {[1, 2, 3, 4].map((w) => (
+                            <button
+                              key={w}
+                              type="button"
+                              className={`wind-chip ${gbWinds.quanfeng === w ? 'active' : ''}`}
+                              onClick={() => setManualQuanfeng(w)}
+                            >
+                              {['东', '南', '西', '北'][w - 1]}
+                            </button>
+                          ))}
+                          <span className="hand-num-info">第{((gbWinds.handIdx - 1) % 4) + 1}局</span>
+                        </div>
+                      )}
+                    </label>
+                    <div className="score-input-row">
+                      <input
+                        type="number"
+                        value={score}
+                        onChange={(e) => setScore(e.target.value)}
+                        placeholder="输入分数"
+                        min="8"
+                      />
+                    </div>
+                    <div className="inline-calc-wrapper">
+                      <GuobiaoCalculator
+                        onSelectScore={handleCalcScoreSelect}
+                        initialOptions={{
+                          quanfeng: gbWinds?.quanfeng || 1,
+                          menfeng: winnerMenfeng,
+                        }}
+                        resetTrigger={calcResetCount}
+                        isSelfDraw={isSelfDraw}
+                        onIsSelfDrawChange={setIsSelfDraw}
+                        onClose={() => {}}
+                      />
+                    </div>
+                  </div>
+                )}
+
 
                 {isDongbei && winnerId && (
                   <div className="form-group">

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -759,6 +759,7 @@ export default function SessionPage() {
                     </div>
                     <div className="inline-calc-wrapper">
                       <GuobiaoCalculator
+                        key={`${gbWinds?.quanfeng || 1}-${winnerMenfeng}`}
                         onSelectScore={handleCalcScoreSelect}
                         initialOptions={{
                           quanfeng: gbWinds?.quanfeng || 1,


### PR DESCRIPTION
This PR addresses multiple issues in the Guobiao Mahjong calculator:
1. **UI Layout**: Improved player selection layout with a 2-column grid to prevent name overflow.
2. **Scoring Logic**:
   - Fixed 'Lao-Shao-Fu' logic to correctly count multiple sets and allow additivity with Pure/Mixed Straights.
   - Fixed 'He-Jue-Zhang' validation to correctly count tiles in exposed melds.
   - Fixed Wind scoring to correctly handle cases where a pung is both Seat and Prevalent wind, preventing over-subtraction of 'Yao-Jiu-Ke'.
3. **Exclusions**: Added missing 'removeFan' rules for high-tier honor fans (Big/Small Four Winds, Big Three Dragons, etc.).
4. **Tests**: Added a comprehensive test suite in \ugfix.test.ts\ for all fixed scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Corrected Guobiao scoring so multiple fan counts and wind/dragon exclusions compute correctly.
  - Refined juezhang validation to ignore open melds when assessing held tiles.

* **UI Improvements**
  - Quick Win Selection redesigned into a two-column layout with adjusted button sizing and spanning behavior.
  - Default win-type set to non-self-draw; quick-win controls moved earlier and always visible.
  - Guobiao calculator integrated inline with auto-filled winds and simplified interaction.

* **Tests**
  - Added and updated Guobiao Vitest cases to reflect corrected scoring and expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->