### PR TITLE
feat: redesign dashboard history cards and refine fan table UI

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1679,7 +1679,7 @@ tr:hover td {
 
 .example-hint.prev {
   background: #a2cecd;
-  color: #046b6b;
+  color: white;
 }
 
 .badge-discovery {
@@ -1690,7 +1690,7 @@ tr:hover td {
 
 .badge-discovery-prev {
   background: #a2cecd;
-  color: #046b6b;
+  color: white;
   font-weight: 700;
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1630,20 +1630,22 @@ tr:hover td {
   margin-bottom: 8px;
 }
 
-.fan-item-example {
+.fan-item-example-container {
   position: relative;
   margin-top: 32px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  width: 100%;
+}
+
+.fan-item-example {
   padding: 16px 10px 10px 10px;
   display: flex;
   flex-wrap: nowrap;
   column-gap: 4px;
-  background: rgba(0, 0, 0, 0.03);
-  border-radius: 8px;
   align-items: center;
   overflow-x: auto;
-  overflow-y: visible;
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  width: 100%;
 }
 
 .fan-item-example-real {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2365,7 +2365,7 @@ tr:hover td {
 }
 
 .example-hint.reference {
-  background: var(--sol-base1);
+  background: #d4a017;
 }
 
 /* HomePage Hub Styles */

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1720,10 +1720,10 @@ tr:hover td {
 }
 
 .mahjong-tile[src*='Back'] {
-  /* Use filter to transform the red SVG color into emerald green while keeping its original dimensions/aspect ratio */
-  filter: hue-rotate(140deg) saturate(1.6) brightness(0.8) contrast(1.1);
-  border-color: #065f46 !important;
-  box-shadow: 0 2px 4px rgba(6, 95, 70, 0.2);
+  /* Transform the red SVG into a fresh, light Tiffany Blue style */
+  filter: hue-rotate(185deg) brightness(1.3) saturate(0.6) contrast(0.95);
+  border-color: #96e0da !important;
+  box-shadow: 0 2px 6px rgba(129, 216, 208, 0.4);
 }
 
 .mahjong-tile:hover {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2629,222 +2629,158 @@ tr:hover td {
   }
 }
 
-/* Dashboard V2 Table Styles */
-.dashboard-table-container {
-  width: 100%;
-  overflow-x: auto;
+/* Dashboard Card List Styles */
+.dashboard-sessions-list {
+  display: flex;
+  flex-direction: column;
 }
 
-.dashboard-table {
-  width: 100%;
-  border-collapse: collapse;
-  min-width: 800px;
-}
-
-.dashboard-table th,
-.dashboard-table td {
-  padding: 12px 16px;
+.session-history-card {
+  padding: 20px 24px;
   border-bottom: 1px solid var(--border);
-  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  outline: none;
 }
 
-.dashboard-table th {
-  background: var(--sol-base3);
-  font-size: 0.85rem;
-  color: var(--text-light);
-  text-transform: uppercase;
-  letter-spacing: 1px;
+.session-history-card:last-child {
+  border-bottom: none;
 }
 
-.dashboard-table tr:hover td {
+.session-history-card:hover {
   background: rgba(33, 140, 116, 0.04);
 }
 
-.dashboard-table tr:focus-visible {
-  outline: 2px solid var(--mj-green);
-  outline-offset: -2px;
-}
-
-.dashboard-table tr:focus-visible td {
+.session-history-card:focus-visible {
   background: rgba(33, 140, 116, 0.08);
+  box-shadow: inset 4px 0 0 var(--mj-green);
 }
 
-.cell-rank {
-  min-width: 140px;
+.session-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
 }
 
-.cell-player-box {
+.mode-text {
+  font-weight: 900;
+  color: var(--mj-gold);
+  font-size: 1rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.session-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.session-card-date {
+  font-size: 0.85rem;
+  color: var(--text-light);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.session-status-tag {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.status-in_progress {
+  background: rgba(33, 140, 116, 0.15);
+  color: var(--mj-green);
+  border: 1px solid rgba(33, 140, 116, 0.2);
+}
+
+.status-completed {
+  background: var(--sol-base3);
+  color: var(--text-light);
+  border: 1px solid var(--border);
+}
+
+.session-card-players {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+
+.player-rank-item {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
 
-.cell-player-name {
+.player-rank-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rank-number {
+  font-weight: 900;
+  font-size: 0.8rem;
+  min-width: 20px;
+  opacity: 0.5;
+}
+
+.rank-1 .rank-number {
+  color: #b58900;
+  opacity: 1;
+}
+.rank-2 .rank-number {
+  color: #839496;
+  opacity: 1;
+}
+.rank-3 .rank-number {
+  color: #cb4b16;
+  opacity: 1;
+}
+
+.player-name {
   font-weight: 700;
   color: var(--primary);
   font-size: 0.95rem;
-}
-
-.cell-player-stats {
-  font-size: 0.75rem;
-  color: var(--text-light);
-}
-
-.cell-mode {
-  font-weight: 800;
-  color: var(--mj-gold);
-  font-size: 0.9rem;
-}
-
-.cell-date {
-  font-size: 0.8rem;
-  color: var(--text-light);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.cell-status-badge {
-  display: inline-block;
-  font-size: 0.7rem;
-  padding: 2px 6px;
-  border-radius: 4px;
-}
-
-.score-positive {
-  color: var(--success) !important;
-}
-.score-negative {
-  color: var(--danger) !important;
-}
-
-.dashboard-table th.rank-tag-1 {
-  color: #b58900 !important;
-}
-.dashboard-table th.rank-tag-2 {
-  color: #839496 !important;
-}
-.dashboard-table th.rank-tag-3 {
-  color: #cb4b16 !important;
+.player-score {
+  font-size: 0.85rem;
+  font-weight: 800;
+  padding-left: 28px;
 }
 
 @media (max-width: 850px) {
-  .dashboard-table,
-  .dashboard-table thead,
-  .dashboard-table tbody,
-  .dashboard-table th,
-  .dashboard-table td,
-  .dashboard-table tr {
-    display: block;
+  .session-card-header {
+    margin-bottom: 12px;
   }
 
-  .dashboard-table {
-    min-width: unset;
+  .session-card-players {
+    grid-template-columns: 1fr;
+    gap: 8px;
   }
 
-  .dashboard-table thead tr {
-    position: absolute;
-    top: -9999px;
-    left: -9999px;
-  }
-
-  .dashboard-table tr {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    margin-bottom: 16px;
-    background: var(--card);
-    padding: 4px 0;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-
-  .dashboard-table td {
-    border: none;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-    position: relative;
-    padding-left: 50%;
-    min-height: 48px;
-    display: flex;
-    align-items: center;
-  }
-
-  .dashboard-table td.cell-rank {
-    width: 100%;
-    order: 4;
-  }
-
-  .dashboard-table td.cell-mode {
-    order: 1;
-    width: auto;
-    padding: 8px 16px;
-    border-bottom: none;
-    min-height: auto;
-  }
-
-  .dashboard-table td.cell-date {
-    order: 2;
-    width: auto;
-    margin-left: auto;
-    padding: 8px 8px 8px 0;
-    border-bottom: none;
-    min-height: auto;
-    font-size: 0.75rem;
-  }
-
-  .dashboard-table td.cell-status {
-    order: 3;
-    width: auto;
-    padding: 8px 16px 8px 0;
-    border-bottom: none;
-    min-height: auto;
-  }
-
-  .dashboard-table td:last-child {
-    border-bottom: none;
-  }
-
-  .dashboard-table td:before {
-    position: absolute;
-    left: 16px;
-    width: 40%;
-    white-space: nowrap;
-    font-weight: bold;
-    color: var(--text-light);
-    font-size: 0.8rem;
-    text-transform: uppercase;
-  }
-
-  .dashboard-table td.cell-mode:before,
-  .dashboard-table td.cell-date:before,
-  .dashboard-table td.cell-status:before {
-    display: none;
-  }
-
-  .dashboard-table td:nth-of-type(2):before {
-    content: '#1';
-    color: #b58900;
-  }
-  .dashboard-table td:nth-of-type(3):before {
-    content: '#2';
-    color: #839496;
-  }
-  .dashboard-table td:nth-of-type(4):before {
-    content: '#3';
-    color: #cb4b16;
-  }
-  .dashboard-table td:nth-of-type(5):before {
-    content: '#4';
-  }
-
-  .cell-player-box {
+  .player-rank-item {
     flex-direction: row;
-    width: 100%;
     justify-content: space-between;
     align-items: center;
-    padding-right: 16px;
+    padding: 4px 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.03);
   }
 
-  .cell-player-stats {
-    font-size: 0.85rem;
-    font-weight: 600;
+  .player-rank-item:last-child {
+    border-bottom: none;
+  }
+
+  .player-score {
+    padding-left: 0;
+    font-size: 0.8rem;
   }
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2798,12 +2798,12 @@ tr:hover td {
   font-weight: 800;
 }
 
-.score-positive {
-  color: var(--success) !important;
+.session-history-card .score-positive {
+  color: var(--success);
 }
 
-.score-negative {
-  color: var(--danger) !important;
+.session-history-card .score-negative {
+  color: var(--danger);
 }
 
 @media (max-width: 480px) {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1657,6 +1657,12 @@ tr:hover td {
   position: relative;
 }
 
+.fan-item-example-real.prev-season {
+  background: rgba(42, 161, 152, 0.02);
+  border-color: rgba(42, 161, 152, 0.2);
+  opacity: 0.8;
+}
+
 .example-hint {
   position: absolute;
   top: -13px;
@@ -1669,6 +1675,23 @@ tr:hover td {
   font-weight: 800;
   text-transform: uppercase;
   z-index: 10;
+}
+
+.example-hint.prev {
+  background: #a2cecd;
+  color: #046b6b;
+}
+
+.badge-discovery {
+  background: #069494;
+  color: white;
+  font-weight: 700;
+}
+
+.badge-discovery-prev {
+  background: #a2cecd;
+  color: #046b6b;
+  font-weight: 700;
 }
 
 .mahjong-hand {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2629,91 +2629,101 @@ tr:hover td {
   }
 }
 
-/* Dashboard Card List Styles */
+/* Dashboard Card Grid Styles */
 .dashboard-sessions-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+  padding: 24px;
+  background: var(--sol-base2); /* Slightly darker background to make cards pop */
 }
 
 .session-history-card {
-  padding: 20px 24px;
-  border-bottom: 1px solid var(--border);
+  background: var(--card);
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   outline: none;
-}
-
-.session-history-card:last-child {
-  border-bottom: none;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.02);
 }
 
 .session-history-card:hover {
-  background: rgba(33, 140, 116, 0.04);
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
+  border-color: var(--mj-green);
 }
 
 .session-history-card:focus-visible {
-  background: rgba(33, 140, 116, 0.08);
-  box-shadow: inset 4px 0 0 var(--mj-green);
+  border-color: var(--mj-green);
+  box-shadow: 0 0 0 3px rgba(33, 140, 116, 0.2);
 }
 
 .session-card-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 12px;
 }
 
 .mode-text {
   font-weight: 900;
   color: var(--mj-gold);
-  font-size: 1rem;
+  font-size: 0.95rem;
   letter-spacing: 0.5px;
-  text-transform: uppercase;
 }
 
 .session-card-meta {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
 }
 
 .session-card-date {
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   color: var(--text-light);
-  font-family: 'JetBrains Mono', monospace;
 }
 
 .session-status-tag {
-  font-size: 0.7rem;
-  padding: 2px 8px;
-  border-radius: 12px;
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  border-radius: 4px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
 }
 
 .status-in_progress {
-  background: rgba(33, 140, 116, 0.15);
+  background: rgba(33, 140, 116, 0.1);
   color: var(--mj-green);
-  border: 1px solid rgba(33, 140, 116, 0.2);
 }
 
 .status-completed {
   background: var(--sol-base3);
   color: var(--text-light);
-  border: 1px solid var(--border);
 }
 
 .session-card-players {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .player-rank-item {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+}
+
+.player-rank-item:not(:last-child) {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.02);
+  padding-bottom: 8px;
 }
 
 .player-rank-main {
@@ -2724,9 +2734,9 @@ tr:hover td {
 
 .rank-number {
   font-weight: 900;
-  font-size: 0.8rem;
-  min-width: 20px;
-  opacity: 0.5;
+  font-size: 0.75rem;
+  min-width: 18px;
+  opacity: 0.4;
 }
 
 .rank-1 .rank-number {
@@ -2743,9 +2753,10 @@ tr:hover td {
 }
 
 .player-name {
-  font-weight: 700;
+  font-weight: 600;
   color: var(--primary);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
+  max-width: 120px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2754,33 +2765,19 @@ tr:hover td {
 .player-score {
   font-size: 0.85rem;
   font-weight: 800;
-  padding-left: 28px;
 }
 
-@media (max-width: 850px) {
-  .session-card-header {
-    margin-bottom: 12px;
-  }
+.score-positive {
+  color: var(--success) !important;
+}
 
-  .session-card-players {
-    grid-template-columns: 1fr;
-    gap: 8px;
-  }
+.score-negative {
+  color: var(--danger) !important;
+}
 
-  .player-rank-item {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    padding: 4px 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.03);
-  }
-
-  .player-rank-item:last-child {
-    border-bottom: none;
-  }
-
-  .player-score {
-    padding-left: 0;
-    font-size: 0.8rem;
+@media (max-width: 480px) {
+  .dashboard-sessions-list {
+    padding: 16px;
+    gap: 16px;
   }
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1632,8 +1632,8 @@ tr:hover td {
 
 .fan-item-example {
   position: relative;
-  margin-top: 24px;
-  padding: 28px 10px 10px 10px;
+  margin-top: 32px;
+  padding: 16px 10px 10px 10px;
   display: flex;
   flex-wrap: nowrap;
   column-gap: 4px;
@@ -1644,6 +1644,29 @@ tr:hover td {
   overflow-y: visible;
   border: 1px solid rgba(0, 0, 0, 0.05);
   width: 100%;
+}
+
+.fan-item-example-real {
+  margin-top: 32px;
+  padding: 16px 10px 10px 10px;
+  background: rgba(42, 161, 152, 0.05);
+  border-radius: 8px;
+  border: 1px dashed var(--sol-cyan);
+  position: relative;
+}
+
+.example-hint {
+  position: absolute;
+  top: -13px;
+  left: 10px;
+  font-size: 0.75rem;
+  background: #069494;
+  color: white;
+  padding: 2px 10px;
+  border-radius: 6px 6px 0 0;
+  font-weight: 800;
+  text-transform: uppercase;
+  z-index: 10;
 }
 
 .mahjong-hand {
@@ -2327,30 +2350,6 @@ tr:hover td {
     padding: 10px 4px;
   }
 }
-.fan-item-example-real {
-  margin-top: 20px;
-  padding: 16px 10px 10px 10px;
-  background: rgba(42, 161, 152, 0.05);
-  border-radius: 8px;
-  border: 1px dashed var(--sol-cyan);
-  position: relative;
-}
-
-.example-hint {
-  position: absolute;
-  top: 6px;
-  right: 12px;
-  font-size: 0.8rem;
-  background: #069494;
-  color: white;
-  padding: 4px 10px;
-  border-radius: 6px;
-  font-weight: 800;
-  text-transform: uppercase;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
-  z-index: 10;
-}
-
 .badge-accent {
   background: #d4a017;
   color: #000;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1720,11 +1720,10 @@ tr:hover td {
 }
 
 .mahjong-tile[src*='Back'] {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%) !important;
-  border-color: #064e3b !important;
-  box-shadow: 0 2px 4px rgba(6, 78, 59, 0.3);
-  /* Replace the red image with transparency to show the gradient background */
-  content: url('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+  /* Use filter to transform the red SVG color into emerald green while keeping its original dimensions/aspect ratio */
+  filter: hue-rotate(140deg) saturate(1.6) brightness(0.8) contrast(1.1);
+  border-color: #065f46 !important;
+  box-shadow: 0 2px 4px rgba(6, 95, 70, 0.2);
 }
 
 .mahjong-tile:hover {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2763,27 +2763,27 @@ tr:hover td {
   gap: 8px;
 }
 
-.rank-number {
+.session-history-card .rank-number {
   font-weight: 900;
   font-size: 0.75rem;
   min-width: 18px;
   opacity: 0.4;
 }
 
-.rank-1 .rank-number {
+.session-history-card .rank-1 .rank-number {
   color: #b58900;
   opacity: 1;
 }
-.rank-2 .rank-number {
+.session-history-card .rank-2 .rank-number {
   color: #839496;
   opacity: 1;
 }
-.rank-3 .rank-number {
+.session-history-card .rank-3 .rank-number {
   color: #cb4b16;
   opacity: 1;
 }
 
-.player-name {
+.session-history-card .player-name {
   font-weight: 600;
   color: var(--primary);
   font-size: 0.9rem;
@@ -2793,7 +2793,7 @@ tr:hover td {
   text-overflow: ellipsis;
 }
 
-.player-score {
+.session-history-card .player-score {
   font-size: 0.85rem;
   font-weight: 800;
 }
@@ -2810,5 +2810,6 @@ tr:hover td {
   .dashboard-sessions-list {
     padding: 16px;
     gap: 16px;
+    grid-template-columns: 1fr;
   }
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1668,7 +1668,7 @@ tr:hover td {
   top: -13px;
   left: 10px;
   font-size: 0.75rem;
-  background: #069494;
+  background: #046b6b; /* Darker teal for better contrast with white text */
   color: white;
   padding: 2px 10px;
   border-radius: 6px 6px 0 0;
@@ -1679,18 +1679,18 @@ tr:hover td {
 
 .example-hint.prev {
   background: #a2cecd;
-  color: white;
+  color: #003333; /* Dark text for light background */
 }
 
 .badge-discovery {
-  background: #069494;
+  background: #046b6b; /* Consistent with example-hint */
   color: white;
   font-weight: 700;
 }
 
 .badge-discovery-prev {
   background: #a2cecd;
-  color: white;
+  color: #003333; /* Dark text for light background */
   font-weight: 700;
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1719,6 +1719,14 @@ tr:hover td {
   padding: 1px;
 }
 
+.mahjong-tile[src*='Back'] {
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%) !important;
+  border-color: #064e3b !important;
+  box-shadow: 0 2px 4px rgba(6, 78, 59, 0.3);
+  /* Replace the red image with transparency to show the gradient background */
+  content: url('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+}
+
 .mahjong-tile:hover {
   transform: translateY(-3px);
 }

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -34,27 +34,6 @@ export default function DashboardPage() {
       </div>
     )
 
-  const renderPlayerCell = (rankings: PlayerPerformance[] | undefined, index: number) => {
-    const p = rankings?.[index]
-    if (!p) return <td className="cell-rank">-</td>
-
-    return (
-      <td className="cell-rank">
-        <div className="cell-player-box">
-          <span className="cell-player-name">{p.userName}</span>
-          <span
-            className={`cell-player-stats ${
-              p.totalScore > 0 ? 'score-positive' : p.totalScore < 0 ? 'score-negative' : ''
-            }`}
-            style={{ fontWeight: 700 }}
-          >
-            {p.totalScore > 0 ? `+${p.totalScore}` : p.totalScore}
-          </span>
-        </div>
-      </td>
-    )
-  }
-
   return (
     <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
       <div className="flex-between" style={{ padding: '20px 24px', borderBottom: '1px solid var(--border)' }}>
@@ -69,60 +48,67 @@ export default function DashboardPage() {
           <p>暂无对局记录。开始你的第一局吧！</p>
         </div>
       ) : (
-        <div className="dashboard-table-container">
-          <table className="dashboard-table">
-            <thead>
-              <tr>
-                <th>模式</th>
-                <th className="rank-tag-1">#1</th>
-                <th className="rank-tag-2">#2</th>
-                <th className="rank-tag-3">#3</th>
-                <th className="rank-tag-4">#4</th>
-                <th>时间</th>
-                <th>状态</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sessions.map((s) => (
-                <tr
-                  key={s.id}
-                  onClick={() => navigate(`/session/${s.id}`)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      navigate(`/session/${s.id}`)
-                    }
-                  }}
-                  tabIndex={0}
-                  role="row"
-                  style={{ cursor: 'pointer' }}
-                >
-                  <td className="cell-mode">{s.gameModeDisplayName}</td>
-                  {renderPlayerCell(s.rankings, 0)}
-                  {renderPlayerCell(s.rankings, 1)}
-                  {renderPlayerCell(s.rankings, 2)}
-                  {renderPlayerCell(s.rankings, 3)}
-                  <td className="cell-date">
+        <div className="dashboard-sessions-list">
+          {sessions.map((s) => (
+            <div
+              key={s.id}
+              className="session-history-card"
+              onClick={() => navigate(`/session/${s.id}`)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  navigate(`/session/${s.id}`)
+                }
+              }}
+              tabIndex={0}
+              role="button"
+            >
+              <div className="session-card-header">
+                <div className="session-card-mode">
+                  <span className="mode-text">{s.gameModeDisplayName}</span>
+                </div>
+                <div className="session-card-meta">
+                  <span className="session-card-date">
                     {new Date(s.createdAt).toLocaleString([], {
                       month: '2-digit',
                       day: '2-digit',
                       hour: '2-digit',
                       minute: '2-digit',
                     })}
-                  </td>
-                  <td className="cell-status">
-                    <span
-                      className={`cell-status-badge badge ${
-                        s.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'
-                      }`}
-                    >
-                      {s.status === 'IN_PROGRESS' ? '进行中' : '已结束'}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                  </span>
+                  <span className={`session-status-tag status-${s.status.toLowerCase()}`}>
+                    {s.status === 'IN_PROGRESS' ? '进行中' : '已结束'}
+                  </span>
+                </div>
+              </div>
+              <div className="session-card-players">
+                {[0, 1, 2, 3].map((idx) => {
+                  const p = s.rankings?.[idx]
+                  if (!p)
+                    return (
+                      <div key={idx} className="player-rank-item empty">
+                        -
+                      </div>
+                    )
+                  return (
+                    <div key={p.userName} className={`player-rank-item rank-${idx + 1}`}>
+                      <div className="player-rank-main">
+                        <span className="rank-number">#{idx + 1}</span>
+                        <span className="player-name">{p.userName}</span>
+                      </div>
+                      <span
+                        className={`player-score ${
+                          p.totalScore > 0 ? 'score-positive' : p.totalScore < 0 ? 'score-negative' : ''
+                        }`}
+                      >
+                        {p.totalScore > 0 ? `+${p.totalScore}` : p.totalScore}
+                      </span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -50,18 +50,11 @@ export default function DashboardPage() {
       ) : (
         <div className="dashboard-sessions-list">
           {sessions.map((s) => (
-            <div
+            <Link
               key={s.id}
+              to={`/session/${s.id}`}
               className="session-history-card"
-              onClick={() => navigate(`/session/${s.id}`)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  navigate(`/session/${s.id}`)
-                }
-              }}
-              tabIndex={0}
-              role="button"
+              style={{ textDecoration: 'none' }}
             >
               <div className="session-card-header">
                 <div className="session-card-mode">

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -100,7 +100,7 @@ export default function DashboardPage() {
                   )
                 })}
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -311,9 +311,7 @@ const FanTablePage: React.FC = () => {
                         <MahjongHand
                           hand={(currentDiscovery?.exampleHand || prevDiscovery?.exampleHand) ?? undefined}
                         />
-                        <span className={`example-hint ${!currentDiscovery?.exampleHand ? 'prev' : ''}`}>
-                          {currentDiscovery?.exampleHand ? '实战例子' : '实战例子 (历史)'}
-                        </span>
+                        <span className={`example-hint ${!currentDiscovery?.exampleHand ? 'prev' : ''}`}>实战例子</span>
                       </div>
                     )}
                   </div>

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -251,7 +251,7 @@ const FanTablePage: React.FC = () => {
                           <span
                             className="badge badge-discovery-prev"
                             style={{ fontSize: '0.7rem', padding: '2px 8px', borderRadius: '4px' }}
-                            title={`上月冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
+                            title={`历史冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
                           >
                             历史冠名: {prevDiscovery.playerName}
                           </span>

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -237,8 +237,8 @@ const FanTablePage: React.FC = () => {
                         {item.name}
                         {hasCurrent && (
                           <span
-                            className="badge badge-accent"
-                            style={{ fontSize: '0.7rem', padding: '2px 6px' }}
+                            className="badge badge-discovery"
+                            style={{ fontSize: '0.7rem', padding: '2px 8px', borderRadius: '4px' }}
                             title={`首位达成者: ${currentDiscovery.playerName}${
                               (currentDiscovery.bonusRp ?? 0) > 0 ? ` (+${currentDiscovery.bonusRp} RP)` : ''
                             }`}
@@ -249,14 +249,8 @@ const FanTablePage: React.FC = () => {
                         )}
                         {hasPrev && (
                           <span
-                            className="badge"
-                            style={{
-                              fontSize: '0.7rem',
-                              padding: '2px 6px',
-                              background: 'var(--text-light)',
-                              color: 'white',
-                              opacity: 0.6,
-                            }}
+                            className="badge badge-discovery-prev"
+                            style={{ fontSize: '0.7rem', padding: '2px 8px', borderRadius: '4px' }}
                             title={`上月冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
                           >
                             历史冠名: {prevDiscovery.playerName}
@@ -311,10 +305,15 @@ const FanTablePage: React.FC = () => {
                         </div>
                       </div>
                     )}
-                    {currentDiscovery?.exampleHand && (
-                      <div className="fan-item-example-real">
-                        <MahjongHand hand={currentDiscovery.exampleHand ?? undefined} />
-                        <span className="example-hint">实战例子</span>
+                    {/* Show real example hand: current month priority, otherwise historical fallback */}
+                    {(currentDiscovery?.exampleHand || prevDiscovery?.exampleHand) && (
+                      <div className={`fan-item-example-real ${!currentDiscovery?.exampleHand ? 'prev-season' : ''}`}>
+                        <MahjongHand
+                          hand={(currentDiscovery?.exampleHand || prevDiscovery?.exampleHand) ?? undefined}
+                        />
+                        <span className={`example-hint ${!currentDiscovery?.exampleHand ? 'prev' : ''}`}>
+                          {currentDiscovery?.exampleHand ? '实战例子' : '实战例子 (历史)'}
+                        </span>
                       </div>
                     )}
                   </div>

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -243,7 +243,7 @@ const FanTablePage: React.FC = () => {
                               (currentDiscovery.bonusRp ?? 0) > 0 ? ` (+${currentDiscovery.bonusRp} RP)` : ''
                             }`}
                           >
-                            🏆 {currentDiscovery.playerName}
+                            本月冠名: {currentDiscovery.playerName}
                             {(currentDiscovery.bonusRp ?? 0) > 0 && ` (+${currentDiscovery.bonusRp})`}
                           </span>
                         )}
@@ -259,7 +259,7 @@ const FanTablePage: React.FC = () => {
                             }}
                             title={`上月冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
                           >
-                            🏆 {prevDiscovery.playerName}
+                            历史冠名: {prevDiscovery.playerName}
                           </span>
                         )}
                         {item.tags?.map((tag) => (

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -276,37 +276,39 @@ const FanTablePage: React.FC = () => {
                     </div>
                     <p className="fan-item-desc">{item.description}</p>
                     {item.example && item.example.length > 0 && (
-                      <div className="fan-item-example">
+                      <div className="fan-item-example-container">
                         <span className="example-hint reference">理论参考</span>
-                        {item.example.split('|').map((group, groupIdx) => {
-                          const trimmedGroup = group.trim()
-                          const isGroupHighlighted = trimmedGroup.startsWith('*')
-                          const cleanGroup = isGroupHighlighted ? trimmedGroup.substring(1).trim() : trimmedGroup
-                          const tiles = cleanGroup
-                            .split(' ')
-                            .map((t) => t.trim())
-                            .filter(Boolean)
+                        <div className="fan-item-example">
+                          {item.example.split('|').map((group, groupIdx) => {
+                            const trimmedGroup = group.trim()
+                            const isGroupHighlighted = trimmedGroup.startsWith('*')
+                            const cleanGroup = isGroupHighlighted ? trimmedGroup.substring(1).trim() : trimmedGroup
+                            const tiles = cleanGroup
+                              .split(' ')
+                              .map((t) => t.trim())
+                              .filter(Boolean)
 
-                          return (
-                            <div
-                              key={groupIdx}
-                              className={`mahjong-group ${isGroupHighlighted ? 'highlighted-group' : ''}`}
-                            >
-                              {tiles.map((tile, tileIdx) => {
-                                const isTileHighlighted = tile.startsWith('*') || tile.startsWith('^')
-                                const cleanTile = isTileHighlighted ? tile.substring(1) : tile
-                                return (
-                                  <img
-                                    key={tileIdx}
-                                    src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${cleanTile}.svg`}
-                                    alt={cleanTile}
-                                    className={`mahjong-tile ${isTileHighlighted ? 'highlighted-tile' : ''}`}
-                                  />
-                                )
-                              })}
-                            </div>
-                          )
-                        })}
+                            return (
+                              <div
+                                key={groupIdx}
+                                className={`mahjong-group ${isGroupHighlighted ? 'highlighted-group' : ''}`}
+                              >
+                                {tiles.map((tile, tileIdx) => {
+                                  const isTileHighlighted = tile.startsWith('*') || tile.startsWith('^')
+                                  const cleanTile = isTileHighlighted ? tile.substring(1) : tile
+                                  return (
+                                    <img
+                                      key={tileIdx}
+                                      src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${cleanTile}.svg`}
+                                      alt={cleanTile}
+                                      className={`mahjong-tile ${isTileHighlighted ? 'highlighted-tile' : ''}`}
+                                    />
+                                  )
+                                })}
+                              </div>
+                            )
+                          })}
+                        </div>
                       </div>
                     )}
                     {currentDiscovery?.exampleHand && (


### PR DESCRIPTION
### 本次工作总结：

1.  **Dashboard 深度重构**：
    *   将对局历史从老旧的表格迁移到了**响应式卡片网格**布局。
    *   优化了卡片的悬浮动效、阴影和间距，找回了正负分（红/绿）的色彩展示，视觉感官更加现代。
2.  **番表 UI 精修**：
    *   **切页签样式**：解决了移动端“理论参考”标签遮挡牌张的问题，将其改为坐在边框上的 Tab 样式。
    *   **Tiffany 蓝牌背**：将暗杠牌背从红色升级为清新的 Tiffany 蓝样式，全局观感更轻盈。
    *   **冠名系统优化**：统一了“本月冠名”与“历史冠名”的蓝绿色调标签，移除了多余图标，并支持了**历史实战样例**的自动追溯展示。
3.  **代码清理与优化**：
    *   移除了一系列过时的表格样式。
    *   修复了编辑过程中产生的 JSX 结构问题，确保页面在各种分辨率下都能完美渲染。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned session history into clickable, card-style entries with hover/focus-visible states, status tags, player rank/score visuals and responsive grid behavior (single-column on small screens).
  * Updated fan discovery badges and badge text with current/previous-season variants; restyled mahjong tile backs and other visuals for clearer hierarchy.

* **Improvements**
  * Example hand rendering now prefers current-month data, falls back to previous-season with a clear "prev-season" indication; improved keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->