### PR TITLE
feat: support riichi stick deduction on win rounds

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
@@ -57,8 +57,12 @@ public class RiichiModeHandler implements GameModeHandler {
     params.put("honba", request.getHonba() != null ? request.getHonba() : 0);
     params.put("kyoutaku", request.getKyoutaku() != null ? request.getKyoutaku() : 0);
 
-    return calculator.calculate(
-        sessionPlayerIds, request.getWinnerId(), request.getDealInPlayerId(), params);
+    Map<Long, Integer> scores =
+        calculator.calculate(
+            sessionPlayerIds, request.getWinnerId(), request.getDealInPlayerId(), params);
+
+    applyRiichiSticks(request, sessionPlayerIds, scores);
+    return scores;
   }
 
   private Map<Long, Integer> calculateDrawnGame(
@@ -93,7 +97,12 @@ public class RiichiModeHandler implements GameModeHandler {
         }
       }
     }
-    // Riichi stick deductions: -1000 per declaring player
+    applyRiichiSticks(request, sessionPlayerIds, scores);
+    return scores;
+  }
+
+  private void applyRiichiSticks(
+      AddRoundRequest request, List<Long> sessionPlayerIds, Map<Long, Integer> scores) {
     List<Long> riichiIds = request.getRiichiPlayerIds();
     if (riichiIds != null) {
       Set<Long> uniqueRiichiIds = new HashSet<>(riichiIds);
@@ -104,6 +113,5 @@ public class RiichiModeHandler implements GameModeHandler {
         scores.merge(id, -1000, Integer::sum);
       }
     }
-    return scores;
   }
 }

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -138,6 +138,7 @@ export default function SessionPage() {
           kyoutaku: gameState.kyoutaku,
           dealInPlayerId: isSelfDraw ? null : Number(dealInPlayerId),
           fanCount: parseInt(fan),
+          riichiPlayerIds: riichiPlayerIds.length > 0 ? riichiPlayerIds : undefined,
         })
       } else if (isDongbei) {
         await addRound(session.id, {
@@ -590,6 +591,32 @@ export default function SessionPage() {
                 )}
 
                 {preview && <div className="score-preview">{preview}</div>}
+
+                {isRiichi && !isRyuukyoku && (
+                  <div className="form-group">
+                    <label>本局立直</label>
+                    <div className="player-chips">
+                      {session.players.map((p) => (
+                        <span
+                          key={p.id}
+                          className={`chip ${riichiPlayerIds.includes(p.id) ? 'selected' : ''}`}
+                          onClick={() => {
+                            setRiichiPlayerIds((prev) =>
+                              prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
+                            )
+                          }}
+                          style={{ cursor: 'pointer' }}
+                        >
+                          {p.userName}
+                          {riichiPlayerIds.includes(p.id) && ' ✓'}
+                        </span>
+                      ))}
+                    </div>
+                    {riichiPlayerIds.length > 0 && (
+                      <span className="field-hint">{riichiPlayerIds.length}人立直 → 各扣1000</span>
+                    )}
+                  </div>
+                )}
 
                 {error && <p className="error-text">{error}</p>}
 


### PR DESCRIPTION
## Summary
- Add "本局立直" chip selection in the win round form for marking players who declared riichi
- Include `riichiPlayerIds` in the win round API payload (previously only sent for drawn games)
- Backend: extract shared `applyRiichiSticks()` method in `RiichiModeHandler`, applied to both win and drawn game rounds
- Each declaring player is deducted -1000 points for their riichi stick

## Test plan
- [ ] In a riichi win round, select 1-2 riichi players → verify -1000 deducted per player in scores
- [ ] Winner who also declared riichi → verify -1000 deducted from winner too
- [ ] No riichi selected → scores unchanged from before this PR
- [ ] Drawn game riichi still works as before
- [ ] Mobile: riichi chips render correctly and are tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)