### PR TITLE
fix: award current round riichi sticks to winner

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/service/handler/RiichiModeHandler.java
@@ -62,6 +62,13 @@ public class RiichiModeHandler implements GameModeHandler {
             sessionPlayerIds, request.getWinnerId(), request.getDealInPlayerId(), params);
 
     applyRiichiSticks(request, sessionPlayerIds, scores);
+
+    List<Long> riichiIds = request.getRiichiPlayerIds();
+    if (riichiIds != null && !riichiIds.isEmpty()) {
+      int riichiPool = new HashSet<>(riichiIds).size() * 1000;
+      scores.merge(request.getWinnerId(), riichiPool, Integer::sum);
+    }
+
     return scores;
   }
 

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -271,29 +271,34 @@ export default function SessionPage() {
       const honbaNum = gameState.honba
       const honbaBonus = 100 * honbaNum
       const kyoutakuNum = gameState.kyoutaku
+      const riichiPool = riichiPlayerIds.length * 1000
+      const bonusPool = kyoutakuNum + riichiPool
+      const bonusLabel = [kyoutakuNum > 0 ? `供托${kyoutakuNum}` : '', riichiPool > 0 ? `立直棒${riichiPool}` : '']
+        .filter(Boolean)
+        .join('+')
 
       if (isSelfDraw) {
         if (winnerIsDealer) {
           const each = r100(basic * 2) + honbaBonus
           const numOthers = session.playerCount - 1
-          const winnerTotal = each * numOthers + kyoutakuNum
+          const winnerTotal = each * numOthers + bonusPool
           return `自摸 (亲家): ${numOthers}人各付${each}${honbaNum > 0 ? ` (含${honbaNum}本场)` : ''}${
-            kyoutakuNum > 0 ? ` +供托${kyoutakuNum}` : ''
+            bonusPool > 0 ? ` +${bonusLabel}` : ''
           } → 共+${winnerTotal}`
         } else {
           const dealerPays = r100(basic * 2) + honbaBonus
           const otherPays = r100(basic) + honbaBonus
           const numNonDealers = session.playerCount - 2
-          const total = dealerPays + numNonDealers * otherPays + kyoutakuNum
+          const total = dealerPays + numNonDealers * otherPays + bonusPool
           return `自摸: 亲家付${dealerPays}, ${numNonDealers > 0 ? `其他各付${otherPays}, ` : ''}${
             honbaNum > 0 ? `(含${honbaNum}本场) ` : ''
-          }${kyoutakuNum > 0 ? `+供托${kyoutakuNum} ` : ''}共+${total}`
+          }${bonusPool > 0 ? `+${bonusLabel} ` : ''}共+${total}`
         }
       } else {
         const base = (winnerIsDealer ? r100(basic * 6) : r100(basic * 4)) + 300 * honbaNum
-        const total = base + kyoutakuNum
+        const total = base + bonusPool
         return `荣和${winnerIsDealer ? ' (亲家)' : ''}: ${base}点${honbaNum > 0 ? ` (含${honbaNum}本场)` : ''}${
-          kyoutakuNum > 0 ? ` +供托${kyoutakuNum}` : ''
+          bonusPool > 0 ? ` +${bonusLabel}` : ''
         } → 共+${total}`
       }
     }
@@ -613,7 +618,9 @@ export default function SessionPage() {
                       ))}
                     </div>
                     {riichiPlayerIds.length > 0 && (
-                      <span className="field-hint">{riichiPlayerIds.length}人立直 → 各扣1000</span>
+                      <span className="field-hint">
+                        {riichiPlayerIds.length}人立直 → 各扣1000, 胜者收立直棒+{riichiPlayerIds.length * 1000}
+                      </span>
                     )}
                   </div>
                 )}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -271,9 +271,15 @@ export default function SessionPage() {
       const honbaNum = gameState.honba
       const honbaBonus = 100 * honbaNum
       const kyoutakuNum = gameState.kyoutaku
-      const riichiPool = riichiPlayerIds.length * 1000
-      const bonusPool = kyoutakuNum + riichiPool
-      const bonusLabel = [kyoutakuNum > 0 ? `供托${kyoutakuNum}` : '', riichiPool > 0 ? `立直棒${riichiPool}` : '']
+      const uniqueRiichiCount = new Set(riichiPlayerIds).size
+      const riichiPool = uniqueRiichiCount * 1000
+      const winnerDeclaredRiichi = riichiPlayerIds.includes(Number(winnerId))
+      const winnerRiichiNet = riichiPool - (winnerDeclaredRiichi ? 1000 : 0)
+      const bonusPool = kyoutakuNum + winnerRiichiNet
+      const bonusLabel = [
+        kyoutakuNum > 0 ? `供托${kyoutakuNum}` : '',
+        winnerRiichiNet > 0 ? `立直棒${winnerRiichiNet}` : '',
+      ]
         .filter(Boolean)
         .join('+')
 


### PR DESCRIPTION
## Summary
- Winner now correctly receives all riichi sticks placed in the current round (standard rule: winner collects all sticks on the table)
- Previously, riichi declarers lost 1000 points each but the winner never received them — points vanished
- Frontend score preview now shows both 供托 (previous round kyoutaku) and 立直棒 (current round sticks) in the winner's total

## Test plan
- [ ] Create a riichi session, declare riichi with one player, have another player win → verify winner receives +1000 from riichi stick
- [ ] Multiple riichi declarers in one round → winner receives N×1000
- [ ] Winner themselves declared riichi → net zero on the stick (loses 1000, gains it back)
- [ ] Drawn game with riichi → sticks still go to kyoutaku (no winner bonus)
- [ ] Score preview text shows correct totals including riichi sticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Winners now receive riichi sticks from the accumulated pool during scoring.
  * Score preview now incorporates riichi stick bonuses alongside other payouts.

* **Improvements**
  * Updated in-game messaging to clearly indicate winners receive riichi sticks.
  * Enhanced score calculation display to show complete bonus pool composition.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmdtoycar/mahjong-omakase/pull/84)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->