### PR TITLE
fix: align riichi rules with M.League and improve ryuukyoku UX

### DIFF
--- a/ui/src/data/riichiFanTableData.ts
+++ b/ui/src/data/riichiFanTableData.ts
@@ -200,6 +200,31 @@ export const riichiFanTableData: RiichiFanItem[] = [
   },
 
   // 13番 (役满)
+  { fan: 13, name: '天和', description: '庄家发牌后第一张牌即和牌。暗杠不成立。', example: '' },
+  {
+    fan: 13,
+    name: '地和',
+    description: '闲家在第一巡自摸和牌。这之前如有他家的吃、碰、明杠，则该役不成立。',
+    example: '',
+  },
+  {
+    fan: 13,
+    name: '四杠子',
+    description: '4个杠。',
+    example: '*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Pin3 Pin3 Pin3 Pin3 | *Pin4 Pin4 Pin4 Pin4 | Shaa Shaa',
+  },
+  {
+    fan: 13,
+    name: '国士无双',
+    description: '由13种一、九及字牌各一张，外加其中任何一种的一张组成的和牌。门前清限定。',
+    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun Chun',
+  },
+  {
+    fan: 13,
+    name: '国士无双十三面听',
+    description: '手牌先集齐13种么九牌各一张，听所有13种么九牌。',
+    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun ^Chun',
+  },
   {
     fan: 13,
     name: '四暗刻',
@@ -208,9 +233,9 @@ export const riichiFanTableData: RiichiFanItem[] = [
   },
   {
     fan: 13,
-    name: '国士无双',
-    description: '由13种一、九及字牌各一张，外加其中任何一种的一张组成的和牌。门前清限定。',
-    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun Chun',
+    name: '四暗刻单骑',
+    description: '先集齐4个暗刻，单听将牌的和牌型。',
+    example: '*Man1 Man1 Man1 | *Man2 Man2 Man2 | *Man3 Man3 Man3 | *Man4 Man4 Man4 | ^Pin1 Pin1',
   },
   {
     fan: 13,
@@ -232,6 +257,12 @@ export const riichiFanTableData: RiichiFanItem[] = [
   },
   {
     fan: 13,
+    name: '大四喜',
+    description: '包含风牌的4副刻子组成的和牌。',
+    example: '*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Pei Pei Pei | Man1 Man1',
+  },
+  {
+    fan: 13,
     name: '绿一色',
     description: '只包含绿色牌（条子2、3、4、6、8和发财）构成的和牌。可不包含发财。',
     example: '*Sou2 Sou3 Sou4 | *Sou6 Sou6 Sou6 | *Sou8 Sou8 Sou8 | *Hatsu Hatsu Hatsu | *Sou2 Sou2',
@@ -244,45 +275,12 @@ export const riichiFanTableData: RiichiFanItem[] = [
   },
   {
     fan: 13,
-    name: '地和',
-    description: '闲家在第一巡自摸和牌。这之前如有他家的吃、碰、明杠，则该役不成立。',
-    example: '',
-  },
-  {
-    fan: 13,
     name: '九莲宝灯',
     description: '由一种花色的1112345678999构成的牌型，和该种花色的任意一张。门前清限定。',
     example: '*Man1 Man1 Man1 Man2 Man3 Man4 Man5 Man6 Man7 Man8 Man9 Man9 Man9 Man1',
   },
-  { fan: 13, name: '天和', description: '庄家发牌后第一张牌即和牌。暗杠不成立。', example: '' },
   {
     fan: 13,
-    name: '四杠子',
-    description: '4个杠。',
-    example: '*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Pin3 Pin3 Pin3 Pin3 | *Pin4 Pin4 Pin4 Pin4 | Shaa Shaa',
-  },
-
-  // 26番 (双倍役满)
-  {
-    fan: 26,
-    name: '四暗刻单骑',
-    description: '先集齐4个暗刻，单听将牌的和牌型。',
-    example: '*Man1 Man1 Man1 | *Man2 Man2 Man2 | *Man3 Man3 Man3 | *Man4 Man4 Man4 | ^Pin1 Pin1',
-  },
-  {
-    fan: 26,
-    name: '国士无双十三面听',
-    description: '手牌先集齐13种么九牌各一张，听所有13种么九牌。',
-    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun ^Chun',
-  },
-  {
-    fan: 26,
-    name: '大四喜',
-    description: '包含风牌的4副刻子组成的和牌。',
-    example: '*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Pei Pei Pei | Man1 Man1',
-  },
-  {
-    fan: 26,
     name: '纯正九莲宝灯',
     description: '九莲宝灯听九面。1112345678999听所有同花色牌。',
     example: '*Man1 Man1 Man1 Man2 Man3 Man4 Man5 Man6 Man7 Man8 Man9 Man9 Man9 | ^Man1',

--- a/ui/src/data/riichiFanTableData.ts
+++ b/ui/src/data/riichiFanTableData.ts
@@ -209,21 +209,9 @@ export const riichiFanTableData: RiichiFanItem[] = [
   },
   {
     fan: 13,
-    name: '四杠子',
-    description: '4个杠。',
-    example: '*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Pin3 Pin3 Pin3 Pin3 | *Pin4 Pin4 Pin4 Pin4 | Shaa Shaa',
-  },
-  {
-    fan: 13,
-    name: '国士无双',
-    description: '由13种一、九及字牌各一张，外加其中任何一种的一张组成的和牌。门前清限定。',
-    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun Chun',
-  },
-  {
-    fan: 13,
-    name: '国士无双十三面听',
-    description: '手牌先集齐13种么九牌各一张，听所有13种么九牌。',
-    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun ^Chun',
+    name: '大三元',
+    description: '包含中、发、白的三副刻子。',
+    example: '*Chun Chun Chun | *Hatsu Hatsu Hatsu | *Haku Haku Haku | Man1 Man2 Man3 | Pin1 Pin1',
   },
   {
     fan: 13,
@@ -239,15 +227,33 @@ export const riichiFanTableData: RiichiFanItem[] = [
   },
   {
     fan: 13,
-    name: '大三元',
-    description: '包含中、发、白的三副刻子。',
-    example: '*Chun Chun Chun | *Hatsu Hatsu Hatsu | *Haku Haku Haku | Man1 Man2 Man3 | Pin1 Pin1',
-  },
-  {
-    fan: 13,
     name: '字一色',
     description: '全部由字牌组成的和牌。',
     example: '*Ton Ton Ton | *Nan Nan Nan | *Shaa Shaa Shaa | *Haku Haku Haku | *Chun Chun',
+  },
+  {
+    fan: 13,
+    name: '绿一色',
+    description: '只包含绿色牌（条子2、3、4、6、8和发财）构成的和牌。可不包含发财。',
+    example: '*Sou2 Sou3 Sou4 | *Sou6 Sou6 Sou6 | *Sou8 Sou8 Sou8 | *Hatsu Hatsu Hatsu | *Sou2 Sou2',
+  },
+  {
+    fan: 13,
+    name: '清老头',
+    description: '全部包含老头牌（一、九）的对对和。',
+    example: '*Man1 Man1 Man1 | *Man9 Man9 Man9 | *Pin1 Pin1 Pin1 | *Pin9 Pin9 Pin9 | *Sou1 Sou1',
+  },
+  {
+    fan: 13,
+    name: '国士无双',
+    description: '由13种一、九及字牌各一张，外加其中任何一种的一张组成的和牌。门前清限定。',
+    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun Chun',
+  },
+  {
+    fan: 13,
+    name: '国士无双十三面听',
+    description: '手牌先集齐13种幺九牌各一张，听所有13种幺九牌。',
+    example: '*Man1 Man9 Pin1 Pin9 Sou1 Sou9 Ton Nan Shaa Pei Haku Hatsu Chun ^Chun',
   },
   {
     fan: 13,
@@ -263,15 +269,9 @@ export const riichiFanTableData: RiichiFanItem[] = [
   },
   {
     fan: 13,
-    name: '绿一色',
-    description: '只包含绿色牌（条子2、3、4、6、8和发财）构成的和牌。可不包含发财。',
-    example: '*Sou2 Sou3 Sou4 | *Sou6 Sou6 Sou6 | *Sou8 Sou8 Sou8 | *Hatsu Hatsu Hatsu | *Sou2 Sou2',
-  },
-  {
-    fan: 13,
-    name: '清老头',
-    description: '全部包含老头牌（一、九）的对对和。',
-    example: '*Man1 Man1 Man1 | *Man9 Man9 Man9 | *Pin1 Pin1 Pin1 | *Pin9 Pin9 Pin9 | *Sou1 Sou1',
+    name: '四杠子',
+    description: '4个杠。',
+    example: '*Pin1 Pin1 Pin1 Pin1 | *Pin2 Pin2 Pin2 Pin2 | *Pin3 Pin3 Pin3 Pin3 | *Pin4 Pin4 Pin4 Pin4 | Shaa Shaa',
   },
   {
     fan: 13,

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -161,7 +161,6 @@ const FanTablePage: React.FC = () => {
   const getFanLabel = (fan: number) => {
     if (activeTab === 'RIICHI') {
       if (fan === 13) return '役满'
-      if (fan === 26) return '双倍役满'
     }
     if (activeTab === 'DONGBEI') {
       if (fan === 0) return '规则概览'

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -378,68 +378,58 @@ export default function SessionPage() {
 
             {isRyuukyoku ? (
               <>
-                <div className="form-group">
-                  <label>选择听牌玩家</label>
-                  <div className="player-chips">
-                    {session.players.map((p) => (
-                      <span
-                        key={p.id}
-                        className={`chip ${tenpaiPlayerIds.includes(p.id) ? 'selected' : ''}`}
-                        onClick={() => {
-                          setTenpaiPlayerIds((prev) =>
-                            prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
-                          )
-                          if (tenpaiPlayerIds.includes(p.id)) {
-                            setRiichiPlayerIds((prev) => prev.filter((id) => id !== p.id))
-                          }
-                        }}
-                        style={{ cursor: 'pointer' }}
-                      >
-                        {p.userName}
-                        {tenpaiPlayerIds.includes(p.id) && ' ✓'}
-                      </span>
-                    ))}
-                  </div>
-                  <span className="field-hint">
-                    {tenpaiPlayerIds.length === 0 || tenpaiPlayerIds.length === session.players.length
-                      ? '全员听牌或全员未听 → 无点数变动'
-                      : `${tenpaiPlayerIds.length}人听牌, ${
-                          session.players.length - tenpaiPlayerIds.length
-                        }人未听 → 未听各付${3000 / (session.players.length - tenpaiPlayerIds.length)}, 听牌各得${
-                          3000 / tenpaiPlayerIds.length
-                        }`}
-                  </span>
-                </div>
-                <div className="form-group">
-                  <label>选择立直玩家</label>
-                  <div className="player-chips">
-                    {session.players.map((p) => (
-                      <span
-                        key={p.id}
-                        className={`chip ${riichiPlayerIds.includes(p.id) ? 'selected' : ''}`}
-                        onClick={() => {
-                          if (riichiPlayerIds.includes(p.id)) {
-                            setRiichiPlayerIds((prev) => prev.filter((id) => id !== p.id))
-                          } else {
-                            setRiichiPlayerIds((prev) => [...prev, p.id])
-                            if (!tenpaiPlayerIds.includes(p.id)) {
-                              setTenpaiPlayerIds((prev) => [...prev, p.id])
+                <div className="quick-win-container">
+                  <div className="quick-win-row">
+                    {session.players.map((p, idx) => {
+                      const isRiichiPlayer = riichiPlayerIds.includes(p.id)
+                      const isTenpaiOnly = !isRiichiPlayer && tenpaiPlayerIds.includes(p.id)
+                      let btnClass = 'quick-player-btn'
+                      if (isRiichiPlayer) btnClass += ' winner'
+                      if (isTenpaiOnly) btnClass += ' loser'
+
+                      return (
+                        <button
+                          key={p.id}
+                          className={btnClass}
+                          onClick={() => {
+                            if (isRiichiPlayer) {
+                              setRiichiPlayerIds((prev) => prev.filter((id) => id !== p.id))
+                              setTenpaiPlayerIds((prev) => (prev.includes(p.id) ? prev : [...prev, p.id]))
+                            } else if (isTenpaiOnly) {
+                              setTenpaiPlayerIds((prev) => prev.filter((id) => id !== p.id))
+                            } else {
+                              setRiichiPlayerIds((prev) => [...prev, p.id])
+                              setTenpaiPlayerIds((prev) => (prev.includes(p.id) ? prev : [...prev, p.id]))
                             }
-                          }
-                        }}
-                        style={{ cursor: 'pointer' }}
-                      >
-                        {p.userName}
-                        {riichiPlayerIds.includes(p.id) && ' ✓'}
-                      </span>
-                    ))}
+                          }}
+                        >
+                          <div className="btn-name">{p.userName}</div>
+                          <div className={`btn-wind${p.id === gameState.dealerPlayerId ? ' btn-wind-dealer' : ''}`}>
+                            {isRiichiPlayer
+                              ? '立直'
+                              : isTenpaiOnly
+                              ? '默听'
+                              : getWindName(getPlayerMenfeng(getPlayerSeat(p, idx)))}
+                          </div>
+                        </button>
+                      )
+                    })}
                   </div>
-                  {riichiPlayerIds.length > 0 && (
-                    <span className="field-hint">
-                      {riichiPlayerIds.length}人立直 → 各扣1000, 供托 +{riichiPlayerIds.length * 1000}
-                    </span>
-                  )}
                 </div>
+                <span className="field-hint">
+                  {tenpaiPlayerIds.length === 0 || tenpaiPlayerIds.length === session.players.length
+                    ? '全员听牌或全员未听 → 无点数变动'
+                    : `${tenpaiPlayerIds.length}人听牌, ${
+                        session.players.length - tenpaiPlayerIds.length
+                      }人未听 → 未听各付${3000 / (session.players.length - tenpaiPlayerIds.length)}, 听牌各得${
+                        3000 / tenpaiPlayerIds.length
+                      }`}
+                </span>
+                {riichiPlayerIds.length > 0 && (
+                  <span className="field-hint">
+                    {riichiPlayerIds.length}人立直 → 各扣1000, 供托 +{riichiPlayerIds.length * 1000}
+                  </span>
+                )}
                 <button className="btn btn-primary" onClick={handleAddRound} disabled={submitting}>
                   {submitting ? '提交中...' : '添加流局'}
                 </button>


### PR DESCRIPTION
## Summary
- Remove separate 双倍役満 category from fan table; merge 4 hands (四暗刻単騎, 国士無双十三面, 大四喜, 純正九蓮宝燈) into 役満 section at 13番
- Reorder yakuman: 天和/地和/四杠子 first, then paired variants grouped together (四暗刻→四暗刻単騎, 国士無双→十三面, 小四喜→大四喜, 九蓮宝燈→純正)
- Replace two separate chip lists (聴牌/立直) in 流局 form with unified tri-state player buttons matching winner selection design (1st click=立直, 2nd=默聴, 3rd=reset)

Closes #75

## Test plan
- [ ] Verify fan table 役満 section displays in correct order with paired variants adjacent
- [ ] Verify no 双倍役満 section appears
- [ ] Test 流局 flow: tap player once → shows 立直, tap again → shows 默听, tap again → resets
- [ ] Verify riichi auto-implies tenpai in score hint
- [ ] Verify score calculation unchanged (切上満貫, 数え役満 still work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a legacy special-case label for the highest-scoring hand so it now displays a consistent numeric label.

* **Improvements**
  * Redesigned player-status selection during active sessions to a unified per-player button interface for marking waiting/riichi.

* **Refactor**
  * Reordered and consolidated high-value hand entries in the reference table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->