### PR TITLE
style: align result display, rename CSS classes, cleanup

### DIFF
--- a/ui/src/components/GuobiaoCalculator.tsx
+++ b/ui/src/components/GuobiaoCalculator.tsx
@@ -341,9 +341,9 @@ export const GuobiaoCalculator: React.FC<GuobiaoCalculatorProps> = ({
                     <span className="score-unit">番</span>
                   </div>
                 </div>
-                <div className="fan-list-mini">
+                <div className="pattern-list">
                   {r.fans.map((f, fi) => (
-                    <span key={fi} className="mini-fan-tag">
+                    <span key={fi} className="pattern-tag">
                       {f.name}
                       {f.count && f.count > 1 ? ` x${f.count}` : ''} +{f.score}
                     </span>
@@ -363,9 +363,9 @@ export const GuobiaoCalculator: React.FC<GuobiaoCalculatorProps> = ({
               <span className="score-num">{huResult.totalScore}</span>
               <span className="score-unit">番</span>
             </div>
-            <div className="fan-list-mini">
+            <div className="pattern-list">
               {huResult.fans.map((f, i) => (
-                <span key={i} className="mini-fan-tag">
+                <span key={i} className="pattern-tag">
                   {f.name}
                   {f.count && f.count > 1 ? ` x${f.count}` : ''} +{f.score}
                 </span>

--- a/ui/src/components/MahjongHand.tsx
+++ b/ui/src/components/MahjongHand.tsx
@@ -132,7 +132,7 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
     <div className="mahjong-hand-container">
       <div className="mahjong-hand">{elements}</div>
       {fanTags.length > 0 && (
-        <div className="fan-list-mini" style={{ marginTop: '8px' }}>
+        <div className="pattern-list" style={{ marginTop: '8px' }}>
           {fanTags.map((tag, idx) => {
             // tag is like "花牌(2x2)" or "大四喜(88)"
             const match = tag.match(/^(.+)\((\d+)(x(\d+))?\)$/)
@@ -141,14 +141,14 @@ export const MahjongHand: React.FC<Props> = ({ hand, details }) => {
               const totalScore = match[2]
               const count = match[4]
               return (
-                <span key={idx} className="mini-fan-tag">
+                <span key={idx} className="pattern-tag">
                   {name}
                   {count ? `x${count}` : ''} +{totalScore}
                 </span>
               )
             }
             return (
-              <span key={idx} className="mini-fan-tag">
+              <span key={idx} className="pattern-tag">
                 {tag}
               </span>
             )

--- a/ui/src/components/RiichiCalculator.tsx
+++ b/ui/src/components/RiichiCalculator.tsx
@@ -345,22 +345,32 @@ export const RiichiCalculator: React.FC<RiichiCalculatorProps> = ({
 
       {huResult && (
         <div className={`result-preview-mini ${huResult.yakuList.length === 0 ? 'error' : ''}`}>
-          <div className="fan-list-mini">
-            <strong>{huResult.han} 番:</strong>
-            {huResult.yakuList.map((y, i) => (
-              <span key={i} className="mini-fan-tag">
-                {y.name} {y.isYakuman ? '役满' : `${y.han}番`}
-              </span>
-            ))}
-          </div>
-          {huResult.fuDetails.length > 0 && (
-            <div className="fan-list-mini">
-              <strong>{huResult.fu} 符:</strong>
-              {huResult.fuDetails.map((f, i) => (
-                <span key={i} className="mini-fan-tag">
-                  {f.reason} {f.fu}符
+          <div className="result-main-row">
+            <div className="score-badge small">
+              <span className="score-num">{huResult.han}</span>
+              <span className="score-unit">番</span>
+            </div>
+            <div className="pattern-list">
+              {huResult.yakuList.map((y, i) => (
+                <span key={i} className="pattern-tag">
+                  {y.name} {y.isYakuman ? '役满' : `${y.han}番`}
                 </span>
               ))}
+            </div>
+          </div>
+          {huResult.fuDetails.length > 0 && (
+            <div className="result-main-row">
+              <div className="score-badge small">
+                <span className="score-num">{huResult.fu}</span>
+                <span className="score-unit">符</span>
+              </div>
+              <div className="pattern-list">
+                {huResult.fuDetails.map((f, i) => (
+                  <span key={i} className="pattern-tag">
+                    {f.reason} {f.fu}符
+                  </span>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -61,8 +61,6 @@
   color: var(--sol-base01);
 }
 
-/* Rank Circles (Legacy, will remove if unused) */
-
 html {
   scroll-behavior: smooth;
 }
@@ -1111,7 +1109,7 @@ tr:hover td {
     gap: 6px;
   }
 
-  .ting-row-item .fan-list-mini {
+  .ting-row-item .pattern-list {
     width: 100%;
   }
 
@@ -1553,27 +1551,23 @@ tr:hover td {
   gap: 12px;
 }
 
-.fan-list-mini {
+.pattern-list {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 4px;
-}
-
-.fan-list-mini.subtle {
-  margin-top: 2px;
-  opacity: 0.7;
 }
 
 .winning-options-section {
   margin-top: 8px;
 }
 
-.ting-row-item .fan-list-mini {
+.ting-row-item .pattern-list {
   max-width: 200px;
 }
 
-.mini-fan-tag {
-  font-size: 0.65rem;
+.pattern-tag {
+  font-size: 0.7rem;
   font-weight: 600;
   background: white;
   border: 1px solid var(--border);
@@ -2218,15 +2212,15 @@ tr:hover td {
 }
 
 .game-card .rank-1 .rank-number {
-  color: #b58900;
+  color: var(--sol-yellow);
   opacity: 1;
 }
 .game-card .rank-2 .rank-number {
-  color: #839496;
+  color: var(--sol-base0);
   opacity: 1;
 }
 .game-card .rank-3 .rank-number {
-  color: #cb4b16;
+  color: var(--sol-orange);
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- Riichi calculator result now uses `score-badge small` circles for 番/符 (matching Guobiao's pattern)
- Rename `fan-list-mini` → `pattern-list`, `mini-fan-tag` → `pattern-tag` (used by both fan and fu)
- Remove orphaned `.pattern-list.subtle` CSS class
- Remove stale "Rank Circles (Legacy)" comment
- Replace hardcoded hex colors (`#b58900`, `#839496`, `#cb4b16`) with CSS variables in `.game-card .rank-X`

## Test plan
- [ ] Verify riichi calculator result shows circle badges for 番 and 符
- [ ] Verify guobiao calculator result still displays correctly
- [ ] Verify MahjongHand component fan details render properly
- [ ] Verify game card rank colors display correctly on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual consistency for pattern and fan scoring information throughout the application's calculator interfaces.
  * Updated rank indicator colors and styling to align with the application's design theme.
  * Refined the layout and presentation of scoring result preview panels for improved readability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmdtoycar/mahjong-omakase/pull/91)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->