### PR TITLE
feat: auto-derive dealer/honba/kyoutaku, riichi tracking, and mobile fixes

### DIFF
--- a/.claude/commands/audit-ui.md
+++ b/.claude/commands/audit-ui.md
@@ -13,6 +13,9 @@ Check every file in ui/src/pages/ and ui/src/App.tsx for any user-visible Englis
 Note: SignUpPage.tsx ("Join Leo's friends' mahjong games!") is intentionally English — do not flag it.
 Note: AdminPage.tsx is intentionally English — do not flag it.
 Note: Game session default names ("Game #1", "Game 4/21/2026 17:19") are intentionally English — do not flag it.
+Note: App.tsx "Mahjong Omakase" in the header is intentional branding — do not flag it.
+Note: HomePage.tsx footer "© 2026 Mahjong Omakase Team · Let's NB!" is intentional — do not flag it.
+Note: Japanese Riichi terms (役満, 三倍満, 倍満, 跳満, 満貫) in SessionPage fan selector are intentional domain terminology — do not flag them.
 Note: Only flag text that is visually rendered to users. Do not flag non-visible text such as `alt` attributes, `title` attributes, HTML comments, console logs, variable names, etc.
 
 ## Part 2: Mobile Check

--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -34,6 +34,8 @@ public class AddRoundRequest {
 
   private List<Long> tenpaiPlayerIds; // for drawn games
 
+  private List<Long> riichiPlayerIds; // players who declared riichi
+
   private String winHand;
 
   private String fanDetails;
@@ -175,5 +177,13 @@ public class AddRoundRequest {
 
   public void setTenpaiPlayerIds(List<Long> tenpaiPlayerIds) {
     this.tenpaiPlayerIds = tenpaiPlayerIds;
+  }
+
+  public List<Long> getRiichiPlayerIds() {
+    return riichiPlayerIds;
+  }
+
+  public void setRiichiPlayerIds(List<Long> riichiPlayerIds) {
+    this.riichiPlayerIds = riichiPlayerIds;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -70,6 +70,7 @@ public class SessionDetailResponse {
     private Long dealInPlayerId;
     private String dealInPlayerName;
     private Integer prevalentWind;
+    private List<Long> riichiPlayerIds;
 
     public RoundInfo(
         int roundNumber,
@@ -80,7 +81,8 @@ public class SessionDetailResponse {
         Integer fanCount,
         Long dealInPlayerId,
         String dealInPlayerName,
-        Integer prevalentWind) {
+        Integer prevalentWind,
+        List<Long> riichiPlayerIds) {
       this.roundNumber = roundNumber;
       this.scores = scores;
       this.winnerId = winnerId;
@@ -90,6 +92,7 @@ public class SessionDetailResponse {
       this.dealInPlayerId = dealInPlayerId;
       this.dealInPlayerName = dealInPlayerName;
       this.prevalentWind = prevalentWind;
+      this.riichiPlayerIds = riichiPlayerIds;
     }
 
     public int getRoundNumber() {
@@ -126,6 +129,10 @@ public class SessionDetailResponse {
 
     public Integer getPrevalentWind() {
       return prevalentWind;
+    }
+
+    public List<Long> getRiichiPlayerIds() {
+      return riichiPlayerIds;
     }
   }
 

--- a/server/src/main/java/com/mahjong/omakase/model/Round.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Round.java
@@ -34,6 +34,17 @@ public class Round {
   private Long dealInPlayerId;
   private Integer prevalentWind;
 
+  @Column(columnDefinition = "TEXT")
+  private String riichiPlayerIds;
+
+  public String getRiichiPlayerIds() {
+    return riichiPlayerIds;
+  }
+
+  public void setRiichiPlayerIds(String riichiPlayerIds) {
+    this.riichiPlayerIds = riichiPlayerIds;
+  }
+
   public Integer getPrevalentWind() {
     return prevalentWind;
   }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -326,6 +326,17 @@ public class GameService {
                     dealInName = playerNameMap.getOrDefault(round.getDealInPlayerId(), "?");
                   }
 
+                  List<Long> riichiIds = null;
+                  if (round.getRiichiPlayerIds() != null
+                      && !round.getRiichiPlayerIds().isBlank()) {
+                    riichiIds =
+                        Arrays.stream(round.getRiichiPlayerIds().split(","))
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .map(Long::valueOf)
+                            .toList();
+                  }
+
                   return new SessionDetailResponse.RoundInfo(
                       round.getRoundNumber(),
                       scores,
@@ -335,7 +346,8 @@ public class GameService {
                       round.getFanCount(),
                       round.getDealInPlayerId(),
                       dealInName,
-                      round.getPrevalentWind());
+                      round.getPrevalentWind(),
+                      riichiIds);
                 })
             .collect(Collectors.toList()));
 
@@ -410,7 +422,8 @@ public class GameService {
         request.getFanDetails(),
         request.getFanCount(),
         request.isSelfDraw() ? null : request.getDealInPlayerId(),
-        request.getPrevalentWind());
+        request.getPrevalentWind(),
+        request.getRiichiPlayerIds());
   }
 
   public void deleteRound(Long sessionId, int roundNumber) {
@@ -720,7 +733,8 @@ public class GameService {
       String fanDetails,
       Integer fanCount,
       Long dealInId,
-      Integer prevalentWind) {
+      Integer prevalentWind,
+      List<Long> riichiPlayerIds) {
     Round round = new Round();
     round.setGameSession(session);
     round.setRoundNumber(roundNumber);
@@ -730,6 +744,10 @@ public class GameService {
     round.setFanCount(fanCount);
     round.setDealInPlayerId(dealInId);
     round.setPrevalentWind(prevalentWind);
+    if (riichiPlayerIds != null && !riichiPlayerIds.isEmpty()) {
+      round.setRiichiPlayerIds(
+          riichiPlayerIds.stream().map(String::valueOf).collect(Collectors.joining(",")));
+    }
 
     round = roundRepo.save(round);
 

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -327,8 +327,7 @@ public class GameService {
                   }
 
                   List<Long> riichiIds = null;
-                  if (round.getRiichiPlayerIds() != null
-                      && !round.getRiichiPlayerIds().isBlank()) {
+                  if (round.getRiichiPlayerIds() != null && !round.getRiichiPlayerIds().isBlank()) {
                     riichiIds =
                         Arrays.stream(round.getRiichiPlayerIds().split(","))
                             .map(String::trim)

--- a/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
@@ -91,6 +91,13 @@ public class RiichiModeHandler implements GameModeHandler {
         }
       }
     }
+    // Riichi stick deductions: -1000 per declaring player
+    List<Long> riichiIds = request.getRiichiPlayerIds();
+    if (riichiIds != null) {
+      for (Long id : riichiIds) {
+        scores.merge(id, -1000, Integer::sum);
+      }
+    }
     return scores;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
@@ -4,8 +4,10 @@ import com.mahjong.omakase.dto.AddRoundRequest;
 import com.mahjong.omakase.model.GameMode;
 import com.mahjong.omakase.service.scoring.RiichiScoreCalculator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -94,7 +96,11 @@ public class RiichiModeHandler implements GameModeHandler {
     // Riichi stick deductions: -1000 per declaring player
     List<Long> riichiIds = request.getRiichiPlayerIds();
     if (riichiIds != null) {
-      for (Long id : riichiIds) {
+      Set<Long> uniqueRiichiIds = new HashSet<>(riichiIds);
+      for (Long id : uniqueRiichiIds) {
+        if (id == null || !sessionPlayerIds.contains(id)) {
+          throw new IllegalArgumentException("Riichi player " + id + " is not in this session");
+        }
         scores.merge(id, -1000, Integer::sum);
       }
     }

--- a/ui/src/components/ActiveGameCard.tsx
+++ b/ui/src/components/ActiveGameCard.tsx
@@ -1,28 +1,15 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { SessionDetail } from '../types'
+import { deriveGameState, getWindName } from '../utils/gameState'
 
 interface Props {
   session: SessionDetail
 }
 
 export const ActiveGameCard: React.FC<Props> = ({ session }) => {
-  const getWindName = (w: number) => ['东', '南', '西', '北'][(w - 1) % 4]
+  const state = deriveGameState(session)
 
-  const nextRoundNum = session.rounds.length + 1
-  const lastRound = session.rounds.length > 0 ? session.rounds[session.rounds.length - 1] : null
-  let qf = (Math.floor((nextRoundNum - 1) / 4) % 4) + 1
-  if (lastRound?.prevalentWind != null) {
-    const nextGroup = Math.floor((nextRoundNum - 1) / 4)
-    const lastGroup = Math.floor((session.rounds.length - 1) / 4)
-    qf = ((lastRound.prevalentWind - 1 + (nextGroup - lastGroup)) % 4) + 1
-  }
-  const hand = ((nextRoundNum - 1) % 4) + 1
-  const roundStatus = `${getWindName(qf)}${hand}`
-
-  const dealerSeat = ((nextRoundNum - 1) % 4) + 1
-
-  // Compute stable standard ranks from scores
   const sortedScores = session.players.map((p) => session.totalScores[p.id] || 0).sort((a, b) => b - a)
   const getRank = (score: number) => sortedScores.indexOf(score) + 1
 
@@ -30,7 +17,7 @@ export const ActiveGameCard: React.FC<Props> = ({ session }) => {
     <Link to={`/session/${session.id}`} className="active-game-card">
       <div className="active-game-header">
         <span className="active-game-mode">{session.gameModeDisplayName}</span>
-        <span className="badge badge-progress">{roundStatus} 进行中</span>
+        <span className="badge badge-progress">{state.displayName} 进行中</span>
       </div>
       <div className="active-game-players">
         {[...session.players]
@@ -38,10 +25,9 @@ export const ActiveGameCard: React.FC<Props> = ({ session }) => {
           .map((p) => {
             const score = session.totalScores[p.id] || 0
             const rank = getRank(score)
-            const originalIdx = session.players.findIndex((op) => op.id === p.id)
-            const seat = p.seat ?? originalIdx + 1
-            const menfeng = ((seat - dealerSeat + 4) % 4) + 1
-            const isDealer = seat === dealerSeat
+            const seat = p.seat ?? session.players.findIndex((op) => op.id === p.id) + 1
+            const menfeng = ((seat - state.dealerSeat + state.playerCount) % state.playerCount) + 1
+            const isDealer = p.id === state.dealerPlayerId
             return (
               <div key={p.id} className="active-game-player-row">
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1489,6 +1489,11 @@ tr:hover td {
     letter-spacing: 2px;
   }
 
+  .home-start-btn {
+    width: auto;
+    display: inline-flex;
+  }
+
   .landing-features {
     grid-template-columns: 1fr;
     gap: 12px;
@@ -1550,6 +1555,45 @@ tr:hover td {
 
   .options-grid.compact {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .fan-item-header {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .fan-item-name {
+    flex-wrap: wrap;
+  }
+
+  .ting-row-item {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .ting-row-item .fan-list-mini {
+    width: 100%;
+  }
+
+  .tile-grid-compact {
+    grid-template-columns: repeat(9, 1fr);
+  }
+
+  .active-games-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .round-form .score-inline-group {
+    flex-wrap: wrap;
+  }
+
+  .options-grid.compact.cols-3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .quick-win-container {
+    margin-bottom: 12px;
   }
 }
 
@@ -1772,7 +1816,7 @@ tr:hover td {
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: auto;
 }
 .calc-top-row {
   display: flex;
@@ -2283,6 +2327,11 @@ tr:hover td {
 }
 
 /* Quick Win Selection */
+.quick-win-container {
+  grid-column: 1 / -1;
+  margin-bottom: 16px;
+}
+
 .quick-win-row {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -2422,6 +2471,12 @@ tr:hover td {
   margin-top: 2px;
 }
 
+.quick-player-btn .btn-wind-dealer {
+  color: var(--danger);
+  font-weight: 600;
+  opacity: 1;
+}
+
 @media (max-width: 600px) {
   .quick-win-row {
     gap: 4px;
@@ -2550,14 +2605,13 @@ tr:hover td {
 /* Hall of Fame Styles */
 .hall-of-fame-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: 1fr;
   gap: 24px;
   margin-top: 16px;
 }
 
 @media (max-width: 600px) {
   .hall-of-fame-grid {
-    grid-template-columns: 1fr;
     gap: 16px;
   }
 }
@@ -2855,7 +2909,7 @@ tr:hover td {
   color: var(--danger);
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   .dashboard-sessions-list {
     padding: 16px;
     gap: 16px;

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -188,14 +188,14 @@ export default function AdminPage() {
         <h2>Settings</h2>
         <div className="form-group">
           <label>Participation Bonus (RP per game)</label>
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
             <input
               type="number"
               value={bonus}
               onChange={(e) => setBonus(parseFloat(e.target.value) || 0)}
               step="0.1"
               min="0"
-              style={{ width: 120 }}
+              style={{ width: '100%', maxWidth: 120 }}
             />
             <button
               className="btn btn-primary btn-small"
@@ -229,18 +229,18 @@ export default function AdminPage() {
                   <td>{p.userName}</td>
                   <td>
                     {editingId === p.id ? (
-                      <div style={{ display: 'flex', gap: 6 }}>
+                      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                         <input
                           value={editFirst}
                           onChange={(e) => setEditFirst(e.target.value)}
-                          style={{ width: 80 }}
+                          style={{ width: '100%', maxWidth: 80 }}
                           placeholder="First"
                           autoFocus
                         />
                         <input
                           value={editLast}
                           onChange={(e) => setEditLast(e.target.value)}
-                          style={{ width: 80 }}
+                          style={{ width: '100%', maxWidth: 80 }}
                           placeholder="Last"
                           onKeyDown={(e) => e.key === 'Enter' && handleSave(p.id)}
                         />

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -90,6 +90,7 @@ export default function DashboardPage() {
             gap: '8px',
             flex: 1,
             justifyContent: 'flex-end',
+            flexWrap: 'wrap',
           }}
         >
           <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -215,7 +215,7 @@ const FanTablePage: React.FC = () => {
             placeholder="搜索番名、分数、描述或冠名玩家..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            style={{ flex: 1, minWidth: '200px' }}
+            style={{ flex: 1, minWidth: 0 }}
           />
           {activeTab === 'guobiao' && seasons.length > 0 && (
             <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -91,19 +91,18 @@ export default function HomePage() {
   return (
     <div className="home-hub">
       <div style={{ marginBottom: '40px', textAlign: 'center' }}>
+        <div style={{ marginBottom: '16px' }}>
+          <img src="/logo-header.png" alt="" style={{ height: '64px', width: 'auto' }} />
+        </div>
         <Link
           to="/new-session"
-          className="btn btn-accent btn-hero-shine"
+          className="btn btn-accent btn-hero-shine home-start-btn"
           style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: '12px',
             fontSize: '1.1rem',
             padding: '12px 24px',
             borderRadius: '50px',
           }}
         >
-          <img src="/logo-header.png" alt="" style={{ height: '24px', width: 'auto' }} />
           麻将，启动！
         </Link>
       </div>

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -54,7 +54,7 @@ export default function PlayerDetailPage() {
           </div>
         ) : (
           <div className="score-table">
-            <table>
+            <table style={{ minWidth: 340 }}>
               <thead>
                 <tr>
                   <th>游戏</th>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -385,11 +385,14 @@ export default function SessionPage() {
                       <span
                         key={p.id}
                         className={`chip ${tenpaiPlayerIds.includes(p.id) ? 'selected' : ''}`}
-                        onClick={() =>
+                        onClick={() => {
                           setTenpaiPlayerIds((prev) =>
                             prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
                           )
-                        }
+                          if (tenpaiPlayerIds.includes(p.id)) {
+                            setRiichiPlayerIds((prev) => prev.filter((id) => id !== p.id))
+                          }
+                        }}
                         style={{ cursor: 'pointer' }}
                       >
                         {p.userName}
@@ -414,11 +417,16 @@ export default function SessionPage() {
                       <span
                         key={p.id}
                         className={`chip ${riichiPlayerIds.includes(p.id) ? 'selected' : ''}`}
-                        onClick={() =>
-                          setRiichiPlayerIds((prev) =>
-                            prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
-                          )
-                        }
+                        onClick={() => {
+                          if (riichiPlayerIds.includes(p.id)) {
+                            setRiichiPlayerIds((prev) => prev.filter((id) => id !== p.id))
+                          } else {
+                            setRiichiPlayerIds((prev) => [...prev, p.id])
+                            if (!tenpaiPlayerIds.includes(p.id)) {
+                              setTenpaiPlayerIds((prev) => [...prev, p.id])
+                            }
+                          }
+                        }}
                         style={{ cursor: 'pointer' }}
                       >
                         {p.userName}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -6,6 +6,7 @@ import { calculateRanks } from '../logic/ranking'
 import { GuobiaoCalculator } from '../components/GuobiaoCalculator'
 import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
+import { deriveGameState, deriveRoundState, getWindName } from '../utils/gameState'
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>()
@@ -14,20 +15,17 @@ export default function SessionPage() {
   const [score, setScore] = useState('')
   const [fan, setFan] = useState<string>('')
   const [fu, setFu] = useState<string>('')
-  const [dealerId, setDealerId] = useState<string>('')
-  const [honba, setHonba] = useState<string>('0')
-  const [kyoutaku, setKyoutaku] = useState<string>('0')
   const [isSelfDraw, setIsSelfDraw] = useState(false)
   const [dealInPlayerId, setDealInPlayerId] = useState<string>('')
   const [bimenPlayerIds, setBimenPlayerIds] = useState<number[]>([])
   const [isRyuukyoku, setIsRyuukyoku] = useState(false)
   const [tenpaiPlayerIds, setTenpaiPlayerIds] = useState<number[]>([])
+  const [riichiPlayerIds, setRiichiPlayerIds] = useState<number[]>([])
   const [calcResetCount, setCalcResetCount] = useState(0)
   const [submitting, setSubmitting] = useState(false)
   const [winHand, setWinHand] = useState<string>('')
   const [fanDetails, setFanDetails] = useState<string>('')
   const [fanCount, setFanCount] = useState<number>(0)
-  const [manualQuanfeng, setManualQuanfeng] = useState<number | null>(null)
   const [error, setError] = useState('')
 
   const handleCalcScoreSelect = useCallback((s: number | null, hand?: string, details?: string, fCount?: number) => {
@@ -75,12 +73,10 @@ export default function SessionPage() {
     setDealInPlayerId('')
     setIsRyuukyoku(false)
     setTenpaiPlayerIds([])
-    setHonba('0')
-    setKyoutaku('0')
+    setRiichiPlayerIds([])
     setWinHand('')
     setFanDetails('')
     setFanCount(0)
-    setManualQuanfeng(null)
     setCalcResetCount((prev) => prev + 1)
   }
 
@@ -113,9 +109,9 @@ export default function SessionPage() {
   const canSubmit =
     winnerId &&
     (isRiichi
-      ? fan && fu && dealerId
+      ? fan && fu
       : isDongbei
-      ? fan && dealerId
+      ? fan
       : score && parseInt(score) >= (isGuobiao ? 8 : 1)) &&
     (isSelfDraw || dealInPlayerId)
 
@@ -127,6 +123,7 @@ export default function SessionPage() {
         await addRound(session.id, {
           roundType: 'DRAWN_GAME',
           tenpaiPlayerIds,
+          riichiPlayerIds: riichiPlayerIds.length > 0 ? riichiPlayerIds : undefined,
         })
         resetForm()
         await load()
@@ -138,9 +135,9 @@ export default function SessionPage() {
           winnerId: Number(winnerId),
           fan: parseInt(fan),
           fu: parseInt(fu),
-          dealerId: Number(dealerId),
-          honba: parseInt(honba) || 0,
-          kyoutaku: parseInt(kyoutaku) || 0,
+          dealerId: gameState.dealerPlayerId,
+          honba: gameState.honba,
+          kyoutaku: gameState.kyoutaku,
           dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
           fanCount: parseInt(fan),
         })
@@ -148,7 +145,7 @@ export default function SessionPage() {
         await addRound(session.id, {
           winnerId: Number(winnerId),
           fan: parseInt(fan),
-          dealerId: Number(dealerId),
+          dealerId: gameState.dealerPlayerId,
           bimenPlayerIds,
           dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
           fanCount: parseInt(fan),
@@ -161,7 +158,7 @@ export default function SessionPage() {
           winHand,
           fanDetails,
           fanCount: fanCount || parseInt(score),
-          prevalentWind: gbWinds?.quanfeng,
+          prevalentWind: gameState.prevalentWind,
         })
       }
 
@@ -231,34 +228,7 @@ export default function SessionPage() {
   )
   const rankMap = Object.fromEntries(rankings.map((r) => [r.playerId, r]))
 
-  const getGuobiaoWinds = () => {
-    if (!isGuobiao) return null
-    const handIdx = session.rounds.length + 1
-
-    let qf: number
-    if (manualQuanfeng !== null) {
-      qf = manualQuanfeng
-    } else if (session.rounds.length > 0) {
-      const lastRound = session.rounds[session.rounds.length - 1]
-      // Use the stored prevalent wind from the last round, or fall back to calculation
-      const lastQf = lastRound.prevalentWind || (Math.floor((session.rounds.length - 1) / 4) % 4) + 1
-
-      if (handIdx > 1 && (handIdx - 1) % 4 === 0) {
-        // Every 4 rounds, the wind should increment (e.g. 5th, 9th, 13th round)
-        qf = (lastQf % 4) + 1
-      } else {
-        // Otherwise stay the same as the previous round
-        qf = lastQf
-      }
-    } else {
-      // First round default
-      qf = (Math.floor((handIdx - 1) / 4) % 4) + 1
-    }
-
-    const dealerSeat = ((handIdx - 1) % 4) + 1
-    return { quanfeng: qf, dealerSeat, handIdx }
-  }
-  const gbWinds = getGuobiaoWinds()
+  const gameState = deriveGameState(session)
 
   const winnerIndex = session.players.findIndex((p) => String(p.id) === winnerId)
 
@@ -267,32 +237,27 @@ export default function SessionPage() {
   }
 
   function getPlayerMenfeng(playerSeat: number) {
-    if (!gbWinds) return 1
-    return ((playerSeat - gbWinds.dealerSeat + 4) % 4) + 1
+    return ((playerSeat - gameState.dealerSeat + gameState.playerCount) % gameState.playerCount) + 1
   }
 
   const winnerMenfeng =
     winnerIndex !== -1 ? getPlayerMenfeng(getPlayerSeat(session.players[winnerIndex], winnerIndex)) : 1
 
-  const getWindName = (w: number) => ['东', '南', '西', '北'][w - 1] + '风'
-
-  const getRoundWind = (round: RoundInfo) => {
-    if (!isGuobiao) return null
-    const roundNum = round.roundNumber
-    const qf = round.prevalentWind || (Math.floor((roundNum - 1) / 4) % 4) + 1
-    const hand = ((roundNum - 1) % 4) + 1
-    return { qf, hand, name: `${['东', '南', '西', '北'][qf - 1]}${hand}` }
+  const getRoundLabel = (round: RoundInfo) => {
+    const state = deriveRoundState(session, round.roundNumber)
+    return state.displayName
   }
 
   const playerColPct = `${Math.floor(90 / session.players.length)}%`
-  const playerColStyle = { textAlign: 'center' as const, width: playerColPct, minWidth: 80 }
+  const playerColStyle = { textAlign: 'center' as const, width: playerColPct, minWidth: 56 }
 
   const otherPlayers = session.players.filter((p) => p.id !== Number(winnerId))
-  const winnerIsDealer = winnerId && dealerId && winnerId === dealerId
+  const dealerId = String(gameState.dealerPlayerId)
+  const winnerIsDealer = winnerId && winnerId === dealerId
 
   const getScorePreview = (): string | null => {
     if (isRiichi) {
-      if (!fan || !fu || !dealerId) return null
+      if (!fan || !fu) return null
       const h = parseInt(fan),
         f = parseInt(fu)
       let basic: number
@@ -304,9 +269,9 @@ export default function SessionPage() {
       else basic = Math.min(f * Math.pow(2, 2 + h), 2000)
 
       const r100 = (v: number) => Math.ceil(v / 100) * 100
-      const honbaNum = parseInt(honba) || 0
+      const honbaNum = gameState.honba
       const honbaBonus = 100 * honbaNum
-      const kyoutakuNum = parseInt(kyoutaku) || 0
+      const kyoutakuNum = gameState.kyoutaku
 
       if (isSelfDraw) {
         if (winnerIsDealer) {
@@ -335,7 +300,7 @@ export default function SessionPage() {
     }
 
     if (isDongbei) {
-      if (!fan || !dealerId || !winnerId) return null
+      if (!fan || !winnerId) return null
       const fanNum = parseInt(fan)
       const bimenSet = new Set(bimenPlayerIds)
       const opponents = session.players.filter((p) => p.id !== Number(winnerId))
@@ -398,6 +363,7 @@ export default function SessionPage() {
       {session.status === 'IN_PROGRESS' && (
         <div className="card round-form-card">
           <div className="round-form">
+            <h3 className="round-form-title">添加 — {gameState.displayName}</h3>
             {isRiichi && (
               <div className="form-group" style={{ marginBottom: 16 }}>
                 <label className="zimo-toggle">
@@ -445,6 +411,31 @@ export default function SessionPage() {
                         }`}
                   </span>
                 </div>
+                <div className="form-group">
+                  <label>选择立直玩家</label>
+                  <div className="player-chips">
+                    {session.players.map((p) => (
+                      <span
+                        key={p.id}
+                        className={`chip ${riichiPlayerIds.includes(p.id) ? 'selected' : ''}`}
+                        onClick={() =>
+                          setRiichiPlayerIds((prev) =>
+                            prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
+                          )
+                        }
+                        style={{ cursor: 'pointer' }}
+                      >
+                        {p.userName}
+                        {riichiPlayerIds.includes(p.id) && ' ✓'}
+                      </span>
+                    ))}
+                  </div>
+                  {riichiPlayerIds.length > 0 && (
+                    <span className="field-hint">
+                      {riichiPlayerIds.length}人立直 → 各扣1000, 供托 +{riichiPlayerIds.length * 1000}
+                    </span>
+                  )}
+                </div>
                 <button className="btn btn-primary" onClick={handleAddRound} disabled={submitting}>
                   {submitting ? '提交中...' : '添加流局'}
                 </button>
@@ -453,27 +444,6 @@ export default function SessionPage() {
               <>
                 {isRiichi ? (
                   <div className="round-form-grid">
-                    <div className="form-group">
-                      <label>亲家</label>
-                      <select value={dealerId} onChange={(e) => setDealerId(e.target.value)}>
-                        <option value=""></option>
-                        {session.players.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.userName}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div className="form-group">
-                      <label>本场</label>
-                      <input
-                        type="number"
-                        value={honba}
-                        onChange={(e) => setHonba(e.target.value)}
-                        min="0"
-                        placeholder="0"
-                      />
-                    </div>
                     <div className="form-group">
                       <label>
                         番
@@ -517,33 +487,11 @@ export default function SessionPage() {
                         ))}
                       </select>
                     </div>
-                    <div className="form-group">
-                      <label>供托</label>
-                      <input
-                        type="number"
-                        value={kyoutaku}
-                        onChange={(e) => setKyoutaku(e.target.value)}
-                        min="0"
-                        step="1000"
-                        placeholder="0"
-                      />
-                    </div>
                   </div>
                 ) : null}
 
                 {isDongbei && (
                   <div className="round-form-grid">
-                    <div className="form-group">
-                      <label>庄家</label>
-                      <select value={dealerId} onChange={(e) => setDealerId(e.target.value)}>
-                        <option value=""></option>
-                        {session.players.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.userName}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
                     <div className="form-group">
                       <label>番</label>
                       <input
@@ -557,7 +505,7 @@ export default function SessionPage() {
                   </div>
                 )}
 
-                <div className="quick-win-container" style={{ gridColumn: '1 / -1', marginBottom: '16px' }}>
+                <div className="quick-win-container">
                   <h2>算番器</h2>
                   <div className="quick-win-row">
                     {session.players.map((p, idx) => {
@@ -570,11 +518,10 @@ export default function SessionPage() {
                       return (
                         <button key={p.id} className={btnClass} onClick={() => handlePlayerClick(String(p.id))}>
                           <div className="btn-name">{p.userName}</div>
-                          {isGuobiao && (
-                            <div className="wind-badge small">
-                              {['东', '南', '西', '北'][getPlayerMenfeng(getPlayerSeat(p, idx)) - 1]}
-                            </div>
-                          )}
+                          <div className={`btn-wind${p.id === gameState.dealerPlayerId ? ' btn-wind-dealer' : ''}`}>
+                            {getWindName(getPlayerMenfeng(getPlayerSeat(p, idx)))}
+                            {p.id === gameState.dealerPlayerId ? ' 庄' : ''}
+                          </div>
                         </button>
                       )
                     })}
@@ -608,10 +555,10 @@ export default function SessionPage() {
                     </div>
                     <div className="inline-calc-wrapper">
                       <GuobiaoCalculator
-                        key={`${gbWinds?.quanfeng || 1}-${winnerMenfeng}`}
+                        key={`${gameState.prevalentWind}-${winnerMenfeng}`}
                         onSelectScore={handleCalcScoreSelect}
                         initialOptions={{
-                          quanfeng: gbWinds?.quanfeng || 1,
+                          quanfeng: gameState.prevalentWind,
                           menfeng: winnerMenfeng,
                         }}
                         resetTrigger={calcResetCount}
@@ -662,7 +609,7 @@ export default function SessionPage() {
       <div className="card">
         <div className="flex-between" style={{ marginBottom: 16 }}>
           <h2 style={{ marginBottom: 0 }}>计分板</h2>
-          <div style={{ textAlign: 'right', display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <div style={{ textAlign: 'right', display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
             <span className="session-meta" style={{ margin: 0, fontSize: '0.85rem' }}>
               {session.gameModeDisplayName} &middot; {new Date(session.createdAt).toLocaleDateString()}
               &nbsp;
@@ -702,24 +649,9 @@ export default function SessionPage() {
                     <tr>
                       <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
                         <div className="round-info-cell">
-                          {(() => {
-                            const rw = getRoundWind(round)
-                            return rw ? (
-                              <div
-                                style={{
-                                  display: 'flex',
-                                  flexDirection: 'column',
-                                  alignItems: 'center',
-                                  gap: '2px',
-                                  width: '100%',
-                                }}
-                              >
-                                <span className="round-wind-tag">{rw.name}</span>
-                              </div>
-                            ) : (
-                              <strong>#{round.roundNumber}</strong>
-                            )
-                          })()}
+                          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2px', width: '100%' }}>
+                            <span className="round-wind-tag">{getRoundLabel(round)}</span>
+                          </div>
                         </div>
                       </td>
                       {session.players.map((p) => {

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -108,11 +108,7 @@ export default function SessionPage() {
 
   const canSubmit =
     winnerId &&
-    (isRiichi
-      ? fan && fu
-      : isDongbei
-      ? fan
-      : score && parseInt(score) >= (isGuobiao ? 8 : 1)) &&
+    (isRiichi ? fan && fu : isDongbei ? fan : score && parseInt(score) >= (isGuobiao ? 8 : 1)) &&
     (isSelfDraw || dealInPlayerId)
 
   const handleAddRound = async () => {
@@ -649,7 +645,15 @@ export default function SessionPage() {
                     <tr>
                       <td style={{ whiteSpace: 'nowrap', textAlign: 'center' }}>
                         <div className="round-info-cell">
-                          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2px', width: '100%' }}>
+                          <div
+                            style={{
+                              display: 'flex',
+                              flexDirection: 'column',
+                              alignItems: 'center',
+                              gap: '2px',
+                              width: '100%',
+                            }}
+                          >
                             <span className="round-wind-tag">{getRoundLabel(round)}</span>
                           </div>
                         </div>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -51,6 +51,7 @@ export interface RoundInfo {
   dealInPlayerId?: number | null
   dealInPlayerName?: string | null
   prevalentWind?: number
+  riichiPlayerIds?: number[]
 }
 
 export interface SessionDetail {
@@ -81,6 +82,7 @@ export interface AddRoundData {
   bimenPlayerIds?: number[] // for Dongbei: 闭门 players
   dealInPlayerId?: number | null // null = 自摸
   tenpaiPlayerIds?: number[] // for drawn games
+  riichiPlayerIds?: number[] // players who declared riichi
   winHand?: string
   fanDetails?: string
   fanCount?: number

--- a/ui/src/utils/gameState.ts
+++ b/ui/src/utils/gameState.ts
@@ -1,0 +1,105 @@
+import { SessionDetail, GameModeKey, RoundInfo } from '../types'
+
+const WIND_NAMES = ['东', '南', '西', '北']
+
+export interface GameState {
+  dealerSeat: number
+  dealerPlayerId: number
+  prevalentWind: number // 1=东, 2=南, 3=西, 4=北
+  handNumber: number // 1-based within current wind
+  honba: number // consecutive dealer continuations
+  kyoutaku: number // accumulated riichi sticks (in points)
+  displayName: string // e.g. "东1" or "第3/4局"
+  playerCount: number
+}
+
+function getPlayersBySeat(session: SessionDetail) {
+  return [...session.players].sort((a, b) => (a.seat ?? 0) - (b.seat ?? 0))
+}
+
+function dealerStaysAfterRound(gameMode: GameModeKey, round: RoundInfo, dealerPlayerId: number): boolean {
+  if (round.winnerId === dealerPlayerId) return true
+  if (round.winnerId == null) {
+    if (gameMode === 'DONGBEI') return true
+    if (gameMode === 'RIICHI') return (round.scores[dealerPlayerId] ?? 0) >= 0
+  }
+  return false
+}
+
+function totalBaseRounds(gameMode: GameModeKey, playerCount: number): number {
+  if (gameMode === 'GUOBIAO') return playerCount
+  if (gameMode === 'DONGBEI') return playerCount
+  return playerCount * 2 // Riichi 半庄: 2 winds
+}
+
+export function deriveGameState(session: SessionDetail): GameState {
+  const playersBySeat = getPlayersBySeat(session)
+  const playerCount = playersBySeat.length
+
+  if (session.gameMode === 'GUOBIAO') {
+    const nextRound = session.rounds.length + 1
+    const total = totalBaseRounds('GUOBIAO', playerCount)
+    const seatIndex = (nextRound - 1) % playerCount
+    const dealer = playersBySeat[seatIndex]
+    return {
+      dealerSeat: dealer.seat ?? seatIndex + 1,
+      dealerPlayerId: dealer.id,
+      prevalentWind: 1,
+      handNumber: nextRound,
+      honba: 0,
+      kyoutaku: 0,
+      displayName: `第${nextRound}/${total}局`,
+      playerCount,
+    }
+  }
+
+  let seatIndex = 0
+  let prevalentWind = 1
+  let handNumber = 1
+  let honba = 0
+  let kyoutaku = 0
+
+  for (const round of session.rounds) {
+    const riichiCount = round.riichiPlayerIds?.length ?? 0
+    kyoutaku += riichiCount * 1000
+
+    if (round.winnerId != null) {
+      kyoutaku = 0
+    }
+
+    const dealer = playersBySeat[seatIndex]
+    if (dealerStaysAfterRound(session.gameMode, round, dealer.id)) {
+      honba++
+    } else {
+      seatIndex = (seatIndex + 1) % playerCount
+      handNumber++
+      honba = 0
+      if (handNumber > playerCount) {
+        handNumber = 1
+        prevalentWind++
+      }
+    }
+  }
+
+  const dealer = playersBySeat[seatIndex]
+  const windHand = `${WIND_NAMES[(prevalentWind - 1) % 4]}${handNumber}`
+  return {
+    dealerSeat: dealer.seat ?? seatIndex + 1,
+    dealerPlayerId: dealer.id,
+    prevalentWind,
+    handNumber,
+    honba,
+    kyoutaku,
+    displayName: honba > 0 ? `${windHand} ${honba}本场` : windHand,
+    playerCount,
+  }
+}
+
+export function deriveRoundState(session: SessionDetail, upToRound: number): GameState {
+  const trimmed = { ...session, rounds: session.rounds.slice(0, upToRound - 1) }
+  return deriveGameState(trimmed)
+}
+
+export function getWindName(w: number): string {
+  return WIND_NAMES[(w - 1) % 4]
+}


### PR DESCRIPTION
## Summary
- **Auto-derive dealer**: Seating order + round history determines the dealer for Riichi/Dongbei — no more manual dropdown selection each round
- **Auto-derive honba/kyoutaku**: Honba increments on renchan and resets on dealer rotation; kyoutaku accumulates from riichi declarations in drawn games and resets when collected by a winner
- **Riichi drawn game tracking**: New chip selector for riichi players during 流局; backend deducts -1000 per declaring player and stores riichi info on Round entity
- **3-player support**: Guobiao shows correct round total (第X/3局), menfeng calculation uses playerCount instead of hardcoded 4, Riichi 半庄 handles 2 winds × playerCount hands
- **Round labels for all modes**: Score table shows 东1/南2/etc. for Riichi/Dongbei (was only Guobiao), form title shows current round state
- **Mobile responsiveness**: Flex-wrap on narrow layouts, tile grid scaling, CTA button sizing, dashboard grid collapse, table min-width reductions, fan-item-header wrapping
- **Audit skill update**: Added known localization exceptions to avoid re-flagging intentional English text

## Test plan
- [ ] Create a 4-player Riichi game, verify dealer auto-rotates correctly after wins and drawn games
- [ ] Create a 3-player game for each mode, verify round count and wind display
- [ ] Test 流局 with riichi player selection, verify -1000 deductions and kyoutaku carry-over
- [ ] Verify ActiveGameCard and SessionPage show consistent round state
- [ ] Test mobile layout on 320px and 375px viewports
- [ ] Verify existing Guobiao/Dongbei games still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track and submit which players declared riichi; declare riichi when a round is drawn and have riichi sticks applied to scores.

* **New UI**
  * Centralized game-state derivation to consistently show dealer, wind, hand, honba and kyoutaku across the app.
  * Small layout/header updates (Home start button, Hall of Fame, responsive adjustments).

* **Bug Fixes / UX**
  * Improved responsive/mobile layout and score preview/round label accuracy.

* **Documentation**
  * Audit guidance updated with additional localization exceptions for branding and domain terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->