### PR TITLE
fix: misc UI and achievement system fixes

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/model/Player.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Player.java
@@ -73,4 +73,8 @@ public class Player {
   public String getDisplayName() {
     return firstName + " " + lastName;
   }
+
+  public boolean isBot() {
+    return "BOT".equals(this.userName);
+  }
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -734,7 +734,9 @@ public class GameService {
     }
 
     // Process Fan Discoveries (GUOBIAO only, skip BOT winners)
-    if (winnerId != null && fanDetails != null && !fanDetails.isBlank()
+    if (winnerId != null
+        && fanDetails != null
+        && !fanDetails.isBlank()
         && session.getGameMode() == GameMode.GUOBIAO) {
       Player winner = playerRepo.findById(winnerId).orElse(null);
       if (winner != null && !winner.isBot()) {

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -86,9 +86,11 @@ public class GameService {
 
       for (Round round : rounds) {
         if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
+        // Fan discoveries only apply to GUOBIAO mode
+        if (round.getGameSession().getGameMode() != GameMode.GUOBIAO) continue;
         Player winner =
             playerRepo.findById(java.util.Objects.requireNonNull(round.getWinnerId())).orElse(null);
-        if (winner == null) continue;
+        if (winner == null || winner.isBot()) continue;
 
         String season = getSeasonString(round.getGameSession().getCreatedAt());
         String[] parts = round.getFanDetails().split(",\\s*");
@@ -628,6 +630,7 @@ public class GameService {
     }
 
     return players.stream()
+        .filter(p -> !p.isBot())
         .map(
             p -> {
               PlayerStatsResponse stat = new PlayerStatsResponse();
@@ -730,10 +733,11 @@ public class GameService {
       roundScoreRepo.save(rs);
     }
 
-    // Process Fan Discoveries
-    if (winnerId != null && fanDetails != null && !fanDetails.isBlank()) {
+    // Process Fan Discoveries (GUOBIAO only, skip BOT winners)
+    if (winnerId != null && fanDetails != null && !fanDetails.isBlank()
+        && session.getGameMode() == GameMode.GUOBIAO) {
       Player winner = playerRepo.findById(winnerId).orElse(null);
-      if (winner != null) {
+      if (winner != null && !winner.isBot()) {
         String season = getSeasonString(session.getCreatedAt());
         String[] parts = fanDetails.split(",\\s*");
         for (String p : parts) {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1633,7 +1633,7 @@ tr:hover td {
 .fan-item-example {
   position: relative;
   margin-top: 24px;
-  padding: 20px 10px 10px 10px;
+  padding: 28px 10px 10px 10px;
   display: flex;
   flex-wrap: nowrap;
   column-gap: 4px;
@@ -1641,6 +1641,7 @@ tr:hover td {
   border-radius: 8px;
   align-items: center;
   overflow-x: auto;
+  overflow-y: visible;
   border: 1px solid rgba(0, 0, 0, 0.05);
   width: 100%;
 }
@@ -2337,7 +2338,7 @@ tr:hover td {
 
 .example-hint {
   position: absolute;
-  top: -12px;
+  top: 6px;
   right: 12px;
   font-size: 0.8rem;
   background: #069494;

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -26,11 +26,13 @@ const FanTablePage: React.FC = () => {
     fetchActiveSeasons()
       .then((data) => {
         if (!mounted) return
-        const list = data.map((s) => ({
-          year: s.year,
-          month: s.month,
-          label: getSeasonLabel(s.year, s.month),
-        }))
+        const list = data
+          .map((s) => ({
+            year: s.year,
+            month: s.month,
+            label: getSeasonLabel(s.year, s.month),
+          }))
+          .sort((a, b) => b.year - a.year || b.month - a.month)
         setSeasons(list)
         if (list.length > 0) {
           setSeasonKey((prev) =>
@@ -49,13 +51,17 @@ const FanTablePage: React.FC = () => {
 
   // Load selected season discoveries
   useEffect(() => {
-    if (seasonKey === 'all') {
-      setDiscoveries([])
-      return
-    }
     const controller = new AbortController()
-    const [y, m] = seasonKey.split('-').map(Number)
-    fetchFanDiscoveries(y, m, controller.signal)
+    let year: number | undefined
+    let month: number | undefined
+
+    if (seasonKey !== 'all') {
+      const [y, m] = seasonKey.split('-').map(Number)
+      year = y
+      month = m
+    }
+
+    fetchFanDiscoveries(year, month, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) setDiscoveries(data)
       })

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -18,9 +18,7 @@ const FanTablePage: React.FC = () => {
   // Previous season discoveries (fallback when current season has no record yet)
   const [prevDiscoveries, setPrevDiscoveries] = useState<FanDiscovery[]>([])
   const [seasons, setSeasons] = useState<Season[]>([])
-  const [seasonKey, setSeasonKey] = useState<string>(
-    `${currentSeason.year}-${currentSeason.month}`
-  )
+  const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.month}`)
 
   // Load active seasons from backend (same as StatsPage)
   useEffect(() => {
@@ -36,9 +34,7 @@ const FanTablePage: React.FC = () => {
         setSeasons(list)
         if (list.length > 0) {
           setSeasonKey((prev) =>
-            list.some((s) => `${s.year}-${s.month}` === prev)
-              ? prev
-              : `${list[0].year}-${list[0].month}`
+            list.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${list[0].year}-${list[0].month}`
           )
         }
       })
@@ -71,16 +67,13 @@ const FanTablePage: React.FC = () => {
 
   // Load previous season discoveries as fallback (only when viewing current season)
   useEffect(() => {
-    const isCurrentSeason =
-      seasonKey === `${currentSeason.year}-${currentSeason.month}`
+    const isCurrentSeason = seasonKey === `${currentSeason.year}-${currentSeason.month}`
     if (!isCurrentSeason) {
       setPrevDiscoveries([])
       return
     }
     // Find the season just before current in the list
-    const idx = seasons.findIndex(
-      (s) => `${s.year}-${s.month}` === seasonKey
-    )
+    const idx = seasons.findIndex((s) => `${s.year}-${s.month}` === seasonKey)
     const prev = seasons[idx + 1] // seasons are newest-first
     if (!prev) {
       setPrevDiscoveries([])
@@ -97,10 +90,7 @@ const FanTablePage: React.FC = () => {
     return () => controller.abort()
   }, [seasonKey, seasons])
 
-  const discoveriesMap = useMemo(
-    () => Object.fromEntries(discoveries.map((d) => [d.fanName, d])),
-    [discoveries]
-  )
+  const discoveriesMap = useMemo(() => Object.fromEntries(discoveries.map((d) => [d.fanName, d])), [discoveries])
   const prevDiscoveriesMap = useMemo(
     () => Object.fromEntries(prevDiscoveries.map((d) => [d.fanName, d])),
     [prevDiscoveries]
@@ -200,11 +190,7 @@ const FanTablePage: React.FC = () => {
             style={{ flex: 1, minWidth: '200px' }}
           />
           {activeTab === 'guobiao' && seasons.length > 0 && (
-            <select
-              value={seasonKey}
-              onChange={(e) => setSeasonKey(e.target.value)}
-              className="select-inline"
-            >
+            <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">
               {seasons.map((s: Season) => (
                 <option key={`${s.year}-${s.month}`} value={`${s.year}-${s.month}`}>
                   {s.label}
@@ -230,93 +216,91 @@ const FanTablePage: React.FC = () => {
                 const hasCurrent = !!currentDiscovery
                 const hasPrev = !hasCurrent && !!prevDiscovery
                 return (
-                <div key={item.name} className="fan-item-card">
-                  <div className="fan-item-header">
-                    <span className="fan-item-name" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                      {item.name}
-                      {hasCurrent && (
-                        <span
-                          className="badge badge-accent"
-                          style={{ fontSize: '0.7rem', padding: '2px 6px' }}
-                          title={`首位达成者: ${currentDiscovery.playerName}${
-                            (currentDiscovery.bonusRp ?? 0) > 0
-                              ? ` (+${currentDiscovery.bonusRp} RP)`
-                              : ''
-                          }`}
-                        >
-                          🏆 {currentDiscovery.playerName}
-                          {(currentDiscovery.bonusRp ?? 0) > 0 && ` (+${currentDiscovery.bonusRp})`}
-                        </span>
-                      )}
-                      {hasPrev && (
-                        <span
-                          className="badge"
-                          style={{
-                            fontSize: '0.7rem',
-                            padding: '2px 6px',
-                            background: 'var(--text-light)',
-                            color: 'white',
-                            opacity: 0.6,
-                          }}
-                          title={`上月冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
-                        >
-                          🏆 {prevDiscovery.playerName}
-                        </span>
-                      )}
-                      {item.tags?.map((tag) => (
-                        <span
-                          key={tag}
-                          className="badge badge-completed"
-                          style={{ fontSize: '0.7rem', padding: '2px 6px' }}
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </span>
-                    <span className="fan-item-score">{getFanLabel(item.fan)}</span>
-                  </div>
-                  <p className="fan-item-desc">{item.description}</p>
-                  {item.example && item.example.length > 0 && (
-                    <div className="fan-item-example">
-                      <span className="example-hint reference">理论参考</span>
-                      {item.example.split('|').map((group, groupIdx) => {
-                        const trimmedGroup = group.trim()
-                        const isGroupHighlighted = trimmedGroup.startsWith('*')
-                        const cleanGroup = isGroupHighlighted ? trimmedGroup.substring(1).trim() : trimmedGroup
-                        const tiles = cleanGroup
-                          .split(' ')
-                          .map((t) => t.trim())
-                          .filter(Boolean)
-
-                        return (
-                          <div
-                            key={groupIdx}
-                            className={`mahjong-group ${isGroupHighlighted ? 'highlighted-group' : ''}`}
+                  <div key={item.name} className="fan-item-card">
+                    <div className="fan-item-header">
+                      <span className="fan-item-name" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        {item.name}
+                        {hasCurrent && (
+                          <span
+                            className="badge badge-accent"
+                            style={{ fontSize: '0.7rem', padding: '2px 6px' }}
+                            title={`首位达成者: ${currentDiscovery.playerName}${
+                              (currentDiscovery.bonusRp ?? 0) > 0 ? ` (+${currentDiscovery.bonusRp} RP)` : ''
+                            }`}
                           >
-                            {tiles.map((tile, tileIdx) => {
-                              const isTileHighlighted = tile.startsWith('*') || tile.startsWith('^')
-                              const cleanTile = isTileHighlighted ? tile.substring(1) : tile
-                              return (
-                                <img
-                                  key={tileIdx}
-                                  src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${cleanTile}.svg`}
-                                  alt={cleanTile}
-                                  className={`mahjong-tile ${isTileHighlighted ? 'highlighted-tile' : ''}`}
-                                />
-                              )
-                            })}
-                          </div>
-                        )
-                      })}
+                            🏆 {currentDiscovery.playerName}
+                            {(currentDiscovery.bonusRp ?? 0) > 0 && ` (+${currentDiscovery.bonusRp})`}
+                          </span>
+                        )}
+                        {hasPrev && (
+                          <span
+                            className="badge"
+                            style={{
+                              fontSize: '0.7rem',
+                              padding: '2px 6px',
+                              background: 'var(--text-light)',
+                              color: 'white',
+                              opacity: 0.6,
+                            }}
+                            title={`上月冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
+                          >
+                            🏆 {prevDiscovery.playerName}
+                          </span>
+                        )}
+                        {item.tags?.map((tag) => (
+                          <span
+                            key={tag}
+                            className="badge badge-completed"
+                            style={{ fontSize: '0.7rem', padding: '2px 6px' }}
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </span>
+                      <span className="fan-item-score">{getFanLabel(item.fan)}</span>
                     </div>
-                  )}
-                  {currentDiscovery?.exampleHand && (
-                    <div className="fan-item-example-real">
-                      <MahjongHand hand={currentDiscovery.exampleHand ?? undefined} />
-                      <span className="example-hint">实战例子</span>
-                    </div>
-                  )}
-                </div>
+                    <p className="fan-item-desc">{item.description}</p>
+                    {item.example && item.example.length > 0 && (
+                      <div className="fan-item-example">
+                        <span className="example-hint reference">理论参考</span>
+                        {item.example.split('|').map((group, groupIdx) => {
+                          const trimmedGroup = group.trim()
+                          const isGroupHighlighted = trimmedGroup.startsWith('*')
+                          const cleanGroup = isGroupHighlighted ? trimmedGroup.substring(1).trim() : trimmedGroup
+                          const tiles = cleanGroup
+                            .split(' ')
+                            .map((t) => t.trim())
+                            .filter(Boolean)
+
+                          return (
+                            <div
+                              key={groupIdx}
+                              className={`mahjong-group ${isGroupHighlighted ? 'highlighted-group' : ''}`}
+                            >
+                              {tiles.map((tile, tileIdx) => {
+                                const isTileHighlighted = tile.startsWith('*') || tile.startsWith('^')
+                                const cleanTile = isTileHighlighted ? tile.substring(1) : tile
+                                return (
+                                  <img
+                                    key={tileIdx}
+                                    src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${cleanTile}.svg`}
+                                    alt={cleanTile}
+                                    className={`mahjong-tile ${isTileHighlighted ? 'highlighted-tile' : ''}`}
+                                  />
+                                )
+                              })}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
+                    {currentDiscovery?.exampleHand && (
+                      <div className="fan-item-example-real">
+                        <MahjongHand hand={currentDiscovery.exampleHand ?? undefined} />
+                        <span className="example-hint">实战例子</span>
+                      </div>
+                    )}
+                  </div>
                 )
               })}
             </div>

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -2,23 +2,61 @@ import React, { useState, useMemo, useEffect } from 'react'
 import { fanTableData, FanItem } from '../data/fanTableData'
 import { riichiFanTableData } from '../data/riichiFanTableData'
 import { shenyangFanTableData } from '../data/shenyangFanTableData'
-import { fetchFanDiscoveries } from '../api'
-import { FanDiscovery, getCurrentSeason, getAvailableSeasons, Season } from '../types'
+import { fetchFanDiscoveries, fetchActiveSeasons } from '../api'
+import { FanDiscovery, getCurrentSeason, getSeasonLabel, Season } from '../types'
 import { MahjongHand } from '../components/MahjongHand'
 
 type TabType = 'guobiao' | 'riichi' | 'shenyang'
 
+const currentSeason = getCurrentSeason()
+
 const FanTablePage: React.FC = () => {
   const [search, setSearch] = useState('')
   const [activeTab, setActiveTab] = useState<TabType>('guobiao')
+  // Current season discoveries (for the selected season key)
   const [discoveries, setDiscoveries] = useState<FanDiscovery[]>([])
-  const [seasonKey, setSeasonKey] = useState<string>(() => {
-    const s = getCurrentSeason()
-    return `${s.year}-${s.month}`
-  })
-  const seasons = useMemo(() => getAvailableSeasons(2024), [])
+  // Previous season discoveries (fallback when current season has no record yet)
+  const [prevDiscoveries, setPrevDiscoveries] = useState<FanDiscovery[]>([])
+  const [seasons, setSeasons] = useState<Season[]>([])
+  const [seasonKey, setSeasonKey] = useState<string>(
+    `${currentSeason.year}-${currentSeason.month}`
+  )
 
+  // Load active seasons from backend (same as StatsPage)
   useEffect(() => {
+    let mounted = true
+    fetchActiveSeasons()
+      .then((data) => {
+        if (!mounted) return
+        const list = data.map((s) => ({
+          year: s.year,
+          month: s.month,
+          label: getSeasonLabel(s.year, s.month),
+        }))
+        setSeasons(list)
+        if (list.length > 0) {
+          setSeasonKey((prev) =>
+            list.some((s) => `${s.year}-${s.month}` === prev)
+              ? prev
+              : `${list[0].year}-${list[0].month}`
+          )
+        }
+      })
+      .catch((e) => {
+        if (!mounted) return
+        console.error(e)
+      })
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  // Load selected season discoveries
+  useEffect(() => {
+    if (seasonKey === 'all') {
+      setDiscoveries([])
+      return
+    }
     const controller = new AbortController()
     const [y, m] = seasonKey.split('-').map(Number)
     fetchFanDiscoveries(y, m, controller.signal)
@@ -31,9 +69,42 @@ const FanTablePage: React.FC = () => {
     return () => controller.abort()
   }, [seasonKey])
 
-  const discoveriesMap = useMemo(() => {
-    return Object.fromEntries(discoveries.map((d) => [d.fanName, d]))
-  }, [discoveries])
+  // Load previous season discoveries as fallback (only when viewing current season)
+  useEffect(() => {
+    const isCurrentSeason =
+      seasonKey === `${currentSeason.year}-${currentSeason.month}`
+    if (!isCurrentSeason) {
+      setPrevDiscoveries([])
+      return
+    }
+    // Find the season just before current in the list
+    const idx = seasons.findIndex(
+      (s) => `${s.year}-${s.month}` === seasonKey
+    )
+    const prev = seasons[idx + 1] // seasons are newest-first
+    if (!prev) {
+      setPrevDiscoveries([])
+      return
+    }
+    const controller = new AbortController()
+    fetchFanDiscoveries(prev.year, prev.month, controller.signal)
+      .then((data) => {
+        if (!controller.signal.aborted) setPrevDiscoveries(data)
+      })
+      .catch((err) => {
+        if (err.name !== 'AbortError') console.error(err)
+      })
+    return () => controller.abort()
+  }, [seasonKey, seasons])
+
+  const discoveriesMap = useMemo(
+    () => Object.fromEntries(discoveries.map((d) => [d.fanName, d])),
+    [discoveries]
+  )
+  const prevDiscoveriesMap = useMemo(
+    () => Object.fromEntries(prevDiscoveries.map((d) => [d.fanName, d])),
+    [prevDiscoveries]
+  )
 
   const filteredFanTable = useMemo(() => {
     let data
@@ -108,19 +179,19 @@ const FanTablePage: React.FC = () => {
               className={`tab-btn ${activeTab === 'riichi' ? 'tab-active' : ''}`}
               onClick={() => setActiveTab('riichi')}
             >
-              雀魂日麻
+              立直麻将
             </button>
             <button
               className={`tab-btn ${activeTab === 'shenyang' ? 'tab-active' : ''}`}
               onClick={() => setActiveTab('shenyang')}
             >
-              沈阳穷胡
+              东北麻将
             </button>
           </div>
         </div>
         <p style={{ color: 'var(--text-light)', marginBottom: '24px' }}>{getSubtitle()}</p>
 
-        <div style={{ display: 'flex', gap: '16px', marginBottom: '24px', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', gap: '16px', marginBottom: '24px', flexWrap: 'wrap', alignItems: 'center' }}>
           <input
             type="text"
             placeholder="搜索番名、分数或描述..."
@@ -128,13 +199,20 @@ const FanTablePage: React.FC = () => {
             onChange={(e) => setSearch(e.target.value)}
             style={{ flex: 1, minWidth: '200px' }}
           />
-          <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} style={{ width: '150px' }}>
-            {seasons.map((s: Season) => (
-              <option key={`${s.year}-${s.month}`} value={`${s.year}-${s.month}`}>
-                {s.label}
-              </option>
-            ))}
-          </select>
+          {activeTab === 'guobiao' && seasons.length > 0 && (
+            <select
+              value={seasonKey}
+              onChange={(e) => setSeasonKey(e.target.value)}
+              className="select-inline"
+            >
+              {seasons.map((s: Season) => (
+                <option key={`${s.year}-${s.month}`} value={`${s.year}-${s.month}`}>
+                  {s.label}
+                </option>
+              ))}
+              <option value="all">全部赛季</option>
+            </select>
+          )}
         </div>
 
         {fans.length === 0 && (
@@ -145,23 +223,44 @@ const FanTablePage: React.FC = () => {
           <div key={fan} className="fan-group">
             <h3 className="fan-group-title">{getFanLabel(fan)}</h3>
             <div className="fan-item-grid">
-              {groupedAndSortedFans[fan].map((item) => (
+              {groupedAndSortedFans[fan].map((item) => {
+                // Badge logic: only for guobiao tab
+                const currentDiscovery = activeTab === 'guobiao' ? discoveriesMap[item.name] : null
+                const prevDiscovery = activeTab === 'guobiao' ? prevDiscoveriesMap[item.name] : null
+                const hasCurrent = !!currentDiscovery
+                const hasPrev = !hasCurrent && !!prevDiscovery
+                return (
                 <div key={item.name} className="fan-item-card">
                   <div className="fan-item-header">
                     <span className="fan-item-name" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                       {item.name}
-                      {discoveriesMap[item.name] && (
+                      {hasCurrent && (
                         <span
                           className="badge badge-accent"
                           style={{ fontSize: '0.7rem', padding: '2px 6px' }}
-                          title={`首位达成者: ${discoveriesMap[item.name].playerName}${
-                            (discoveriesMap[item.name].bonusRp ?? 0) > 0
-                              ? ` (+${discoveriesMap[item.name].bonusRp} RP)`
+                          title={`首位达成者: ${currentDiscovery.playerName}${
+                            (currentDiscovery.bonusRp ?? 0) > 0
+                              ? ` (+${currentDiscovery.bonusRp} RP)`
                               : ''
                           }`}
                         >
-                          🏆 {discoveriesMap[item.name].playerName}
-                          {(discoveriesMap[item.name].bonusRp ?? 0) > 0 && ` (+${discoveriesMap[item.name].bonusRp})`}
+                          🏆 {currentDiscovery.playerName}
+                          {(currentDiscovery.bonusRp ?? 0) > 0 && ` (+${currentDiscovery.bonusRp})`}
+                        </span>
+                      )}
+                      {hasPrev && (
+                        <span
+                          className="badge"
+                          style={{
+                            fontSize: '0.7rem',
+                            padding: '2px 6px',
+                            background: 'var(--text-light)',
+                            color: 'white',
+                            opacity: 0.6,
+                          }}
+                          title={`上月冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
+                        >
+                          🏆 {prevDiscovery.playerName}
                         </span>
                       )}
                       {item.tags?.map((tag) => (
@@ -211,14 +310,15 @@ const FanTablePage: React.FC = () => {
                       })}
                     </div>
                   )}
-                  {discoveriesMap[item.name]?.exampleHand && (
+                  {currentDiscovery?.exampleHand && (
                     <div className="fan-item-example-real">
-                      <MahjongHand hand={discoveriesMap[item.name].exampleHand ?? undefined} />
+                      <MahjongHand hand={currentDiscovery.exampleHand ?? undefined} />
                       <span className="example-hint">实战例子</span>
                     </div>
                   )}
                 </div>
-              ))}
+                )
+              })}
             </div>
           </div>
         ))}

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -75,14 +75,18 @@ export default function NewSessionPage() {
 
       <div className="form-group">
         <label>游戏模式</label>
-        <select value={gameMode} onChange={(e) => setGameMode(e.target.value as GameModeKey)}>
-          <option value="">-- 选择游戏模式 --</option>
+        <div className="tab-bar" style={{ marginTop: 8 }}>
           {GAME_MODES.map((m) => (
-            <option key={m.key} value={m.key}>
+            <button
+              key={m.key}
+              className={`tab-btn${gameMode === m.key ? ' tab-active' : ''}`}
+              onClick={() => setGameMode(m.key)}
+              type="button"
+            >
               {m.label}
-            </option>
+            </button>
           ))}
-        </select>
+        </div>
       </div>
 
       <div className="form-group">

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -75,13 +75,15 @@ export default function NewSessionPage() {
 
       <div className="form-group">
         <label>游戏模式</label>
-        <div className="tab-bar" style={{ marginTop: 8 }}>
+        <div className="tab-bar" style={{ marginTop: 8 }} role="tablist" aria-label="游戏模式选择">
           {GAME_MODES.map((m) => (
             <button
               key={m.key}
               className={`tab-btn${gameMode === m.key ? ' tab-active' : ''}`}
               onClick={() => setGameMode(m.key)}
               type="button"
+              role="tab"
+              aria-selected={gameMode === m.key}
             >
               {m.label}
             </button>


### PR DESCRIPTION
## Changes

### UI Fixes
- 番表 tab 名称统一：雀魂日麻 -> 立直麻将，沈阳穷胡 -> 东北麻将（与新建游戏模式选择一致）
- 理论参考徽章裁剪修复：overflow-x: auto 父容器会裁剪 top: -12px 的绝对定位子元素，改为将徽章置于容器内部（top: 6px，增大 padding-top）
- 游戏模式选择改为按钮组：新建游戏页面的模式下拉菜单改为与番表 tab 风格一致的按钮

### Achievement System Fixes
- 新增 Player.isBot()：精确匹配 userName == "BOT" 的玩家为机器人
- BOT 排除：BOT 玩家不计入冠名成就、不出现在排行榜
- 冠名仅限国标：Fan Discovery 系统在历史初始化和实时记录两处均加 GameMode.GUOBIAO 过滤
- 番表赛季选择器：改为 fetchActiveSeasons() 动态拉取（与统计页逻辑一致），加全部赛季选项，非国标 tab 隐藏选择器
- 旧赛季冠名灰色降级：当前赛季无冠名时，自动拉取上月数据以灰色显示，tooltip 提示上月冠名本月尚未被发现


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Season selector now loads active seasons from the server, includes an "All seasons" option, and powers badges showing current-then-previous season discoveries; example hands show only current-season data.
  * Game mode selection switched to a tab-style button interface for easier use.

* **Bug Fixes**
  * Bot players are excluded from player statistics and from fan-discovery tracking.
  * Improved fan example layout and hint positioning for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->