### PR TITLE
feat: add champion player search to fan table

### DIFF
--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -124,11 +124,15 @@ const FanTablePage: React.FC = () => {
         item.fan.toString() === lowerSearch
       )
         return true
-      // Also match against current and previous season champion player names
+      // Also match against visible champion badges only (mirrors hasCurrent / hasPrev display logic)
       if (activeTab === 'guobiao' && seasonKey !== 'all') {
         const currentChampion = discoveriesMap[item.name]?.playerName?.toLowerCase()
-        const prevChampion = prevDiscoveriesMap[item.name]?.playerName?.toLowerCase()
-        if (currentChampion?.includes(lowerSearch) || prevChampion?.includes(lowerSearch)) return true
+        if (currentChampion?.includes(lowerSearch)) return true
+        // Only match prev champion if there is no current-season champion (i.e. prevDiscovery badge is visible)
+        if (!currentChampion) {
+          const prevChampion = prevDiscoveriesMap[item.name]?.playerName?.toLowerCase()
+          if (prevChampion?.includes(lowerSearch)) return true
+        }
       }
       return false
     })

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -126,10 +126,11 @@ const FanTablePage: React.FC = () => {
         return true
       // Also match against visible champion badges only (mirrors hasCurrent / hasPrev display logic)
       if (activeTab === 'guobiao' && seasonKey !== 'all') {
-        const currentChampion = discoveriesMap[item.name]?.playerName?.toLowerCase()
+        const currentDiscovery = discoveriesMap[item.name]
+        const currentChampion = currentDiscovery?.playerName?.toLowerCase()
         if (currentChampion?.includes(lowerSearch)) return true
-        // Only match prev champion if there is no current-season champion (i.e. prevDiscovery badge is visible)
-        if (!currentChampion) {
+        // Only match prev champion if there is no current-season champion discovery object
+        if (!currentDiscovery) {
           const prevChampion = prevDiscoveriesMap[item.name]?.playerName?.toLowerCase()
           if (prevChampion?.includes(lowerSearch)) return true
         }

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -117,13 +117,22 @@ const FanTablePage: React.FC = () => {
 
     if (!search.trim()) return data
     const lowerSearch = search.toLowerCase().trim()
-    return data.filter(
-      (item) =>
+    return data.filter((item) => {
+      if (
         item.name.toLowerCase().includes(lowerSearch) ||
         item.description.toLowerCase().includes(lowerSearch) ||
         item.fan.toString() === lowerSearch
-    )
-  }, [search, activeTab])
+      )
+        return true
+      // Also match against current and previous season champion player names
+      if (activeTab === 'guobiao' && seasonKey !== 'all') {
+        const currentChampion = discoveriesMap[item.name]?.playerName?.toLowerCase()
+        const prevChampion = prevDiscoveriesMap[item.name]?.playerName?.toLowerCase()
+        if (currentChampion?.includes(lowerSearch) || prevChampion?.includes(lowerSearch)) return true
+      }
+      return false
+    })
+  }, [search, activeTab, discoveriesMap, prevDiscoveriesMap, seasonKey])
 
   const groupedAndSortedFans = useMemo(() => {
     const grouped = filteredFanTable.reduce((acc, current) => {
@@ -197,7 +206,7 @@ const FanTablePage: React.FC = () => {
         <div style={{ display: 'flex', gap: '16px', marginBottom: '24px', flexWrap: 'wrap', alignItems: 'center' }}>
           <input
             type="text"
-            placeholder="搜索番名、分数或描述..."
+            placeholder="搜索番名、分数、描述或冠名玩家..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             style={{ flex: 1, minWidth: '200px' }}


### PR DESCRIPTION
**PR #68：番表冠名玩家搜索**

在番表的搜索框中加入了对冠名玩家名称的支持。

**功能**：搜索玩家名（如 `player1`）时，会过滤出该玩家持有可见冠名角标的番种。

**实现细节**：过滤逻辑严格对齐角标的显示规则——若某番种本赛季已有冠名，则只匹配本月冠名玩家；只有在本赛季尚未被发现时，才会匹配历史冠名玩家（即历史角标实际可见的情况）。这样避免了搜索历史冠名但显示本月冠名的"鸠占鹊巢"问题。

**影响范围**：仅修改 `FanTablePage.tsx` 中的 `filteredFanTable` 过滤逻辑及搜索框 placeholder，无后端变更。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced seasonal search filtering to include "named player" matching in addition to fan type fields, providing more comprehensive results.
  * Implemented fallback to historical player naming when current season records are unavailable.
  * Updated search input placeholder text to reflect the expanded search scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->