### PR TITLE
fix: add API cache and align loading text (#72)

### DIFF
--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -11,6 +11,30 @@ import {
 
 const API = '/api'
 
+const cache = new Map<string, { data: unknown; expiry: number }>()
+const CACHE_TTL = 10_000
+
+function getCached<T>(key: string): T | null {
+  const entry = cache.get(key)
+  if (entry && Date.now() < entry.expiry) return entry.data as T
+  cache.delete(key)
+  return null
+}
+
+function setCache(key: string, data: unknown) {
+  cache.set(key, { data, expiry: Date.now() + CACHE_TTL })
+}
+
+export function invalidateCache(prefix?: string) {
+  if (!prefix) {
+    cache.clear()
+    return
+  }
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key)
+  }
+}
+
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
     const error = await res.json().catch(() => ({ message: '请求失败' }))
@@ -19,9 +43,17 @@ async function handleResponse<T>(res: Response): Promise<T> {
   return res.json()
 }
 
+async function cachedFetch<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const cached = getCached<T>(url)
+  if (cached) return cached
+  const res = await fetch(url, signal ? { signal } : undefined)
+  const data = await handleResponse<T>(res)
+  setCache(url, data)
+  return data
+}
+
 export async function fetchPlayers(): Promise<Player[]> {
-  const res = await fetch(`${API}/players`)
-  return handleResponse(res)
+  return cachedFetch(`${API}/players`)
 }
 
 export async function createPlayer(userName: string, firstName: string, lastName: string): Promise<Player> {
@@ -40,8 +72,7 @@ export async function checkUserName(userName: string): Promise<boolean> {
 }
 
 export async function fetchSessions(): Promise<GameSession[]> {
-  const res = await fetch(`${API}/sessions`)
-  return handleResponse(res)
+  return cachedFetch(`${API}/sessions`)
 }
 
 export async function createSession(name: string, gameMode: string, playerIds: number[]): Promise<GameSession> {
@@ -50,12 +81,13 @@ export async function createSession(name: string, gameMode: string, playerIds: n
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, gameMode, playerIds }),
   })
-  return handleResponse(res)
+  const data = await handleResponse<GameSession>(res)
+  invalidateCache()
+  return data
 }
 
 export async function fetchSessionDetail(id: number): Promise<SessionDetail> {
-  const res = await fetch(`${API}/sessions/${id}`)
-  return handleResponse(res)
+  return cachedFetch(`${API}/sessions/${id}`)
 }
 
 export async function addRound(sessionId: number, data: AddRoundData): Promise<void> {
@@ -68,6 +100,7 @@ export async function addRound(sessionId: number, data: AddRoundData): Promise<v
     const error = await res.json().catch(() => ({ message: '添加失败' }))
     throw new Error(error.message || '添加失败')
   }
+  invalidateCache()
 }
 
 export async function deleteRound(sessionId: number, roundNumber: number): Promise<void> {
@@ -76,6 +109,7 @@ export async function deleteRound(sessionId: number, roundNumber: number): Promi
     const error = await res.json().catch(() => ({ message: '删除失败' }))
     throw new Error(error.message || '删除失败')
   }
+  invalidateCache()
 }
 
 export async function completeSession(id: number): Promise<void> {
@@ -84,11 +118,11 @@ export async function completeSession(id: number): Promise<void> {
     const error = await res.json().catch(() => ({ message: '操作失败' }))
     throw new Error(error.message || '操作失败')
   }
+  invalidateCache()
 }
 
 export async function fetchActiveSeasons(): Promise<{ year: number; month: number }[]> {
-  const res = await fetch(`${API}/stats/seasons`)
-  return handleResponse(res)
+  return cachedFetch(`${API}/stats/seasons`)
 }
 
 export async function fetchStats(gameMode?: string, year?: number, month?: number): Promise<PlayerStats[]> {
@@ -99,13 +133,11 @@ export async function fetchStats(gameMode?: string, year?: number, month?: numbe
     params.set('month', String(month))
   }
   const qs = params.toString()
-  const res = await fetch(`${API}/stats${qs ? `?${qs}` : ''}`)
-  return handleResponse(res)
+  return cachedFetch(`${API}/stats${qs ? `?${qs}` : ''}`)
 }
 
 export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
-  const res = await fetch(`${API}/players/${id}/detail`)
-  return handleResponse(res)
+  return cachedFetch(`${API}/players/${id}/detail`)
 }
 
 export async function fetchBestRounds(
@@ -121,8 +153,7 @@ export async function fetchBestRounds(
     params.set('month', String(month))
   }
   const qs = params.toString()
-  const res = await fetch(`${API}/stats/best-rounds${qs ? `?${qs}` : ''}`, { signal })
-  return handleResponse<BestRound[]>(res)
+  return cachedFetch(`${API}/stats/best-rounds${qs ? `?${qs}` : ''}`, signal)
 }
 
 export async function fetchFanDiscoveries(
@@ -139,6 +170,5 @@ export async function fetchFanDiscoveries(
     params.set('month', String(month))
   }
   const qs = params.toString()
-  const res = await fetch(`${API}/stats/fan-discoveries${qs ? `?${qs}` : ''}`, { signal })
-  return handleResponse<FanDiscovery[]>(res)
+  return cachedFetch(`${API}/stats/fan-discoveries${qs ? `?${qs}` : ''}`, signal)
 }

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -105,28 +105,19 @@ export async function addRound(sessionId: number, data: AddRoundData): Promise<v
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
-  if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: MSG.ERROR }))
-    throw new Error(error.message || MSG.ERROR)
-  }
+  await handleResponse(res)
   invalidateCache()
 }
 
 export async function deleteRound(sessionId: number, roundNumber: number): Promise<void> {
   const res = await fetch(`${API}/sessions/${sessionId}/rounds/${roundNumber}`, { method: 'DELETE' })
-  if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: MSG.ERROR }))
-    throw new Error(error.message || MSG.ERROR)
-  }
+  await handleResponse(res)
   invalidateCache()
 }
 
 export async function completeSession(id: number): Promise<void> {
   const res = await fetch(`${API}/sessions/${id}/complete`, { method: 'PUT' })
-  if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: MSG.ERROR }))
-    throw new Error(error.message || MSG.ERROR)
-  }
+  await handleResponse(res)
   invalidateCache()
 }
 

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -15,13 +15,15 @@ const API = '/api'
 const cache = new Map<string, { data: unknown; expiry: number }>()
 const CACHE_TTL = 30_000
 
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') cache.clear()
-})
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') cache.clear()
+  })
+}
 
 function getCached<T>(key: string): T | null {
   const entry = cache.get(key)
-  if (entry && Date.now() < entry.expiry) return entry.data as T
+  if (entry && Date.now() < entry.expiry) return structuredClone(entry.data) as T
   cache.delete(key)
   return null
 }
@@ -67,7 +69,9 @@ export async function createPlayer(userName: string, firstName: string, lastName
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userName, firstName, lastName }),
   })
-  return handleResponse(res)
+  const data = await handleResponse<Player>(res)
+  invalidateCache()
+  return data
 }
 
 export async function checkUserName(userName: string): Promise<boolean> {

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -11,18 +11,15 @@ import {
 
 const API = '/api'
 
-const cache = new Map<string, { data: unknown; expiry: number }>()
-const CACHE_TTL = 10_000
+const cache = new Map<string, unknown>()
 
 function getCached<T>(key: string): T | null {
-  const entry = cache.get(key)
-  if (entry && Date.now() < entry.expiry) return entry.data as T
-  cache.delete(key)
+  if (cache.has(key)) return cache.get(key) as T
   return null
 }
 
 function setCache(key: string, data: unknown) {
-  cache.set(key, { data, expiry: Date.now() + CACHE_TTL })
+  cache.set(key, data)
 }
 
 export function invalidateCache(prefix?: string) {

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -42,8 +42,8 @@ export function invalidateCache(prefix?: string) {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: MSG.REQUEST_FAILED }))
-    throw new Error(error.message || `${MSG.REQUEST_FAILED} (${res.status})`)
+    const error = await res.json().catch(() => ({ message: MSG.ERROR }))
+    throw new Error(error.message || MSG.ERROR)
   }
   return res.json()
 }
@@ -102,8 +102,8 @@ export async function addRound(sessionId: number, data: AddRoundData): Promise<v
     body: JSON.stringify(data),
   })
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: MSG.ADD_FAILED }))
-    throw new Error(error.message || MSG.ADD_FAILED)
+    const error = await res.json().catch(() => ({ message: MSG.ERROR }))
+    throw new Error(error.message || MSG.ERROR)
   }
   invalidateCache()
 }
@@ -111,8 +111,8 @@ export async function addRound(sessionId: number, data: AddRoundData): Promise<v
 export async function deleteRound(sessionId: number, roundNumber: number): Promise<void> {
   const res = await fetch(`${API}/sessions/${sessionId}/rounds/${roundNumber}`, { method: 'DELETE' })
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: MSG.DELETE_FAILED }))
-    throw new Error(error.message || MSG.DELETE_FAILED)
+    const error = await res.json().catch(() => ({ message: MSG.ERROR }))
+    throw new Error(error.message || MSG.ERROR)
   }
   invalidateCache()
 }
@@ -120,8 +120,8 @@ export async function deleteRound(sessionId: number, roundNumber: number): Promi
 export async function completeSession(id: number): Promise<void> {
   const res = await fetch(`${API}/sessions/${id}/complete`, { method: 'PUT' })
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: MSG.ACTION_FAILED }))
-    throw new Error(error.message || MSG.ACTION_FAILED)
+    const error = await res.json().catch(() => ({ message: MSG.ERROR }))
+    throw new Error(error.message || MSG.ERROR)
   }
   invalidateCache()
 }

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -80,8 +80,8 @@ export async function checkUserName(userName: string): Promise<boolean> {
   return data.available
 }
 
-export async function fetchSessions(): Promise<GameSession[]> {
-  return cachedFetch(`${API}/sessions`)
+export async function fetchSessions(signal?: AbortSignal): Promise<GameSession[]> {
+  return cachedFetch(`${API}/sessions`, signal)
 }
 
 export async function createSession(name: string, gameMode: string, playerIds: number[]): Promise<GameSession> {
@@ -95,8 +95,8 @@ export async function createSession(name: string, gameMode: string, playerIds: n
   return data
 }
 
-export async function fetchSessionDetail(id: number): Promise<SessionDetail> {
-  return cachedFetch(`${API}/sessions/${id}`)
+export async function fetchSessionDetail(id: number, signal?: AbortSignal): Promise<SessionDetail> {
+  return cachedFetch(`${API}/sessions/${id}`, signal)
 }
 
 export async function addRound(sessionId: number, data: AddRoundData): Promise<void> {
@@ -134,7 +134,12 @@ export async function fetchActiveSeasons(): Promise<{ year: number; month: numbe
   return cachedFetch(`${API}/stats/seasons`)
 }
 
-export async function fetchStats(gameMode?: string, year?: number, month?: number): Promise<PlayerStats[]> {
+export async function fetchStats(
+  gameMode?: string,
+  year?: number,
+  month?: number,
+  signal?: AbortSignal
+): Promise<PlayerStats[]> {
   const params = new URLSearchParams()
   if (gameMode) params.set('gameMode', gameMode)
   if (year != null && month != null) {
@@ -142,7 +147,7 @@ export async function fetchStats(gameMode?: string, year?: number, month?: numbe
     params.set('month', String(month))
   }
   const qs = params.toString()
-  return cachedFetch(`${API}/stats${qs ? `?${qs}` : ''}`)
+  return cachedFetch(`${API}/stats${qs ? `?${qs}` : ''}`, signal)
 }
 
 export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -14,6 +14,10 @@ const API = '/api'
 const cache = new Map<string, { data: unknown; expiry: number }>()
 const CACHE_TTL = 30_000
 
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') cache.clear()
+})
+
 function getCached<T>(key: string): T | null {
   const entry = cache.get(key)
   if (entry && Date.now() < entry.expiry) return entry.data as T

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -8,6 +8,7 @@ import {
   BestRound,
   FanDiscovery,
 } from '../types'
+import { MSG } from '../constants'
 
 const API = '/api'
 
@@ -41,8 +42,8 @@ export function invalidateCache(prefix?: string) {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: '请求失败' }))
-    throw new Error(error.message || `请求失败 (${res.status})`)
+    const error = await res.json().catch(() => ({ message: MSG.REQUEST_FAILED }))
+    throw new Error(error.message || `${MSG.REQUEST_FAILED} (${res.status})`)
   }
   return res.json()
 }
@@ -101,8 +102,8 @@ export async function addRound(sessionId: number, data: AddRoundData): Promise<v
     body: JSON.stringify(data),
   })
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: '添加失败' }))
-    throw new Error(error.message || '添加失败')
+    const error = await res.json().catch(() => ({ message: MSG.ADD_FAILED }))
+    throw new Error(error.message || MSG.ADD_FAILED)
   }
   invalidateCache()
 }
@@ -110,8 +111,8 @@ export async function addRound(sessionId: number, data: AddRoundData): Promise<v
 export async function deleteRound(sessionId: number, roundNumber: number): Promise<void> {
   const res = await fetch(`${API}/sessions/${sessionId}/rounds/${roundNumber}`, { method: 'DELETE' })
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: '删除失败' }))
-    throw new Error(error.message || '删除失败')
+    const error = await res.json().catch(() => ({ message: MSG.DELETE_FAILED }))
+    throw new Error(error.message || MSG.DELETE_FAILED)
   }
   invalidateCache()
 }
@@ -119,8 +120,8 @@ export async function deleteRound(sessionId: number, roundNumber: number): Promi
 export async function completeSession(id: number): Promise<void> {
   const res = await fetch(`${API}/sessions/${id}/complete`, { method: 'PUT' })
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ message: '操作失败' }))
-    throw new Error(error.message || '操作失败')
+    const error = await res.json().catch(() => ({ message: MSG.ACTION_FAILED }))
+    throw new Error(error.message || MSG.ACTION_FAILED)
   }
   invalidateCache()
 }

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -11,15 +11,18 @@ import {
 
 const API = '/api'
 
-const cache = new Map<string, unknown>()
+const cache = new Map<string, { data: unknown; expiry: number }>()
+const CACHE_TTL = 30_000
 
 function getCached<T>(key: string): T | null {
-  if (cache.has(key)) return cache.get(key) as T
+  const entry = cache.get(key)
+  if (entry && Date.now() < entry.expiry) return entry.data as T
+  cache.delete(key)
   return null
 }
 
 function setCache(key: string, data: unknown) {
-  cache.set(key, data)
+  cache.set(key, { data, expiry: Date.now() + CACHE_TTL })
 }
 
 export function invalidateCache(prefix?: string) {

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,0 +1,9 @@
+export const MSG = {
+  LOADING: '加载中...',
+  LOAD_FAILED: '加载失败',
+  SUBMITTING: '提交中...',
+  REQUEST_FAILED: '请求失败',
+  ADD_FAILED: '添加失败',
+  DELETE_FAILED: '删除失败',
+  ACTION_FAILED: '操作失败',
+} as const

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,9 +1,5 @@
 export const MSG = {
   LOADING: '加载中...',
-  LOAD_FAILED: '加载失败',
   SUBMITTING: '提交中...',
-  REQUEST_FAILED: '请求失败',
-  ADD_FAILED: '添加失败',
-  DELETE_FAILED: '删除失败',
-  ACTION_FAILED: '操作失败',
+  ERROR: '操作失败',
 } as const

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -36,9 +36,9 @@ export default function DashboardPage() {
         }))
         setSeasons(list)
       })
-      .catch((e) => {
+      .catch((e: unknown) => {
         if (!mounted) return
-        setError(e.message)
+        setError(e instanceof Error ? e.message : MSG.ERROR)
       })
       .finally(() => {
         if (mounted) setLoading(false)

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -75,9 +75,7 @@ export default function DashboardPage() {
   if (error)
     return (
       <div className="empty-state">
-        <p>
-          {MSG.LOAD_FAILED}：{error}
-        </p>
+        <p>{error}</p>
       </div>
     )
 

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { GameSession, Season, getCurrentSeason, getSeasonLabel } from '../types'
 import { fetchSessions, fetchActiveSeasons } from '../api'
 import { GameCard } from '../components/GameCard'
+import { MSG } from '../constants'
 
 export default function DashboardPage() {
   const [sessions, setSessions] = useState<GameSession[]>([])
@@ -68,13 +69,15 @@ export default function DashboardPage() {
   if (loading)
     return (
       <div className="empty-state">
-        <p>加载中...</p>
+        <p>{MSG.LOADING}</p>
       </div>
     )
   if (error)
     return (
       <div className="empty-state">
-        <p>加载失败：{error}</p>
+        <p>
+          {MSG.LOAD_FAILED}：{error}
+        </p>
       </div>
     )
 

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -45,7 +45,7 @@ const FanTablePage: React.FC = () => {
           )
         }
       })
-      .catch((e) => {
+      .catch((e: unknown) => {
         if (!mounted) return
         console.error(e)
       })

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -52,8 +52,8 @@ export default function HomePage() {
                 best:
                   bestRounds.length > 0 ? bestRounds.sort((a, b) => (b.fanCount || 0) - (a.fanCount || 0))[0] : null,
               }
-            } catch (err) {
-              if ((err as Error).name !== 'AbortError') {
+            } catch (err: unknown) {
+              if (err instanceof Error && err.name !== 'AbortError') {
                 console.error(`Failed to fetch stats for ${mode.key}:`, err)
               }
               rankingData[mode.key] = { top: [], best: null }
@@ -62,8 +62,8 @@ export default function HomePage() {
         )
 
         if (isActive) setRankings(rankingData)
-      } catch (e) {
-        if ((e as Error).name !== 'AbortError') console.error('Failed to load hub data:', e)
+      } catch (e: unknown) {
+        if (e instanceof Error && e.name !== 'AbortError') console.error('Failed to load hub data:', e)
       } finally {
         inFlight = false
         if (isActive) {

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { fetchSessions, fetchSessionDetail, fetchStats, fetchBestRounds } from '
 import { GameSession, SessionDetail, PlayerStats, BestRound, GAME_MODES, getCurrentSeason } from '../types'
 import { GameCard } from '../components/GameCard'
 import { deriveGameState, getWindName } from '../utils/gameState'
+import { MSG } from '../constants'
 
 export default function HomePage() {
   const [activeSessions, setActiveSessions] = useState<SessionDetail[]>([])
@@ -84,7 +85,7 @@ export default function HomePage() {
   if (loading) {
     return (
       <div className="empty-state">
-        <p>加载中...</p>
+        <p>{MSG.LOADING}</p>
       </div>
     )
   }

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -19,10 +19,10 @@ export default function HomePage() {
 
     async function loadData() {
       try {
-        const sessions = await fetchSessions()
+        const sessions = await fetchSessions(controller.signal)
         const active = sessions.filter((s) => s.status === 'IN_PROGRESS')
 
-        const settledDetails = await Promise.allSettled(active.map((s) => fetchSessionDetail(s.id)))
+        const settledDetails = await Promise.allSettled(active.map((s) => fetchSessionDetail(s.id, controller.signal)))
         const details = settledDetails
           .filter((res): res is PromiseFulfilledResult<SessionDetail> => res.status === 'fulfilled')
           .map((res) => res.value)
@@ -35,7 +35,7 @@ export default function HomePage() {
           GAME_MODES.map(async (mode) => {
             try {
               const [stats, bestRounds] = await Promise.all([
-                fetchStats(mode.key, currentSeason.year, currentSeason.month),
+                fetchStats(mode.key, currentSeason.year, currentSeason.month, controller.signal),
                 fetchBestRounds(mode.key, currentSeason.year, currentSeason.month, controller.signal),
               ])
 

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -14,21 +14,14 @@ export default function HomePage() {
   const currentSeason = getCurrentSeason()
 
   useEffect(() => {
-    let intervalId: ReturnType<typeof setInterval>
     let isActive = true
-    let inFlight = false
     const controller = new AbortController()
 
     async function loadData() {
-      if (inFlight) return
-      inFlight = true
-
       try {
-        // 1. Fetch sessions and filter for IN_PROGRESS
         const sessions = await fetchSessions()
         const active = sessions.filter((s) => s.status === 'IN_PROGRESS')
 
-        // 2. Fetch details for active sessions (using allSettled to prevent single failure from crashing all)
         const settledDetails = await Promise.allSettled(active.map((s) => fetchSessionDetail(s.id)))
         const details = settledDetails
           .filter((res): res is PromiseFulfilledResult<SessionDetail> => res.status === 'fulfilled')
@@ -36,7 +29,6 @@ export default function HomePage() {
 
         if (isActive) setActiveSessions(details)
 
-        // 3. Fetch stats for each mode
         const rankingData: Record<string, { top: PlayerStats[]; best: BestRound | null }> = {}
 
         await Promise.all(
@@ -65,19 +57,14 @@ export default function HomePage() {
       } catch (e: unknown) {
         if (e instanceof Error && e.name !== 'AbortError') console.error('Failed to load hub data:', e)
       } finally {
-        inFlight = false
-        if (isActive) {
-          setLoading(false)
-        }
+        if (isActive) setLoading(false)
       }
     }
 
     loadData()
-    intervalId = setInterval(loadData, 10000)
 
     return () => {
       isActive = false
-      clearInterval(intervalId)
       controller.abort()
     }
   }, [currentSeason.year, currentSeason.month])

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -84,7 +84,7 @@ export default function HomePage() {
   if (loading) {
     return (
       <div className="empty-state">
-        <p>加载枢纽数据中...</p>
+        <p>加载中...</p>
       </div>
     )
   }

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom'
 import { fetchPlayers, createSession } from '../api'
 import { Player, GameModeKey, GAME_MODES } from '../types'
 import { cardFontSize } from '../utils/fontSize'
+import { MSG } from '../constants'
 import { abbrName } from '../utils/format'
 
 const MIN_PLAYERS = 3
@@ -24,7 +25,7 @@ export default function NewSessionPage() {
         setPlayers(p)
         setLoaded(true)
       })
-      .catch(() => setError('加载玩家失败'))
+      .catch(() => setError(MSG.LOAD_FAILED))
   }, [])
 
   const togglePlayer = (id: number) => {
@@ -120,7 +121,7 @@ export default function NewSessionPage() {
         {error ? (
           <p className="error-text">{error}</p>
         ) : !loaded ? (
-          <p style={{ color: 'var(--text-light)', fontSize: '0.9rem', marginTop: 8 }}>加载中...</p>
+          <p style={{ color: 'var(--text-light)', fontSize: '0.9rem', marginTop: 8 }}>{MSG.LOADING}</p>
         ) : players.length > 0 ? (
           <div className="player-select-grid">
             {filteredPlayers.map((p) => {

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -64,8 +64,8 @@ export default function NewSessionPage() {
       )}`
       const session = await createSession(defaultName, gameMode, selectedIds)
       navigate(`/session/${session.id}`)
-    } catch (e: any) {
-      setError(e.message || '创建游戏失败')
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : MSG.ERROR)
       setCreating(false)
     }
   }

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -25,7 +25,7 @@ export default function NewSessionPage() {
         setPlayers(p)
         setLoaded(true)
       })
-      .catch(() => setError(MSG.ERROR))
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : MSG.ERROR))
   }, [])
 
   const togglePlayer = (id: number) => {

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -25,7 +25,7 @@ export default function NewSessionPage() {
         setPlayers(p)
         setLoaded(true)
       })
-      .catch(() => setError(MSG.LOAD_FAILED))
+      .catch(() => setError(MSG.ERROR))
   }, [])
 
   const togglePlayer = (id: number) => {

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -21,8 +21,8 @@ export default function PlayerDetailPage() {
         setPlayer(p)
         setLoading(false)
       })
-      .catch((e) => {
-        setError(e.message)
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : MSG.ERROR)
         setLoading(false)
       })
   }, [id])

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { fetchPlayerDetail } from '../api'
 import { PlayerDetail } from '../types'
 import { abbrName, scoreClass } from '../utils/format'
+import { MSG } from '../constants'
 
 export default function PlayerDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -29,7 +30,7 @@ export default function PlayerDetailPage() {
   if (loading)
     return (
       <div className="empty-state">
-        <p>加载中...</p>
+        <p>{MSG.LOADING}</p>
       </div>
     )
   if (error || !player)

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -163,7 +163,7 @@ export default function SessionPage() {
       resetForm()
       await load()
     } catch (e: any) {
-      setError(e.message || MSG.ACTION_FAILED)
+      setError(e.message || MSG.ERROR)
     } finally {
       setSubmitting(false)
     }
@@ -177,7 +177,7 @@ export default function SessionPage() {
       await deleteRound(session.id, roundNumber)
       await load()
     } catch (e: any) {
-      setError(e.message || MSG.DELETE_FAILED)
+      setError(e.message || MSG.ERROR)
     } finally {
       setSubmitting(false)
     }
@@ -191,7 +191,7 @@ export default function SessionPage() {
       await completeSession(session.id)
       await load()
     } catch (e: any) {
-      setError(e.message || MSG.ACTION_FAILED)
+      setError(e.message || MSG.ERROR)
     } finally {
       setSubmitting(false)
     }

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -8,6 +8,7 @@ import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
 import { deriveGameState, deriveRoundState, getWindName } from '../utils/gameState'
 import { scoreClass } from '../utils/format'
+import { MSG } from '../constants'
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>()
@@ -56,7 +57,7 @@ export default function SessionPage() {
   if (!session)
     return (
       <div className="empty-state">
-        <p>{error || '加载中...'}</p>
+        <p>{error || MSG.LOADING}</p>
       </div>
     )
 
@@ -162,7 +163,7 @@ export default function SessionPage() {
       resetForm()
       await load()
     } catch (e: any) {
-      setError(e.message || '操作失败')
+      setError(e.message || MSG.ACTION_FAILED)
     } finally {
       setSubmitting(false)
     }
@@ -176,7 +177,7 @@ export default function SessionPage() {
       await deleteRound(session.id, roundNumber)
       await load()
     } catch (e: any) {
-      setError(e.message || '删除失败')
+      setError(e.message || MSG.DELETE_FAILED)
     } finally {
       setSubmitting(false)
     }
@@ -190,7 +191,7 @@ export default function SessionPage() {
       await completeSession(session.id)
       await load()
     } catch (e: any) {
-      setError(e.message || '操作失败')
+      setError(e.message || MSG.ACTION_FAILED)
     } finally {
       setSubmitting(false)
     }
@@ -432,7 +433,7 @@ export default function SessionPage() {
                   </span>
                 )}
                 <button className="btn btn-primary" onClick={handleAddRound} disabled={submitting}>
-                  {submitting ? '提交中...' : '添加流局'}
+                  {submitting ? MSG.SUBMITTING : '添加流局'}
                 </button>
               </>
             ) : (
@@ -593,7 +594,7 @@ export default function SessionPage() {
                 {error && <p className="error-text">{error}</p>}
 
                 <button className="btn btn-primary" onClick={handleAddRound} disabled={!canSubmit || submitting}>
-                  {submitting ? '提交中...' : '添加'}
+                  {submitting ? MSG.SUBMITTING : '添加'}
                 </button>
               </>
             )}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -51,7 +51,7 @@ export default function SessionPage() {
   }
 
   useEffect(() => {
-    load().catch((e) => setError(e.message))
+    load().catch((e: unknown) => setError(e instanceof Error ? e.message : MSG.ERROR))
   }, [id])
 
   if (!session)

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -162,8 +162,8 @@ export default function SessionPage() {
 
       resetForm()
       await load()
-    } catch (e: any) {
-      setError(e.message || MSG.ERROR)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : MSG.ERROR)
     } finally {
       setSubmitting(false)
     }
@@ -176,8 +176,8 @@ export default function SessionPage() {
     try {
       await deleteRound(session.id, roundNumber)
       await load()
-    } catch (e: any) {
-      setError(e.message || MSG.ERROR)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : MSG.ERROR)
     } finally {
       setSubmitting(false)
     }
@@ -190,8 +190,8 @@ export default function SessionPage() {
     try {
       await completeSession(session.id)
       await load()
-    } catch (e: any) {
-      setError(e.message || MSG.ERROR)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : MSG.ERROR)
     } finally {
       setSubmitting(false)
     }

--- a/ui/src/pages/SignUpPage.tsx
+++ b/ui/src/pages/SignUpPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { createPlayer, checkUserName } from '../api'
+import { MSG } from '../constants'
 
 export default function SignUpPage() {
   const navigate = useNavigate()
@@ -55,7 +56,7 @@ export default function SignUpPage() {
       await createPlayer(userName.trim(), firstName.trim(), lastName.trim())
       navigate('/')
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : '注册失败')
+      setError(err instanceof Error ? err.message : MSG.ERROR)
       setSubmitting(false)
     }
   }

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -156,9 +156,7 @@ export default function StatsPage() {
   if (error)
     return (
       <div className="empty-state">
-        <p>
-          {MSG.LOAD_FAILED}：{error}
-        </p>
+        <p>{error}</p>
       </div>
     )
 

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -19,6 +19,7 @@ const currentSeason = getCurrentSeason()
 
 import { statFontSize } from '../utils/fontSize'
 import { abbrName } from '../utils/format'
+import { MSG } from '../constants'
 
 export default function StatsPage() {
   const navigate = useNavigate()
@@ -149,13 +150,15 @@ export default function StatsPage() {
   if (loading)
     return (
       <div className="empty-state">
-        <p>加载中...</p>
+        <p>{MSG.LOADING}</p>
       </div>
     )
   if (error)
     return (
       <div className="empty-state">
-        <p>加载失败：{error}</p>
+        <p>
+          {MSG.LOAD_FAILED}：{error}
+        </p>
       </div>
     )
 

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -54,8 +54,8 @@ export default function StatsPage() {
         setStats(s.sort((a, b) => b.totalRP - a.totalRP || b.totalScore - a.totalScore))
         setLoading(false)
       })
-      .catch((e) => {
-        setError(e.message)
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : MSG.ERROR)
         setLoading(false)
       })
   }
@@ -68,8 +68,8 @@ export default function StatsPage() {
         setPlayers(p)
         setLoading(false)
       })
-      .catch((e) => {
-        setError(e.message)
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : MSG.ERROR)
         setLoading(false)
       })
   }
@@ -87,9 +87,9 @@ export default function StatsPage() {
           )
         }
       })
-      .catch((e) => {
+      .catch((e: unknown) => {
         if (!mounted) return
-        setError(e.message)
+        setError(e instanceof Error ? e.message : MSG.ERROR)
       })
     return () => {
       mounted = false
@@ -112,8 +112,8 @@ export default function StatsPage() {
         .then((data) => {
           if (!controller.signal.aborted) setBestRounds(data)
         })
-        .catch((e) => {
-          if (!controller.signal.aborted) setBestRoundsError(e.message)
+        .catch((e: unknown) => {
+          if (!controller.signal.aborted) setBestRoundsError(e instanceof Error ? e.message : MSG.ERROR)
         })
     }
     return () => controller.abort()
@@ -129,9 +129,9 @@ export default function StatsPage() {
         .then((data) => {
           if (!controller.signal.aborted) setMonthlyBestRounds(data)
         })
-        .catch((e) => {
+        .catch((e: unknown) => {
           if (!controller.signal.aborted) {
-            setMonthlyBestRoundsError(e.message)
+            setMonthlyBestRoundsError(e instanceof Error ? e.message : MSG.ERROR)
             setMonthlyBestRounds([])
           }
         })

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -300,7 +300,7 @@ export default function StatsPage() {
                 <span className="best-hand-crown">🌟</span>
                 <h2>{selectedSeason?.label}最高和牌</h2>
               </div>
-              {monthlyBestRoundsError && <p className="error-text">加载月度最高和牌失败: {monthlyBestRoundsError}</p>}
+              {monthlyBestRoundsError && <p className="error-text">{monthlyBestRoundsError}</p>}
               {!monthlyBestRoundsError && monthlyBestRounds.length === 0 && (
                 <div className="empty-state empty-state-compact">
                   <p>本月无记录</p>
@@ -334,7 +334,7 @@ export default function StatsPage() {
                 <span className="best-hand-crown">👑</span>
                 <h2>历史最高和牌</h2>
               </div>
-              {bestRoundsError && <p className="error-text">加载历史最高和牌失败: {bestRoundsError}</p>}
+              {bestRoundsError && <p className="error-text">{bestRoundsError}</p>}
               <div className="best-hand-list">
                 {bestRounds.map((round) => (
                   <div key={`${round.sessionId}-${round.roundNumber}`} className="best-hand-item">


### PR DESCRIPTION
## Summary
- Add in-memory response cache (30s TTL) for all GET API endpoints
- Cache invalidates immediately after any mutation (addRound, deleteRound, completeSession, createSession)
- Cache clears on tab refocus (visibilitychange) so reopening the page always fetches fresh data
- Extract UI text constants to `constants.ts` — MSG.LOADING, MSG.SUBMITTING, MSG.ERROR
- Consolidate all error fallback messages to single `操作失败`
- Align loading text to "加载中..." across all pages

Closes #72

## Test plan
- [ ] Switch between pages quickly — should be instant on second visit within 30s
- [ ] Add a round → verify session detail refreshes with new data
- [ ] Switch to another tab, wait, switch back → verify data refreshes
- [ ] Loading text shows "加载中..." consistently on all pages
- [ ] Error states show the actual error message, not a hardcoded prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Short-lived (30s) client-side response cache with auto-clear when returning to the app to speed repeat requests and support aborting in-flight loads.

* **Bug Fixes**
  * Cache invalidation after data-changing actions; standardized error fallbacks to a shared message for consistent failures.

* **UI Updates**
  * Unified localized status texts for loading, submitting, and errors used across pages; improved error handling to avoid misleading messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->