### PR TITLE
feat: session UI overhaul and input streamline

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -535,9 +535,6 @@ tr:hover td {
 }
 
 .round-form {
-  margin-top: 20px;
-  padding-top: 20px;
-  border-top: 2px solid var(--border);
 }
 
 .round-form-title {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2344,6 +2344,11 @@ tr:hover td {
   margin-top: 0 !important;
 }
 
+.quick-player-btn .wind-badge {
+  top: 2px;
+  right: 2px;
+}
+
 .quick-player-btn .btn-name {
   font-size: 0.9rem;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2297,7 +2297,7 @@ tr:hover td {
 
 .quick-player-btn {
   width: 100%;
-  padding: 6px 4px;
+  padding: 6px 28px 6px 10px; /* Increased right padding to avoid badge overlap */
   border: 1px solid var(--border);
   border-radius: 10px;
   background: #fff;
@@ -2310,6 +2310,7 @@ tr:hover td {
   box-shadow: var(--shadow);
   color: var(--text);
   position: relative;
+  min-height: 40px; /* Ensure enough height for centered badge */
 }
 
 .quick-player-btn:hover:not(:disabled) {
@@ -2361,26 +2362,26 @@ tr:hover td {
   background: rgba(203, 75, 22, 0.08);
 }
 
-.score-inline-group {
-  display: flex !important;
-  flex-direction: row !important;
-  align-items: center !important;
+.round-form .score-inline-group {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   gap: 12px;
-  margin-bottom: 12px !important;
+  margin-bottom: 12px;
 }
 
-.score-inline-group label {
-  margin-bottom: 0 !important;
+.round-form .score-inline-group label {
+  margin-bottom: 0;
   white-space: nowrap;
   font-weight: 700;
 }
 
-.score-input-compact {
+.round-form .score-input-compact {
   max-width: 120px;
-  padding: 6px 10px !important;
+  padding: 6px 10px;
 }
 
-.form-section-title {
+.round-form .form-section-title {
   background: var(--sol-base3);
   font-size: 0.85rem;
   color: var(--text-light);
@@ -2393,10 +2394,10 @@ tr:hover td {
   display: inline-block;
 }
 
-.no-border-top {
-  border-top: none !important;
-  padding-top: 0 !important;
-  margin-top: 0 !important;
+.round-form .no-border-top {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
 }
 
 .quick-player-btn .wind-badge {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2308,6 +2308,25 @@ tr:hover td {
   background: rgba(203, 75, 22, 0.08);
 }
 
+.score-inline-group {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  gap: 12px;
+  margin-bottom: 12px !important;
+}
+
+.score-inline-group label {
+  margin-bottom: 0 !important;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.score-input-compact {
+  max-width: 120px;
+  padding: 6px 10px !important;
+}
+
 .quick-player-btn .btn-name {
   font-size: 0.9rem;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2327,6 +2327,25 @@ tr:hover td {
   padding: 6px 10px !important;
 }
 
+.form-section-title {
+  background: var(--sol-base3);
+  font-size: 0.85rem;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  margin-bottom: 12px;
+  font-weight: 800;
+  display: inline-block;
+}
+
+.no-border-top {
+  border-top: none !important;
+  padding-top: 0 !important;
+  margin-top: 0 !important;
+}
+
 .quick-player-btn .btn-name {
   font-size: 0.9rem;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2345,8 +2345,9 @@ tr:hover td {
 }
 
 .quick-player-btn .wind-badge {
-  top: 2px;
-  right: 2px;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
 }
 
 .quick-player-btn .btn-name {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2856,3 +2856,45 @@ tr:hover td {
     grid-template-columns: 1fr;
   }
 }
+
+.pagination-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 24px;
+  background: var(--sol-base3);
+  border-top: 1px solid var(--border);
+}
+
+.pagination-btn {
+  padding: 6px 16px;
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--primary);
+  transition: all 0.2s;
+  box-shadow: var(--shadow);
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background: var(--sol-base2);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
+}
+
+.pagination-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.pagination-info {
+  font-size: 0.85rem;
+  color: var(--text-light);
+  font-weight: 500;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2242,7 +2242,7 @@ tr:hover td {
 
 .quick-player-btn {
   width: 100%;
-  padding: 10px 4px;
+  padding: 6px 4px;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: #fff;
@@ -2254,6 +2254,7 @@ tr:hover td {
   justify-content: center;
   box-shadow: var(--shadow);
   color: var(--text);
+  position: relative;
 }
 
 .quick-player-btn:hover:not(:disabled) {

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -1,18 +1,29 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { fetchSessions } from '../api'
-import { GameSession, PlayerPerformance } from '../types'
+import { GameSession, Season, getCurrentSeason, getSeasonLabel } from '../types'
+import { fetchSessions, fetchActiveSeasons } from '../api'
 
 export default function DashboardPage() {
   const navigate = useNavigate()
   const [sessions, setSessions] = useState<GameSession[]>([])
+  const [seasons, setSeasons] = useState<Season[]>([])
+  const [seasonKey, setSeasonKey] = useState<string>('all')
+  const [currentPage, setCurrentPage] = useState(1)
+  const pageSize = 10
+
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
   useEffect(() => {
-    fetchSessions()
-      .then((s) => {
-        setSessions(s)
+    Promise.all([fetchSessions(), fetchActiveSeasons()])
+      .then(([sData, seasonsData]) => {
+        setSessions(sData)
+        const list = seasonsData.map((s) => ({
+          year: s.year,
+          month: s.month,
+          label: getSeasonLabel(s.year, s.month),
+        }))
+        setSeasons(list)
         setLoading(false)
       })
       .catch((e) => {
@@ -20,6 +31,21 @@ export default function DashboardPage() {
         setLoading(false)
       })
   }, [])
+
+  // Reset to page 1 when season changes
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [seasonKey])
+
+  const filteredSessions = sessions.filter((s) => {
+    if (seasonKey === 'all') return true
+    const d = new Date(s.createdAt)
+    const key = `${d.getFullYear()}-${d.getMonth() + 1}`
+    return key === seasonKey
+  })
+
+  const totalPages = Math.ceil(filteredSessions.length / pageSize)
+  const paginatedSessions = filteredSessions.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
   if (loading)
     return (
@@ -36,8 +62,21 @@ export default function DashboardPage() {
 
   return (
     <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-      <div className="flex-between" style={{ padding: '20px 24px', borderBottom: '1px solid var(--border)' }}>
-        <h2 style={{ margin: 0 }}>对局历史</h2>
+      <div
+        className="flex-between"
+        style={{ padding: '16px 24px', borderBottom: '1px solid var(--border)', flexWrap: 'wrap', gap: '12px' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          <h2 style={{ margin: 0 }}>对局历史</h2>
+          <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">
+            <option value="all">全部赛季</option>
+            {seasons.map((s) => (
+              <option key={`${s.year}-${s.month}`} value={`${s.year}-${s.month}`}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
         <Link to="/new-session" className="btn btn-primary">
           + 新建游戏
         </Link>
@@ -49,7 +88,7 @@ export default function DashboardPage() {
         </div>
       ) : (
         <div className="dashboard-sessions-list">
-          {sessions.map((s) => (
+          {paginatedSessions.map((s) => (
             <Link
               key={s.id}
               to={`/session/${s.id}`}
@@ -102,6 +141,28 @@ export default function DashboardPage() {
               </div>
             </Link>
           ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="pagination-container">
+          <button
+            className="pagination-btn"
+            disabled={currentPage === 1}
+            onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+          >
+            上一页
+          </button>
+          <div className="pagination-info">
+            第 {currentPage} 页 / 共 {totalPages} 页
+          </div>
+          <button
+            className="pagination-btn"
+            disabled={currentPage === totalPages}
+            onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+          >
+            下一页
+          </button>
         </div>
       )}
     </div>

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -15,21 +15,37 @@ export default function DashboardPage() {
   const [error, setError] = useState('')
 
   useEffect(() => {
-    Promise.all([fetchSessions(), fetchActiveSeasons()])
-      .then(([sData, seasonsData]) => {
+    let mounted = true
+    setLoading(true)
+
+    fetchSessions()
+      .then((sData) => {
+        if (!mounted) return
         setSessions(sData)
+        // If sessions load successfully, we can already stop the main loading spinner
+        // once we also try to get the seasons.
+        return fetchActiveSeasons()
+      })
+      .then((seasonsData) => {
+        if (!mounted || !seasonsData) return
         const list = seasonsData.map((s) => ({
           year: s.year,
           month: s.month,
           label: getSeasonLabel(s.year, s.month),
         }))
         setSeasons(list)
-        setLoading(false)
       })
       .catch((e) => {
+        if (!mounted) return
         setError(e.message)
-        setLoading(false)
       })
+      .finally(() => {
+        if (mounted) setLoading(false)
+      })
+
+    return () => {
+      mounted = false
+    }
   }, [])
 
   // Reset to page 1 when season changes
@@ -82,9 +98,9 @@ export default function DashboardPage() {
         </Link>
       </div>
 
-      {sessions.length === 0 ? (
+      {filteredSessions.length === 0 ? (
         <div className="empty-state" style={{ padding: '40px' }}>
-          <p>暂无对局记录。开始你的第一局吧！</p>
+          <p>{seasonKey === 'all' ? '暂无对局记录。开始你的第一局吧！' : '该赛季暂无对局记录。'}</p>
         </div>
       ) : (
         <div className="dashboard-sessions-list">

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -395,7 +395,6 @@ export default function SessionPage() {
 
   return (
     <>
-
       {session.status === 'IN_PROGRESS' && (
         <div className="card round-form-card">
           <div className="round-form">

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -578,8 +578,8 @@ export default function SessionPage() {
                   </div>
                 )}
 
-                <div className="form-group full-width">
-                  <label>胜负选择</label>
+                <div className="form-group full-width no-border-top">
+                  <h4 className="form-section-title">胜负选择</h4>
                   <div className="quick-win-row">
                     {session.players.map((p, idx) => {
                       const isWinner = winnerId === String(p.id)

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -416,127 +416,10 @@ export default function SessionPage() {
         </div>
       </div>
 
-      <div className="card">
-        <h2>计分板</h2>
-        <div className="score-table">
-          <table>
-            <thead>
-              <tr>
-                <th style={{ textAlign: 'center', width: '60px' }}>局</th>
-                {session.players.map((p) => (
-                  <th key={p.id} style={playerColStyle}>
-                    <div className="player-header-cell">
-                      <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>#{rankMap[p.id]?.rank}</span>
-                      <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
-                        {p.userName}
-                      </span>
-                    </div>
-                  </th>
-                ))}
-                {session.status === 'IN_PROGRESS' && <th></th>}
-              </tr>
-            </thead>
-            <tbody>
-              {session.rounds.map((round) => {
-                return (
-                  <React.Fragment key={round.roundNumber}>
-                    <tr>
-                      <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
-                        <div className="round-info-cell">
-                          {(() => {
-                            const rw = getRoundWind(round)
-                            return rw ? (
-                              <div
-                                style={{
-                                  display: 'flex',
-                                  flexDirection: 'column',
-                                  alignItems: 'center',
-                                  gap: '2px',
-                                  width: '100%',
-                                }}
-                              >
-                                <span className="round-wind-tag">{rw.name}</span>
-                              </div>
-                            ) : (
-                              <strong>#{round.roundNumber}</strong>
-                            )
-                          })()}
-                        </div>
-                      </td>
-                      {session.players.map((p) => {
-                        const val = round.scores[p.id] || 0
-                        const isWinner = round.winnerId === p.id
-                        return (
-                          <td
-                            key={p.id}
-                            className={`score-cell${val > 0 ? ' score-positive' : val < 0 ? ' score-negative' : ''}${
-                              isWinner ? ' score-winner' : ''
-                            }`}
-                            style={{ textAlign: 'center' }}
-                          >
-                            {val > 0 ? `+${val}` : val}
-                          </td>
-                        )
-                      })}
-                      {session.status === 'IN_PROGRESS' && (
-                        <td>
-                          <button
-                            className="delete-btn"
-                            onClick={() => handleDeleteRound(round.roundNumber)}
-                            disabled={submitting}
-                          >
-                            &times;
-                          </button>
-                        </td>
-                      )}
-                    </tr>
-                    {round.winHand && (
-                      <tr className="hand-details-row">
-                        <td
-                          colSpan={session.players.length + (session.status === 'IN_PROGRESS' ? 2 : 1)}
-                          className="hand-details-cell"
-                        >
-                          <MahjongHand hand={round.winHand} details={round.fanDetails} />
-                        </td>
-                      </tr>
-                    )}
-                  </React.Fragment>
-                )
-              })}
-              <tr className="total-row">
-                <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
-                  <strong>合计</strong>
-                </td>
-                {session.players.map((p) => {
-                  const delta = session.totalScores[p.id] || 0
-                  const total = session.rpOrigin + delta
-                  const displayVal = session.rpOrigin ? total : delta
-                  return (
-                    <td
-                      key={p.id}
-                      className={`score-cell${delta > 0 ? ' score-positive' : delta < 0 ? ' score-negative' : ''}`}
-                      style={{ textAlign: 'center' }}
-                    >
-                      <div className="total-score-box">
-                        <div className="total-val">{displayVal}</div>
-                        {session.rounds.length > 0 &&
-                          (() => {
-                            const rp = rankMap[p.id]?.rp ?? 0
-                            return <div className="rp-val">{rp > 0 ? `+${rp.toFixed(1)}` : rp.toFixed(1)} RP</div>
-                          })()}
-                      </div>
-                    </td>
-                  )
-                })}
-                {session.status === 'IN_PROGRESS' && <td></td>}
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        {session.status === 'IN_PROGRESS' && (
+      {session.status === 'IN_PROGRESS' && (
+        <div className="card round-form-card">
           <div className="round-form">
-            <h3 className="round-form-title">添加</h3>
+            <h3 className="round-form-title">添加对局</h3>
 
             {isRiichi && (
               <div className="form-group" style={{ marginBottom: 16 }}>
@@ -795,7 +678,126 @@ export default function SessionPage() {
               </>
             )}
           </div>
-        )}
+        </div>
+      )}
+
+      <div className="card">
+        <h2>计分板</h2>
+        <div className="score-table">
+          <table>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'center', width: '60px' }}>局</th>
+                {session.players.map((p) => (
+                  <th key={p.id} style={playerColStyle}>
+                    <div className="player-header-cell">
+                      <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>#{rankMap[p.id]?.rank}</span>
+                      <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
+                        {p.userName}
+                      </span>
+                    </div>
+                  </th>
+                ))}
+                {session.status === 'IN_PROGRESS' && <th></th>}
+              </tr>
+            </thead>
+            <tbody>
+              {session.rounds.map((round) => {
+                return (
+                  <React.Fragment key={round.roundNumber}>
+                    <tr>
+                      <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
+                        <div className="round-info-cell">
+                          {(() => {
+                            const rw = getRoundWind(round)
+                            return rw ? (
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  flexDirection: 'column',
+                                  alignItems: 'center',
+                                  gap: '2px',
+                                  width: '100%',
+                                }}
+                              >
+                                <span className="round-wind-tag">{rw.name}</span>
+                              </div>
+                            ) : (
+                              <strong>#{round.roundNumber}</strong>
+                            )
+                          })()}
+                        </div>
+                      </td>
+                      {session.players.map((p) => {
+                        const val = round.scores[p.id] || 0
+                        const isWinner = round.winnerId === p.id
+                        return (
+                          <td
+                            key={p.id}
+                            className={`score-cell${val > 0 ? ' score-positive' : val < 0 ? ' score-negative' : ''}${
+                              isWinner ? ' score-winner' : ''
+                            }`}
+                            style={{ textAlign: 'center' }}
+                          >
+                            {val > 0 ? `+${val}` : val}
+                          </td>
+                        )
+                      })}
+                      {session.status === 'IN_PROGRESS' && (
+                        <td>
+                          <button
+                            className="delete-btn"
+                            onClick={() => handleDeleteRound(round.roundNumber)}
+                            disabled={submitting}
+                          >
+                            &times;
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                    {round.winHand && (
+                      <tr className="hand-details-row">
+                        <td
+                          colSpan={session.players.length + (session.status === 'IN_PROGRESS' ? 2 : 1)}
+                          className="hand-details-cell"
+                        >
+                          <MahjongHand hand={round.winHand} details={round.fanDetails} />
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                )
+              })}
+              <tr className="total-row">
+                <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
+                  <strong>合计</strong>
+                </td>
+                {session.players.map((p) => {
+                  const delta = session.totalScores[p.id] || 0
+                  const total = session.rpOrigin + delta
+                  const displayVal = session.rpOrigin ? total : delta
+                  return (
+                    <td
+                      key={p.id}
+                      className={`score-cell${delta > 0 ? ' score-positive' : delta < 0 ? ' score-negative' : ''}`}
+                      style={{ textAlign: 'center' }}
+                    >
+                      <div className="total-score-box">
+                        <div className="total-val">{displayVal}</div>
+                        {session.rounds.length > 0 &&
+                          (() => {
+                            const rp = rankMap[p.id]?.rp ?? 0
+                            return <div className="rp-val">{rp > 0 ? `+${rp.toFixed(1)}` : rp.toFixed(1)} RP</div>
+                          })()}
+                      </div>
+                    </td>
+                  )
+                })}
+                {session.status === 'IN_PROGRESS' && <td></td>}
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       {session.rounds.length > 0 && (

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -615,17 +615,18 @@ export default function SessionPage() {
                 </div>
 
                 {!isRiichi && isGuobiao && (
-                  <div className="form-group score-inline-group">
-                    <label>分数</label>
-                    <input
-                      type="number"
-                      value={score}
-                      onChange={(e) => setScore(e.target.value)}
-                      placeholder="输入分数"
-                      min="8"
-                      className="score-input-compact"
-                    />
-                  </div>
+                  <div className="form-group score-inline-group-container">
+                    <div className="score-inline-group">
+                      <label>分数</label>
+                      <input
+                        type="number"
+                        value={score}
+                        onChange={(e) => setScore(e.target.value)}
+                        placeholder="输入分数"
+                        min="8"
+                        className="score-input-compact"
+                      />
+                    </div>
                     <div className="inline-calc-wrapper">
                       <GuobiaoCalculator
                         key={`${gbWinds?.quanfeng || 1}-${winnerMenfeng}`}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -572,7 +572,7 @@ export default function SessionPage() {
                         <button key={p.id} className={btnClass} onClick={() => handlePlayerClick(String(p.id))}>
                           <div className="btn-name">{p.userName}</div>
                           {isGuobiao && (
-                            <div className="btn-wind">
+                            <div className="wind-badge small">
                               {['东', '南', '西', '北'][getPlayerMenfeng(getPlayerSeat(p, idx)) - 1]}
                             </div>
                           )}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -395,26 +395,6 @@ export default function SessionPage() {
 
   return (
     <>
-      <div className="card">
-        <div className="flex-between">
-          <div>
-            <h2>{session.name || `Game #${session.id}`}</h2>
-            <span className="session-meta">
-              {session.gameModeDisplayName} &middot; {session.playerCount}玩家 &middot;{' '}
-              {new Date(session.createdAt).toLocaleDateString()}
-              &nbsp;
-              <span className={`badge ${session.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
-                {session.status === 'IN_PROGRESS' ? '进行中' : '已结束'}
-              </span>
-            </span>
-          </div>
-          {session.status === 'IN_PROGRESS' && (
-            <button className="btn btn-danger btn-small" onClick={handleComplete} disabled={submitting}>
-              结束游戏
-            </button>
-          )}
-        </div>
-      </div>
 
       {session.status === 'IN_PROGRESS' && (
         <div className="card round-form-card">
@@ -579,7 +559,7 @@ export default function SessionPage() {
                 )}
 
                 <div className="quick-win-container" style={{ gridColumn: '1 / -1', marginBottom: '16px' }}>
-                  <h2>胜负选择</h2>
+                  <h2>算番器</h2>
                   <div className="quick-win-row">
                     {session.players.map((p, idx) => {
                       const isWinner = winnerId === String(p.id)
@@ -681,7 +661,23 @@ export default function SessionPage() {
       )}
 
       <div className="card">
-        <h2>计分板</h2>
+        <div className="flex-between" style={{ marginBottom: 16 }}>
+          <h2 style={{ marginBottom: 0 }}>计分板</h2>
+          <div style={{ textAlign: 'right', display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <span className="session-meta" style={{ margin: 0, fontSize: '0.85rem' }}>
+              {session.gameModeDisplayName} &middot; {new Date(session.createdAt).toLocaleDateString()}
+              &nbsp;
+              <span className={`badge ${session.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
+                {session.status === 'IN_PROGRESS' ? '进行中' : '已结束'}
+              </span>
+            </span>
+            {session.status === 'IN_PROGRESS' && (
+              <button className="btn btn-danger btn-small" onClick={handleComplete} disabled={submitting}>
+                结束游戏
+              </button>
+            )}
+          </div>
+        </div>
         <div className="score-table">
           <table>
             <thead>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -419,8 +419,6 @@ export default function SessionPage() {
       {session.status === 'IN_PROGRESS' && (
         <div className="card round-form-card">
           <div className="round-form">
-            <h3 className="round-form-title">添加对局</h3>
-
             {isRiichi && (
               <div className="form-group" style={{ marginBottom: 16 }}>
                 <label className="zimo-toggle">
@@ -617,17 +615,17 @@ export default function SessionPage() {
                 </div>
 
                 {!isRiichi && isGuobiao && (
-                  <div className="form-group">
+                  <div className="form-group score-inline-group">
                     <label>分数</label>
-                    <div className="score-input-row">
-                      <input
-                        type="number"
-                        value={score}
-                        onChange={(e) => setScore(e.target.value)}
-                        placeholder="输入分数"
-                        min="8"
-                      />
-                    </div>
+                    <input
+                      type="number"
+                      value={score}
+                      onChange={(e) => setScore(e.target.value)}
+                      placeholder="输入分数"
+                      min="8"
+                      className="score-input-compact"
+                    />
+                  </div>
                     <div className="inline-calc-wrapper">
                       <GuobiaoCalculator
                         key={`${gbWinds?.quanfeng || 1}-${winnerMenfeng}`}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -578,8 +578,8 @@ export default function SessionPage() {
                   </div>
                 )}
 
-                <div className="form-group full-width no-border-top">
-                  <h4 className="form-section-title">胜负选择</h4>
+                <div className="quick-win-container" style={{ gridColumn: '1 / -1', marginBottom: '16px' }}>
+                  <h2>胜负选择</h2>
                   <div className="quick-win-row">
                     {session.players.map((p, idx) => {
                       const isWinner = winnerId === String(p.id)


### PR DESCRIPTION
太棒了！这次咱们对对局页面进行了一场非常彻底的“大扫除”和“微整形”。

### 🚀 本次 UI/UX 优化回顾：

1.  **交互逻辑重组**：将“算番器”录入区置顶，让录入操作触手可及。
2.  **空间极致释放**：
    *   整合了顶部的冗余卡片，将模式和日期信息无缝嵌入计分板。
    *   精简了标题和分割线，消除了旧代码遗留的淡黄色“杂线”。
3.  **算番器视觉升级**：
    *   按钮采用了更紧凑的内边距，右上角风向改为精致的**垂直居中圆形角标**。
    *   标题样式与计分板完全统一，视觉上更加专业。
4.  **稳定性修复**：修复了重构过程中的 JSX 语法错误，确保项目编译顺畅。

代码已经全部推送到 `feature/new-logic-enhancement` 并提交了 PR。这次的界面调整让整个录入流程像德芙一样丝滑！还有什么新想法，随时告诉我。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added season filtering and client-side pagination to the dashboard with page controls and page-info display.

* **Style**
  * Reorganized in-progress session layout: round "Add" form moved earlier and scoreboard placed into its own card for clearer flow.
  * Compacted score input layout for certain scoring modes with inline/compact input classes for denser, quicker entry.
  * Reshaped quick-action area with a visible title; adjusted player button spacing, min-height, and badge alignment.
  * Removed top spacing/border from round form and added related utility layout classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->