### PR TITLE
feat: transform HomePage into a dynamic game hub

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/model/Player.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Player.java
@@ -22,6 +22,9 @@ public class Player {
   @Column(nullable = false)
   private LocalDateTime createdAt = LocalDateTime.now();
 
+  @Column(nullable = false, columnDefinition = "boolean default false")
+  private boolean bot = false;
+
   public Player() {}
 
   public Player(String userName, String firstName, String lastName) {
@@ -75,6 +78,10 @@ public class Player {
   }
 
   public boolean isBot() {
-    return "BOT".equals(this.userName);
+    return bot;
+  }
+
+  public void setBot(boolean bot) {
+    this.bot = bot;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/model/Player.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Player.java
@@ -78,7 +78,7 @@ public class Player {
   }
 
   public boolean isBot() {
-    return bot;
+    return bot || "BOT".equals(this.userName);
   }
 
   public void setBot(boolean bot) {

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -171,6 +171,9 @@ public class GameService {
   }
 
   public Player createPlayer(CreatePlayerRequest request) {
+    if ("BOT".equalsIgnoreCase(request.getUserName())) {
+      throw new IllegalArgumentException("Username 'BOT' is reserved");
+    }
     if (playerRepo.existsByUserName(request.getUserName())) {
       log.warn("Duplicate userName '{}'", request.getUserName());
       throw new IllegalArgumentException(
@@ -562,21 +565,23 @@ public class GameService {
                         || (!s.getCreatedAt().isBefore(start) && s.getCreatedAt().isBefore(end)))
             .toList();
 
-    // Add Fan Discovery Bonuses
-    if (hasDateRange) {
-      String season = getSeasonString(start);
-      List<FanDiscovery> discoveries = fanDiscoveryRepo.findBySeason(season);
-      for (FanDiscovery fd : discoveries) {
-        if (fd.getBonusRp() > 0) {
-          totalBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
+    // Add Fan Discovery Bonuses (GUOBIAO only)
+    if (gameMode == null || gameMode == GameMode.GUOBIAO) {
+      if (hasDateRange) {
+        String season = getSeasonString(start);
+        List<FanDiscovery> discoveries = fanDiscoveryRepo.findBySeason(season);
+        for (FanDiscovery fd : discoveries) {
+          if (fd.getBonusRp() > 0) {
+            totalBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
+          }
         }
-      }
-    } else {
-      // All-time: Sum bonuses from all seasons
-      List<FanDiscovery> allDiscoveries = fanDiscoveryRepo.findAll();
-      for (FanDiscovery fd : allDiscoveries) {
-        if (fd.getBonusRp() > 0) {
-          totalBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
+      } else {
+        // All-time: Sum bonuses from all seasons
+        List<FanDiscovery> allDiscoveries = fanDiscoveryRepo.findAll();
+        for (FanDiscovery fd : allDiscoveries) {
+          if (fd.getBonusRp() > 0) {
+            totalBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
+          }
         }
       }
     }

--- a/ui/src/components/ActiveGameCard.tsx
+++ b/ui/src/components/ActiveGameCard.tsx
@@ -26,33 +26,40 @@ export const ActiveGameCard: React.FC<Props> = ({ session }) => {
         {[...session.players]
           .sort((a, b) => (session.totalScores[b.id] || 0) - (session.totalScores[a.id] || 0))
           .map((p, idx) => {
-            const originalIdx = session.players.findIndex(op => op.id === p.id)
+            const originalIdx = session.players.findIndex((op) => op.id === p.id)
             const seat = p.seat ?? originalIdx + 1
             const menfeng = ((seat - dealerSeat + 4) % 4) + 1
+            const isDealer = seat === dealerSeat
             return (
-            <div key={p.id} className="active-game-player-row">
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <span className={`rank-tag rank-tag-${idx + 1}`} style={{ minWidth: '24px', fontSize: '0.8rem' }}>#{idx + 1}</span>
-                <span style={{ 
-                  fontSize: '0.75rem', 
-                  padding: '1px 5px', 
-                  border: '1.5px solid var(--mj-gold)', 
-                  color: 'var(--mj-gold)',
-                  borderRadius: '4px',
-                  fontWeight: 'bold',
-                  minWidth: '24px',
-                  textAlign: 'center',
-                  display: 'inline-block',
-                  lineHeight: '1.2'
-                }}>
-                  {getWindName(menfeng)}
-                </span>
-                <span className="player-name">{p.userName}</span>
+              <div key={p.id} className="active-game-player-row">
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <span className={`rank-tag rank-tag-${idx + 1}`} style={{ minWidth: '24px', fontSize: '0.8rem' }}>
+                    #{idx + 1}
+                  </span>
+                  <span
+                    className={isDealer ? 'dealer-tag' : ''}
+                    style={{
+                      fontSize: '0.75rem',
+                      padding: '1px 5px',
+                      border: `1.5px solid ${isDealer ? 'var(--mj-red)' : 'var(--mj-gold)'}`,
+                      color: isDealer ? '#fff' : 'var(--mj-gold)',
+                      backgroundColor: isDealer ? 'var(--mj-red)' : 'transparent',
+                      borderRadius: '4px',
+                      fontWeight: 'bold',
+                      minWidth: '24px',
+                      textAlign: 'center',
+                      display: 'inline-block',
+                      lineHeight: '1.2',
+                    }}
+                  >
+                    {getWindName(menfeng)}
+                  </span>
+                  <span className="player-name">{p.userName}</span>
+                </div>
+                <span className="player-score">{session.totalScores[p.id] || 0}</span>
               </div>
-              <span className="player-score">{session.totalScores[p.id] || 0}</span>
-            </div>
-          )
-        })}
+            )
+          })}
       </div>
     </Link>
   )

--- a/ui/src/components/ActiveGameCard.tsx
+++ b/ui/src/components/ActiveGameCard.tsx
@@ -10,7 +10,8 @@ export const ActiveGameCard: React.FC<Props> = ({ session }) => {
   const getWindName = (w: number) => ['东', '南', '西', '北'][(w - 1) % 4]
 
   const nextRoundNum = session.rounds.length + 1
-  const qf = (Math.floor((nextRoundNum - 1) / 4) % 4) + 1
+  const lastRound = session.rounds.length > 0 ? session.rounds[session.rounds.length - 1] : null
+  const qf = lastRound?.prevalentWind ?? (Math.floor((nextRoundNum - 1) / 4) % 4) + 1
   const hand = ((nextRoundNum - 1) % 4) + 1
   const roundStatus = `${getWindName(qf)}${hand}`
 

--- a/ui/src/components/ActiveGameCard.tsx
+++ b/ui/src/components/ActiveGameCard.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { SessionDetail } from '../types'
+
+interface Props {
+  session: SessionDetail
+}
+
+export const ActiveGameCard: React.FC<Props> = ({ session }) => {
+  const getWindName = (w: number) => ['东', '南', '西', '北'][(w - 1) % 4]
+
+  const nextRoundNum = session.rounds.length + 1
+  const qf = (Math.floor((nextRoundNum - 1) / 4) % 4) + 1
+  const hand = ((nextRoundNum - 1) % 4) + 1
+  const roundStatus = `${getWindName(qf)}${hand}`
+
+  const dealerSeat = ((nextRoundNum - 1) % 4) + 1
+
+  return (
+    <Link to={`/session/${session.id}`} className="active-game-card">
+      <div className="active-game-header">
+        <span className="active-game-mode">{session.gameModeDisplayName}</span>
+        <span className="badge badge-progress">{roundStatus} 进行中</span>
+      </div>
+      <div className="active-game-players">
+        {[...session.players]
+          .sort((a, b) => (session.totalScores[b.id] || 0) - (session.totalScores[a.id] || 0))
+          .map((p, idx) => {
+            const originalIdx = session.players.findIndex(op => op.id === p.id)
+            const seat = p.seat ?? originalIdx + 1
+            const menfeng = ((seat - dealerSeat + 4) % 4) + 1
+            return (
+            <div key={p.id} className="active-game-player-row">
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <span className={`rank-tag rank-tag-${idx + 1}`} style={{ minWidth: '24px', fontSize: '0.8rem' }}>#{idx + 1}</span>
+                <span style={{ 
+                  fontSize: '0.75rem', 
+                  padding: '1px 5px', 
+                  border: '1.5px solid var(--mj-gold)', 
+                  color: 'var(--mj-gold)',
+                  borderRadius: '4px',
+                  fontWeight: 'bold',
+                  minWidth: '24px',
+                  textAlign: 'center',
+                  display: 'inline-block',
+                  lineHeight: '1.2'
+                }}>
+                  {getWindName(menfeng)}
+                </span>
+                <span className="player-name">{p.userName}</span>
+              </div>
+              <span className="player-score">{session.totalScores[p.id] || 0}</span>
+            </div>
+          )
+        })}
+      </div>
+    </Link>
+  )
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2367,7 +2367,6 @@ tr:hover td {
   background: var(--sol-base1);
 }
 
-
 /* HomePage Hub Styles */
 .active-games-section {
   margin-bottom: 40px;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2366,3 +2366,149 @@ tr:hover td {
 .example-hint.reference {
   background: var(--sol-base1);
 }
+
+
+/* HomePage Hub Styles */
+.active-games-section {
+  margin-bottom: 40px;
+}
+
+.active-games-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 20px;
+  margin-top: 16px;
+}
+
+.active-game-card {
+  background: white !important;
+  border-radius: var(--radius);
+  padding: 20px;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: var(--shadow);
+  transition: transform 0.2s, box-shadow 0.2s;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+}
+
+.active-game-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--mj-green);
+}
+
+.active-game-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.active-game-mode {
+  font-weight: 700;
+  color: var(--mj-green);
+  font-size: 0.9rem;
+}
+
+.active-game-title {
+  font-size: 1.2rem;
+  margin-bottom: 16px;
+  font-weight: 700;
+}
+
+.active-game-players {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex: 1;
+}
+
+.active-game-player-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px dashed var(--border);
+}
+
+.player-name {
+  font-weight: 500;
+}
+
+.player-score {
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.active-game-footer {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  text-align: right;
+}
+
+/* Hall of Fame Styles */
+.hall-of-fame-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+  margin-top: 16px;
+}
+
+.mode-rank-column {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.mode-rank-title {
+  font-size: 1.1rem;
+  border-bottom: 2px solid var(--mj-gold);
+  padding-bottom: 8px;
+  margin-bottom: 16px;
+  color: var(--mj-gold);
+  text-align: center;
+  font-weight: 800;
+}
+
+.rank-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.rank-number {
+  font-weight: 900;
+  font-size: 1.2rem;
+  width: 24px;
+}
+
+.rank-info {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+}
+
+.best-hand-summary {
+  margin-top: 20px;
+  padding: 12px;
+  background: var(--sol-base3);
+  border-radius: 8px;
+  border-left: 4px solid var(--mj-green);
+}
+
+.best-hand-label {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  display: block;
+  margin-bottom: 4px;
+}
+
+.best-hand-value {
+  font-weight: 700;
+  color: var(--mj-green);
+  font-size: 0.9rem;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2455,6 +2455,13 @@ tr:hover td {
   margin-top: 16px;
 }
 
+@media (max-width: 600px) {
+  .hall-of-fame-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}
+
 .mode-rank-column {
   background: var(--card);
   border-radius: var(--radius);

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -51,17 +51,15 @@ const FanTablePage: React.FC = () => {
 
   // Load selected season discoveries
   useEffect(() => {
-    const controller = new AbortController()
-    let year: number | undefined
-    let month: number | undefined
-
-    if (seasonKey !== 'all') {
-      const [y, m] = seasonKey.split('-').map(Number)
-      year = y
-      month = m
+    if (seasonKey === 'all') {
+      setDiscoveries([])
+      return
     }
 
-    fetchFanDiscoveries(year, month, controller.signal)
+    const controller = new AbortController()
+    const [y, m] = seasonKey.split('-').map(Number)
+
+    fetchFanDiscoveries(y, m, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) setDiscoveries(data)
       })

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -216,9 +216,11 @@ const FanTablePage: React.FC = () => {
             <h3 className="fan-group-title">{getFanLabel(fan)}</h3>
             <div className="fan-item-grid">
               {groupedAndSortedFans[fan].map((item) => {
-                // Badge logic: only for guobiao tab
-                const currentDiscovery = activeTab === 'guobiao' ? discoveriesMap[item.name] : null
-                const prevDiscovery = activeTab === 'guobiao' ? prevDiscoveriesMap[item.name] : null
+                // Badge logic: only for guobiao tab and specific season
+                const currentDiscovery =
+                  activeTab === 'guobiao' && seasonKey !== 'all' ? discoveriesMap[item.name] : null
+                const prevDiscovery =
+                  activeTab === 'guobiao' && seasonKey !== 'all' ? prevDiscoveriesMap[item.name] : null
                 const hasCurrent = !!currentDiscovery
                 const hasPrev = !hasCurrent && !!prevDiscovery
                 return (

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -1,35 +1,140 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { fetchSessions, fetchSessionDetail, fetchStats, fetchBestRounds } from '../api'
+import { GameSession, SessionDetail, PlayerStats, BestRound, GAME_MODES, getCurrentSeason } from '../types'
+import { ActiveGameCard } from '../components/ActiveGameCard'
 
 export default function HomePage() {
+  const [activeSessions, setActiveSessions] = useState<SessionDetail[]>([])
+  const [rankings, setRankings] = useState<Record<string, { top: PlayerStats[], best: BestRound | null }>>({})
+  const [loading, setLoading] = useState(true)
+
+  const currentSeason = getCurrentSeason()
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        // 1. Fetch sessions and filter for IN_PROGRESS
+        const sessions = await fetchSessions()
+        const active = sessions.filter(s => s.status === 'IN_PROGRESS')
+        
+        // 2. Fetch details for active sessions
+        const details = await Promise.all(active.map(s => fetchSessionDetail(s.id)))
+        setActiveSessions(details)
+
+        // 3. Fetch stats for each mode
+        const rankingData: Record<string, { top: PlayerStats[], best: BestRound | null }> = {}
+        
+        await Promise.all(GAME_MODES.map(async (mode) => {
+          try {
+            const stats = await fetchStats(mode.key, currentSeason.year, currentSeason.month)
+            const bestRounds = await fetchBestRounds(mode.key, currentSeason.year, currentSeason.month)
+            
+            rankingData[mode.key] = {
+              top: stats.sort((a, b) => b.totalRP - a.totalRP).slice(0, 3),
+              best: bestRounds.length > 0 ? bestRounds.sort((a, b) => (b.fanCount || 0) - (a.fanCount || 0))[0] : null
+            }
+          } catch (err) {
+            console.error(`Failed to fetch stats for ${mode.key}:`, err)
+            rankingData[mode.key] = { top: [], best: null }
+          }
+        }))
+        
+        setRankings(rankingData)
+      } catch (e) {
+        console.error('Failed to load hub data:', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadData()
+  }, [currentSeason.year, currentSeason.month])
+
+  if (loading) {
+    return (
+      <div className="empty-state">
+        <p>加载枢纽数据中...</p>
+      </div>
+    )
+  }
+
   return (
-    <div className="landing">
-      <div className="landing-hero">
-        <img src="/logo.png" alt="Mahjong Omakase" className="landing-logo" />
-        <h1 className="landing-title">Mahjong Omakase</h1>
-        <p className="landing-subtitle">Let's NB!</p>
-        <div className="landing-actions">
-          <Link to="/game" className="btn btn-accent btn-large btn-hero-shine">
-            麻将，启动!
-          </Link>
-        </div>
+    <div className="home-hub">
+      <div style={{ marginBottom: '40px', textAlign: 'center' }}>
+        <Link to="/new-session" className="btn btn-accent btn-hero-shine" style={{ 
+          display: 'inline-flex', 
+          alignItems: 'center', 
+          gap: '12px',
+          fontSize: '1.1rem', 
+          padding: '12px 24px',
+          borderRadius: '50px'
+        }}>
+          <img src="/logo-header.png" alt="" style={{ height: '24px', width: 'auto' }} />
+          麻将，启动！
+        </Link>
       </div>
 
-      <div className="landing-features">
-        <div className="feature-card">
-          <div className="feature-icon">🀄</div>
-          <h3>多种模式</h3>
-          <p>国标麻将，东北麻将，立直麻将，等。</p>
+      <div className="active-games-section">
+        <h2 style={{ marginBottom: '16px' }}>正在进行的对局</h2>
+        {activeSessions.length === 0 ? (
+          <div className="empty-state" style={{ background: 'white', borderRadius: '12px', padding: '40px', boxShadow: 'var(--shadow)' }}>
+            <p style={{ color: 'var(--text-light)', marginBottom: '12px' }}>当前没有正在进行的对局</p>
+            <Link to="/new-session" style={{ color: 'var(--mj-green)', fontWeight: 'bold', textDecoration: 'none' }}>
+              + 开启一局新游戏
+            </Link>
+          </div>
+        ) : (
+          <div className="active-games-grid">
+            {activeSessions.map(s => (
+              <ActiveGameCard key={s.id} session={s} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="rankings-section" style={{ marginTop: '48px' }}>
+        <h2 style={{ marginBottom: '16px' }}>本月荣誉殿堂</h2>
+        <div className="hall-of-fame-grid">
+          {GAME_MODES.map(mode => {
+            const data = rankings[mode.key]
+            return (
+              <div key={mode.key} className="mode-rank-column">
+                <h3 className="mode-rank-title">{mode.label}</h3>
+                <div className="rank-list">
+                  {(!data || data.top.length === 0) ? (
+                    <p className="empty-state" style={{ padding: '20px 0' }}>暂无本月排名</p>
+                  ) : (
+                    data.top.map((player, idx) => (
+                      <div key={player.playerId} className="rank-item">
+                        <span className={`rank-number rank-tag-${idx + 1}`}>#{idx + 1}</span>
+                        <div className="rank-info">
+                          <span className="player-name">{player.userName}</span>
+                          <span className="player-score">{player.totalRP.toFixed(1)} RP</span>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+                {data?.best && (
+                  <div className="best-hand-summary">
+                    <span className="best-hand-label">🏆 本月最高和牌</span>
+                    <div className="best-hand-value">
+                      {data.best.fanCount} 番 · {data.best.winnerName}
+                      <div style={{ fontSize: '0.75rem', marginTop: '4px', color: 'var(--sol-base01)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {data.best.fanDetails}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })}
         </div>
-        <div className="feature-card">
-          <div className="feature-icon">📊</div>
-          <h3>实时计分</h3>
-          <p>逐局记录分数，实时查看总分和排名。</p>
-        </div>
-        <div className="feature-card">
-          <div className="feature-icon">🏆</div>
-          <h3>排行榜</h3>
-          <p>查看历史战绩、胜率和赛季冠军。</p>
-        </div>
+      </div>
+      
+      <div style={{ marginTop: '60px', textAlign: 'center', opacity: 0.5, fontSize: '0.9rem' }}>
+        <p>© 2026 Mahjong Omakase Team · Let's NB!</p>
       </div>
     </div>
   )

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -12,7 +12,8 @@ export default function HomePage() {
   const currentSeason = getCurrentSeason()
 
   useEffect(() => {
-    let intervalId: ReturnType<typeof setInterval>
+    let timeoutId: ReturnType<typeof setTimeout>
+    let isActive = true
 
     async function loadData() {
       try {
@@ -25,7 +26,8 @@ export default function HomePage() {
         const details = settledDetails
           .filter((res): res is PromiseFulfilledResult<SessionDetail> => res.status === 'fulfilled')
           .map((res) => res.value)
-        setActiveSessions(details)
+        
+        if (isActive) setActiveSessions(details)
 
         // 3. Fetch stats for each mode
         const rankingData: Record<string, { top: PlayerStats[]; best: BestRound | null }> = {}
@@ -48,18 +50,23 @@ export default function HomePage() {
           })
         )
 
-        setRankings(rankingData)
+        if (isActive) setRankings(rankingData)
       } catch (e) {
         console.error('Failed to load hub data:', e)
       } finally {
-        setLoading(false)
+        if (isActive) {
+          setLoading(false)
+          timeoutId = setTimeout(loadData, 10000)
+        }
       }
     }
 
     loadData()
-    intervalId = setInterval(loadData, 10000) // Poll every 10 seconds
 
-    return () => clearInterval(intervalId)
+    return () => {
+      isActive = false
+      clearTimeout(timeoutId)
+    }
   }, [currentSeason.year, currentSeason.month])
 
   if (loading) {

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -26,7 +26,7 @@ export default function HomePage() {
         const details = settledDetails
           .filter((res): res is PromiseFulfilledResult<SessionDetail> => res.status === 'fulfilled')
           .map((res) => res.value)
-        
+
         if (isActive) setActiveSessions(details)
 
         // 3. Fetch stats for each mode

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -6,40 +6,48 @@ import { ActiveGameCard } from '../components/ActiveGameCard'
 
 export default function HomePage() {
   const [activeSessions, setActiveSessions] = useState<SessionDetail[]>([])
-  const [rankings, setRankings] = useState<Record<string, { top: PlayerStats[], best: BestRound | null }>>({})
+  const [rankings, setRankings] = useState<Record<string, { top: PlayerStats[]; best: BestRound | null }>>({})
   const [loading, setLoading] = useState(true)
 
   const currentSeason = getCurrentSeason()
 
   useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval>
+
     async function loadData() {
       try {
         // 1. Fetch sessions and filter for IN_PROGRESS
         const sessions = await fetchSessions()
-        const active = sessions.filter(s => s.status === 'IN_PROGRESS')
-        
-        // 2. Fetch details for active sessions
-        const details = await Promise.all(active.map(s => fetchSessionDetail(s.id)))
+        const active = sessions.filter((s) => s.status === 'IN_PROGRESS')
+
+        // 2. Fetch details for active sessions (using allSettled to prevent single failure from crashing all)
+        const settledDetails = await Promise.allSettled(active.map((s) => fetchSessionDetail(s.id)))
+        const details = settledDetails
+          .filter((res): res is PromiseFulfilledResult<SessionDetail> => res.status === 'fulfilled')
+          .map((res) => res.value)
         setActiveSessions(details)
 
         // 3. Fetch stats for each mode
-        const rankingData: Record<string, { top: PlayerStats[], best: BestRound | null }> = {}
-        
-        await Promise.all(GAME_MODES.map(async (mode) => {
-          try {
-            const stats = await fetchStats(mode.key, currentSeason.year, currentSeason.month)
-            const bestRounds = await fetchBestRounds(mode.key, currentSeason.year, currentSeason.month)
-            
-            rankingData[mode.key] = {
-              top: stats.sort((a, b) => b.totalRP - a.totalRP).slice(0, 3),
-              best: bestRounds.length > 0 ? bestRounds.sort((a, b) => (b.fanCount || 0) - (a.fanCount || 0))[0] : null
+        const rankingData: Record<string, { top: PlayerStats[]; best: BestRound | null }> = {}
+
+        await Promise.all(
+          GAME_MODES.map(async (mode) => {
+            try {
+              const stats = await fetchStats(mode.key, currentSeason.year, currentSeason.month)
+              const bestRounds = await fetchBestRounds(mode.key, currentSeason.year, currentSeason.month)
+
+              rankingData[mode.key] = {
+                top: stats.sort((a, b) => b.totalRP - a.totalRP).slice(0, 3),
+                best:
+                  bestRounds.length > 0 ? bestRounds.sort((a, b) => (b.fanCount || 0) - (a.fanCount || 0))[0] : null,
+              }
+            } catch (err) {
+              console.error(`Failed to fetch stats for ${mode.key}:`, err)
+              rankingData[mode.key] = { top: [], best: null }
             }
-          } catch (err) {
-            console.error(`Failed to fetch stats for ${mode.key}:`, err)
-            rankingData[mode.key] = { top: [], best: null }
-          }
-        }))
-        
+          })
+        )
+
         setRankings(rankingData)
       } catch (e) {
         console.error('Failed to load hub data:', e)
@@ -49,6 +57,9 @@ export default function HomePage() {
     }
 
     loadData()
+    intervalId = setInterval(loadData, 10000) // Poll every 10 seconds
+
+    return () => clearInterval(intervalId)
   }, [currentSeason.year, currentSeason.month])
 
   if (loading) {
@@ -62,14 +73,18 @@ export default function HomePage() {
   return (
     <div className="home-hub">
       <div style={{ marginBottom: '40px', textAlign: 'center' }}>
-        <Link to="/new-session" className="btn btn-accent btn-hero-shine" style={{ 
-          display: 'inline-flex', 
-          alignItems: 'center', 
-          gap: '12px',
-          fontSize: '1.1rem', 
-          padding: '12px 24px',
-          borderRadius: '50px'
-        }}>
+        <Link
+          to="/new-session"
+          className="btn btn-accent btn-hero-shine"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '12px',
+            fontSize: '1.1rem',
+            padding: '12px 24px',
+            borderRadius: '50px',
+          }}
+        >
           <img src="/logo-header.png" alt="" style={{ height: '24px', width: 'auto' }} />
           麻将，启动！
         </Link>
@@ -78,7 +93,10 @@ export default function HomePage() {
       <div className="active-games-section">
         <h2 style={{ marginBottom: '16px' }}>正在进行的对局</h2>
         {activeSessions.length === 0 ? (
-          <div className="empty-state" style={{ background: 'white', borderRadius: '12px', padding: '40px', boxShadow: 'var(--shadow)' }}>
+          <div
+            className="empty-state"
+            style={{ background: 'white', borderRadius: '12px', padding: '40px', boxShadow: 'var(--shadow)' }}
+          >
             <p style={{ color: 'var(--text-light)', marginBottom: '12px' }}>当前没有正在进行的对局</p>
             <Link to="/new-session" style={{ color: 'var(--mj-green)', fontWeight: 'bold', textDecoration: 'none' }}>
               + 开启一局新游戏
@@ -86,7 +104,7 @@ export default function HomePage() {
           </div>
         ) : (
           <div className="active-games-grid">
-            {activeSessions.map(s => (
+            {activeSessions.map((s) => (
               <ActiveGameCard key={s.id} session={s} />
             ))}
           </div>
@@ -96,14 +114,16 @@ export default function HomePage() {
       <div className="rankings-section" style={{ marginTop: '48px' }}>
         <h2 style={{ marginBottom: '16px' }}>本月荣誉殿堂</h2>
         <div className="hall-of-fame-grid">
-          {GAME_MODES.map(mode => {
+          {GAME_MODES.map((mode) => {
             const data = rankings[mode.key]
             return (
               <div key={mode.key} className="mode-rank-column">
                 <h3 className="mode-rank-title">{mode.label}</h3>
                 <div className="rank-list">
-                  {(!data || data.top.length === 0) ? (
-                    <p className="empty-state" style={{ padding: '20px 0' }}>暂无本月排名</p>
+                  {!data || data.top.length === 0 ? (
+                    <p className="empty-state" style={{ padding: '20px 0' }}>
+                      暂无本月排名
+                    </p>
                   ) : (
                     data.top.map((player, idx) => (
                       <div key={player.playerId} className="rank-item">
@@ -121,7 +141,16 @@ export default function HomePage() {
                     <span className="best-hand-label">🏆 本月最高和牌</span>
                     <div className="best-hand-value">
                       {data.best.fanCount} 番 · {data.best.winnerName}
-                      <div style={{ fontSize: '0.75rem', marginTop: '4px', color: 'var(--sol-base01)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <div
+                        style={{
+                          fontSize: '0.75rem',
+                          marginTop: '4px',
+                          color: 'var(--sol-base01)',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
                         {data.best.fanDetails}
                       </div>
                     </div>
@@ -132,7 +161,7 @@ export default function HomePage() {
           })}
         </div>
       </div>
-      
+
       <div style={{ marginTop: '60px', textAlign: 'center', opacity: 0.5, fontSize: '0.9rem' }}>
         <p>© 2026 Mahjong Omakase Team · Let's NB!</p>
       </div>


### PR DESCRIPTION
## 首页改版：Mahjong Omakase Game Hub

本次改动将首页从传统的“营销宣传页”转型为功能导向的“游戏控制中心”。

### 主要功能更新：
- **快速启动 (Quick Action)**：顶部显著的“麻将启动”按钮，直接进入对局创建页面。
- **进行中的对局 (Live Games)**：
    - 实时同步显示所有 `IN_PROGRESS` 状态的对局。
    - **自动排名**：玩家列表按当前总分实时从高到低排序。
    - **实时风位**：展示每位玩家当前的门风（东/南/西/北），并对庄家进行醒目标记。
    - **场次追踪**：自动计算并显示当前的圈场（如：东1、南2等）。
- **本月荣誉殿堂 (Hall of Fame)**：
    - 展示国标、立直、东北三种模式本月的 Top 3 玩家排名及积分。
    - 记录并展示本月三种模式下的“最高和牌”番数及获胜者。

### 视觉与体验优化：
- 采用更紧凑的信息布局，减少空间浪费。
- 风格化配色：统一使用姜黄色（Ginger Gold）作为核心点缀色。
- 全站分数颜色加深处理，提升可读性。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home page transformed into an interactive hub with live-updating active-game cards that display session progress, player ranks and scores.
  * Added a “Hall of Fame” section highlighting top performers and best rounds per mode; hub polls for updates.

* **Bug Fixes**
  * Fan badges now only appear for the Guobiao tab when a specific season is selected.
  * Account creation using the reserved name "BOT" is blocked.
  * Fan discovery bonus calculations limited to Guobiao/all-mode contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->