### PR TITLE
style: mobile layout fixes for champion badges and dashboard header

### DIFF
--- a/ui/src/data/fanTableData.ts
+++ b/ui/src/data/fanTableData.ts
@@ -49,7 +49,7 @@ export const fanTableData: FanItem[] = [
     fan: 88,
     name: '十三幺',
     description: '由3种序数牌的一、九牌，7种字牌及其中一对作将组成的和牌。不计五门齐、不求人、单钓将。',
-    example: '*Man1 | *Man9 | *Pin1 | *Pin9 | *Sou1 | *Sou9 | *Ton | *Nan | *Shaa | *Pei | *Haku | *Hatsu | *Chun Chun',
+    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun Chun',
   },
   {
     fan: 64,

--- a/ui/src/data/fanTableData.ts
+++ b/ui/src/data/fanTableData.ts
@@ -128,8 +128,7 @@ export const fanTableData: FanItem[] = [
     name: '七星不靠',
     description:
       '必须有7个单张的东西南北中发白，加上3种花色，数位按147、258、369中的7张序数牌组成没有将牌的和牌。不计五门齐、不求人、单钓将。',
-    example:
-      '*Man1 | *Man4 | *Man7 | *Pin2 | *Pin5 | *Pin8 | *Sou3 | *Ton | *Nan | *Shaa | *Pei | *Haku | *Hatsu | *Chun',
+    example: '*Man1 Man4 Man7 Pin2 Pin5 Pin8 Sou3 Ton Nan Shaa Pei Haku Hatsu Chun',
   },
   {
     fan: 24,
@@ -214,8 +213,7 @@ export const fanTableData: FanItem[] = [
     name: '全不靠',
     description:
       '由单张3种花色147、258、369不能错位的序数牌及东南西北中发白中的任何14张牌组成的和牌。不计五门齐、不求人、单钓将。',
-    example:
-      '*Man1 | *Man4 | *Man7 | *Pin2 | *Pin5 | *Pin8 | *Sou3 | *Sou6 | *Sou9 | *Ton | *Shaa | *Haku | *Hatsu | *Chun',
+    example: '*Man1 Man4 Man7 Pin2 Pin5 Pin8 Sou3 Sou6 Sou9 Ton Shaa Haku Hatsu Chun',
   },
   {
     fan: 12,

--- a/ui/src/data/riichiFanTableData.ts
+++ b/ui/src/data/riichiFanTableData.ts
@@ -210,7 +210,7 @@ export const riichiFanTableData: RiichiFanItem[] = [
     fan: 13,
     name: '国士无双',
     description: '由13种一、九及字牌各一张，外加其中任何一种的一张组成的和牌。门前清限定。',
-    example: '*Man1 | *Man9 | *Pin1 | *Pin9 | *Sou1 | *Sou9 | *Ton | *Nan | *Shaa | *Pei | *Haku | *Hatsu | *Chun Chun',
+    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun Chun',
   },
   {
     fan: 13,
@@ -273,7 +273,7 @@ export const riichiFanTableData: RiichiFanItem[] = [
     fan: 26,
     name: '国士无双十三面听',
     description: '手牌先集齐13种么九牌各一张，听所有13种么九牌。',
-    example: '*Man1 *Man9 *Pin1 *Pin9 *Sou1 *Sou9 *Ton *Nan *Shaa *Pei *Haku *Hatsu *Chun | ^Chun',
+    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun ^Chun',
   },
   {
     fan: 26,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2874,11 +2874,6 @@ tr:hover td {
     padding: 4px;
   }
 
-  .fan-item-example-container,
-  .fan-item-example-real {
-    margin-top: 12px;
-  }
-
   .fan-item-example {
     padding: 12px 6px 6px 6px;
   }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2863,15 +2863,15 @@ tr:hover td {
   }
 
   main {
-    padding: 12px;
+    padding: 2px;
   }
 
   .fan-table-page .card {
-    padding: 12px;
+    padding: 2px;
   }
 
   .fan-item-card {
-    padding: 8px;
+    padding: 4px;
   }
 
   .fan-item-example-container,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1739,6 +1739,12 @@ tr:hover td {
   padding: 1px;
 }
 
+@media (max-width: 480px) {
+  .mahjong-tile {
+    max-width: 18px;
+  }
+}
+
 .mahjong-tile[src*='Back'] {
   /* Transform the red SVG into a fresh, light Tiffany Blue style */
   filter: hue-rotate(185deg) brightness(1.3) saturate(0.6) contrast(0.95);

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2861,6 +2861,31 @@ tr:hover td {
     gap: 16px;
     grid-template-columns: 1fr;
   }
+
+  main {
+    padding: 12px;
+  }
+
+  .fan-table-page .card {
+    padding: 12px;
+  }
+
+  .fan-item-card {
+    padding: 8px;
+  }
+
+  .fan-item-example-container,
+  .fan-item-example-real {
+    margin-top: 12px;
+  }
+
+  .fan-item-example {
+    padding: 12px 6px 6px 6px;
+  }
+
+  .fan-item-example-real {
+    padding: 12px 6px 6px 6px;
+  }
 }
 
 .pagination-container {

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -82,8 +82,17 @@ export default function DashboardPage() {
         className="flex-between"
         style={{ padding: '16px 24px', borderBottom: '1px solid var(--border)', flexWrap: 'wrap', gap: '12px' }}
       >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-          <h2 style={{ margin: 0 }}>对局历史</h2>
+        <h2 style={{ margin: 0, whiteSpace: 'nowrap' }}>对局历史</h2>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+            flex: 1,
+            justifyContent: 'flex-end',
+            flexWrap: 'wrap',
+          }}
+        >
           <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">
             <option value="all">全部赛季</option>
             {seasons.map((s) => (
@@ -92,10 +101,10 @@ export default function DashboardPage() {
               </option>
             ))}
           </select>
+          <Link to="/new-session" className="btn btn-primary" style={{ whiteSpace: 'nowrap' }}>
+            + 新建游戏
+          </Link>
         </div>
-        <Link to="/new-session" className="btn btn-primary">
-          + 新建游戏
-        </Link>
       </div>
 
       {filteredSessions.length === 0 ? (

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -80,17 +80,16 @@ export default function DashboardPage() {
     <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
       <div
         className="flex-between"
-        style={{ padding: '16px 24px', borderBottom: '1px solid var(--border)', flexWrap: 'wrap', gap: '12px' }}
+        style={{ padding: '16px 24px', borderBottom: '1px solid var(--border)', gap: '12px' }}
       >
         <h2 style={{ margin: 0, whiteSpace: 'nowrap' }}>对局历史</h2>
         <div
           style={{
             display: 'flex',
             alignItems: 'center',
-            gap: '12px',
+            gap: '8px',
             flex: 1,
             justifyContent: 'flex-end',
-            flexWrap: 'wrap',
           }}
         >
           <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -5,6 +5,7 @@ import { shenyangFanTableData } from '../data/shenyangFanTableData'
 import { fetchFanDiscoveries, fetchActiveSeasons } from '../api'
 import { FanDiscovery, getCurrentSeason, getSeasonLabel, Season } from '../types'
 import { MahjongHand } from '../components/MahjongHand'
+import { nameFontSize } from '../utils/fontSize'
 
 type TabType = 'guobiao' | 'riichi' | 'shenyang'
 
@@ -247,12 +248,19 @@ const FanTablePage: React.FC = () => {
                 return (
                   <div key={item.name} className="fan-item-card">
                     <div className="fan-item-header">
-                      <span className="fan-item-name" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      <span
+                        className="fan-item-name"
+                        style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}
+                      >
                         {item.name}
                         {hasCurrent && (
                           <span
                             className="badge badge-discovery"
-                            style={{ fontSize: '0.7rem', padding: '2px 8px', borderRadius: '4px' }}
+                            style={{
+                              fontSize: nameFontSize(currentDiscovery.playerName),
+                              padding: '2px 8px',
+                              borderRadius: '4px',
+                            }}
                             title={`首位达成者: ${currentDiscovery.playerName}${
                               (currentDiscovery.bonusRp ?? 0) > 0 ? ` (+${currentDiscovery.bonusRp} RP)` : ''
                             }`}
@@ -264,7 +272,11 @@ const FanTablePage: React.FC = () => {
                         {hasPrev && (
                           <span
                             className="badge badge-discovery-prev"
-                            style={{ fontSize: '0.7rem', padding: '2px 8px', borderRadius: '4px' }}
+                            style={{
+                              fontSize: nameFontSize(prevDiscovery.playerName),
+                              padding: '2px 8px',
+                              borderRadius: '4px',
+                            }}
                             title={`历史冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
                           >
                             历史冠名: {prevDiscovery.playerName}


### PR DESCRIPTION
目前 PR #69 已经包含了所有的 UI 优化和番型展示修正：
1. **看板标题**：修复手机端折行，赛季选择框右对齐。
2. **长冠名优化**：增加自动缩放字号和弹性换行逻辑。
3. **空间极限压缩**：手机端边距压至 2px/4px，牌面缩小 20%，彻底告别横向滚动条。
4. **番型模式高亮**：全不靠、七星不靠、十三幺（国士无双）全部改为 14 张牌整体高亮。