### PR TITLE
feat: tiered per-season bonus, default admin bonus to 0

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -9,6 +9,10 @@ public class PlayerStatsResponse {
   private double avgScore;
   private int wins;
   private double totalRP;
+  private double baseRP;
+  private double tieredBonus;
+  private double adminBonus;
+  private double fanDiscoveryBonus;
 
   public Long getPlayerId() {
     return playerId;
@@ -72,5 +76,37 @@ public class PlayerStatsResponse {
 
   public void setTotalRP(double totalRP) {
     this.totalRP = totalRP;
+  }
+
+  public double getBaseRP() {
+    return baseRP;
+  }
+
+  public void setBaseRP(double baseRP) {
+    this.baseRP = baseRP;
+  }
+
+  public double getTieredBonus() {
+    return tieredBonus;
+  }
+
+  public void setTieredBonus(double tieredBonus) {
+    this.tieredBonus = tieredBonus;
+  }
+
+  public double getAdminBonus() {
+    return adminBonus;
+  }
+
+  public void setAdminBonus(double adminBonus) {
+    this.adminBonus = adminBonus;
+  }
+
+  public double getFanDiscoveryBonus() {
+    return fanDiscoveryBonus;
+  }
+
+  public void setFanDiscoveryBonus(double fanDiscoveryBonus) {
+    this.fanDiscoveryBonus = fanDiscoveryBonus;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -19,6 +19,7 @@ public class SessionDetailResponse {
   private double rpOrigin;
   private double[] umaDist;
   private Double participationBonus;
+  private Map<Long, Double> playerBonuses;
 
   public static class PlayerInfo {
     private Long id;
@@ -253,5 +254,13 @@ public class SessionDetailResponse {
 
   public void setParticipationBonus(Double participationBonus) {
     this.participationBonus = participationBonus;
+  }
+
+  public Map<Long, Double> getPlayerBonuses() {
+    return playerBonuses;
+  }
+
+  public void setPlayerBonuses(Map<Long, Double> playerBonuses) {
+    this.playerBonuses = playerBonuses;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -1,6 +1,7 @@
 package com.mahjong.omakase.dto;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -19,7 +20,7 @@ public class SessionDetailResponse {
   private double rpOrigin;
   private double[] umaDist;
   private Double participationBonus;
-  private Map<Long, Double> playerBonuses;
+  private Map<Long, Double> playerBonuses = Collections.emptyMap();
 
   public static class PlayerInfo {
     private Long id;

--- a/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
@@ -13,4 +13,6 @@ public interface FanDiscoveryRepository extends JpaRepository<FanDiscovery, Long
   Optional<FanDiscovery> findBySeasonAndFanNameAndPlayerBotFalse(String season, String fanName);
 
   List<FanDiscovery> findBySeason(String season);
+
+  List<FanDiscovery> findByRoundGameSessionId(Long sessionId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -14,6 +14,11 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
           + "WHERE rs.round.gameSession.id = :sessionId GROUP BY rs.player.id")
   List<Object[]> getTotalScoresBySession(Long sessionId);
 
+  @Query(
+      "SELECT rs.player.id, COUNT(DISTINCT rs.round.gameSession.id) FROM RoundScore rs "
+          + "WHERE rs.round.gameSession.id IN :sessionIds GROUP BY rs.player.id")
+  List<Object[]> getGamesPlayedPerPlayerInSessions(List<Long> sessionIds);
+
   @Query("SELECT rs.player.id, SUM(rs.score) FROM RoundScore rs GROUP BY rs.player.id")
   List<Object[]> getTotalScoresAllTime();
 

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -119,10 +119,10 @@ public class GameService {
                 return Double.parseDouble(s.getValue());
               } catch (NumberFormatException e) {
                 log.warn("Invalid participation_bonus value '{}', using default", s.getValue());
-                return 5.0;
+                return 0.0;
               }
             })
-        .orElse(5.0);
+        .orElse(0.0);
   }
 
   public List<Player> getAllPlayers() {
@@ -324,8 +324,66 @@ public class GameService {
     resp.setUmaDist(session.getGameMode().getUmaDist(session.getPlayerCount()));
     resp.setParticipationBonus(
         session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0);
+    resp.setPlayerBonuses(computeSessionPlayerBonuses(session));
 
     return resp;
+  }
+
+  /**
+   * Computes per-player bonus contributed by this one session = tieredBonus + adminBonus +
+   * fanDiscoveryBonus. Matches what getPlayerStats aggregates across all sessions. Returns empty
+   * for sessions with no round scores (no bonus for empty sessions).
+   */
+  private Map<Long, Double> computeSessionPlayerBonuses(GameSession session) {
+    Map<Long, Double> bonuses = new HashMap<>();
+
+    List<Object[]> currentSessionScores = roundScoreRepo.getTotalScoresBySession(session.getId());
+    if (currentSessionScores.isEmpty()) {
+      return bonuses;
+    }
+
+    String season = getSeasonString(session.getCreatedAt());
+
+    List<GameSession> seasonSessions =
+        sessionRepo.findAll().stream()
+            .filter(s -> s.getStatus() == SessionStatus.COMPLETED)
+            .filter(s -> s.getGameMode() == session.getGameMode())
+            .filter(s -> getSeasonString(s.getCreatedAt()).equals(season))
+            .filter(s -> !s.getCreatedAt().isAfter(session.getCreatedAt()))
+            .sorted(Comparator.comparing(GameSession::getCreatedAt))
+            .toList();
+
+    Map<Long, Integer> gameIndexUpToHere = new HashMap<>();
+    for (GameSession s : seasonSessions) {
+      List<Object[]> sessScores = roundScoreRepo.getTotalScoresBySession(s.getId());
+      for (Object[] row : sessScores) {
+        if (row[0] != null) gameIndexUpToHere.merge((Long) row[0], 1, Integer::sum);
+      }
+    }
+    boolean currentIncluded =
+        seasonSessions.stream().anyMatch(s -> s.getId().equals(session.getId()));
+
+    double adminBonus =
+        session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0;
+
+    for (Object[] row : currentSessionScores) {
+      if (row[0] == null) continue;
+      Long pid = (Long) row[0];
+      int idx = gameIndexUpToHere.getOrDefault(pid, 0);
+      if (!currentIncluded) idx += 1;
+      double tiered = idx <= 10 ? 10.0 : idx <= 20 ? 5.0 : 0.0;
+      bonuses.merge(pid, tiered + adminBonus, Double::sum);
+    }
+
+    if (session.getGameMode() == GameMode.GUOBIAO) {
+      for (FanDiscovery fd : fanDiscoveryRepo.findByRoundGameSessionId(session.getId())) {
+        if (fd.getBonusRp() > 0 && fd.getPlayer() != null) {
+          bonuses.merge(fd.getPlayer().getId(), fd.getBonusRp(), Double::sum);
+        }
+      }
+    }
+
+    return bonuses;
   }
 
   public void addRound(Long sessionId, AddRoundRequest request) {
@@ -534,7 +592,9 @@ public class GameService {
 
     Map<Long, Integer> wins = new HashMap<>();
     Map<Long, Double> totalRP = new HashMap<>();
-    Map<Long, Double> totalBonusPerPlayer = new HashMap<>();
+    Map<Long, Double> tieredBonusPerPlayer = new HashMap<>();
+    Map<Long, Double> adminBonusPerPlayer = new HashMap<>();
+    Map<Long, Double> fanBonusPerPlayer = new HashMap<>();
     List<GameSession> completedSessions =
         sessionRepo.findAll().stream()
             .filter(s -> s.getStatus() == SessionStatus.COMPLETED)
@@ -543,7 +603,12 @@ public class GameService {
                 s ->
                     !hasDateRange
                         || (!s.getCreatedAt().isBefore(start) && s.getCreatedAt().isBefore(end)))
+            .sorted(Comparator.comparing(GameSession::getCreatedAt))
             .toList();
+
+    // Tracks chronological game count per (season, mode, player) for tiered bonus.
+    // Keyed separately by mode so each game mode has its own 20-game tier per season.
+    Map<String, Map<Long, Integer>> gameIndexBySeasonModePlayer = new HashMap<>();
 
     // Add Fan Discovery Bonuses (GUOBIAO only)
     if (gameMode == null || gameMode == GameMode.GUOBIAO) {
@@ -552,7 +617,7 @@ public class GameService {
         List<FanDiscovery> discoveries = fanDiscoveryRepo.findBySeason(season);
         for (FanDiscovery fd : discoveries) {
           if (fd.getBonusRp() > 0) {
-            totalBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
+            fanBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
           }
         }
       } else {
@@ -560,7 +625,7 @@ public class GameService {
         List<FanDiscovery> allDiscoveries = fanDiscoveryRepo.findAll();
         for (FanDiscovery fd : allDiscoveries) {
           if (fd.getBonusRp() > 0) {
-            totalBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
+            fanBonusPerPlayer.merge(fd.getPlayer().getId(), fd.getBonusRp(), (a, b) -> a + b);
           }
         }
       }
@@ -569,11 +634,26 @@ public class GameService {
     for (GameSession session : completedSessions) {
       List<Object[]> sessionScores = roundScoreRepo.getTotalScoresBySession(session.getId());
       if (!sessionScores.isEmpty()) {
+        String season = getSeasonString(session.getCreatedAt());
+        String seasonModeKey = season + ":" + session.getGameMode().name();
+        Map<Long, Integer> seasonCounts =
+            gameIndexBySeasonModePlayer.computeIfAbsent(seasonModeKey, k -> new HashMap<>());
+        double adminBonus =
+            session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0;
         for (Object[] row : sessionScores) {
           if (row[0] != null) {
-            double bonus =
-                session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0;
-            totalBonusPerPlayer.merge((Long) row[0], bonus, (a, b) -> a + b);
+            Long playerId = (Long) row[0];
+            int gameIndex = seasonCounts.merge(playerId, 1, Integer::sum);
+            double tieredBonus;
+            if (gameIndex <= 10) {
+              tieredBonus = 10.0;
+            } else if (gameIndex <= 20) {
+              tieredBonus = 5.0;
+            } else {
+              tieredBonus = 0.0;
+            }
+            tieredBonusPerPlayer.merge(playerId, tieredBonus, (a, b) -> a + b);
+            adminBonusPerPlayer.merge(playerId, adminBonus, (a, b) -> a + b);
           }
         }
         List<Object[]> sorted = new ArrayList<>(sessionScores);
@@ -616,10 +696,17 @@ public class GameService {
               stat.setTotalScore(totalScores.getOrDefault(p.getId(), 0));
               stat.setWins(wins.getOrDefault(p.getId(), 0));
               double baseRP = totalRP.getOrDefault(p.getId(), 0.0);
-              double bonusRP = totalBonusPerPlayer.getOrDefault(p.getId(), 0.0);
-              stat.setTotalRP(baseRP + bonusRP);
+              double tieredBonus = tieredBonusPerPlayer.getOrDefault(p.getId(), 0.0);
+              double adminBonus = adminBonusPerPlayer.getOrDefault(p.getId(), 0.0);
+              double fanBonus = fanBonusPerPlayer.getOrDefault(p.getId(), 0.0);
+              double total = baseRP + tieredBonus + adminBonus + fanBonus;
+              stat.setBaseRP(baseRP);
+              stat.setTieredBonus(tieredBonus);
+              stat.setAdminBonus(adminBonus);
+              stat.setFanDiscoveryBonus(fanBonus);
+              stat.setTotalRP(total);
               int games = gamesPlayed.getOrDefault(p.getId(), 0);
-              stat.setAvgScore(games > 0 ? (baseRP + bonusRP) / games : 0);
+              stat.setAvgScore(games > 0 ? total / games : 0);
               return stat;
             })
         .collect(Collectors.toList());

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -354,10 +354,12 @@ public class GameService {
             .toList();
 
     Map<Long, Integer> gameIndexUpToHere = new HashMap<>();
-    for (GameSession s : seasonSessions) {
-      List<Object[]> sessScores = roundScoreRepo.getTotalScoresBySession(s.getId());
-      for (Object[] row : sessScores) {
-        if (row[0] != null) gameIndexUpToHere.merge((Long) row[0], 1, Integer::sum);
+    if (!seasonSessions.isEmpty()) {
+      List<Long> seasonSessionIds = seasonSessions.stream().map(GameSession::getId).toList();
+      for (Object[] row : roundScoreRepo.getGamesPlayedPerPlayerInSessions(seasonSessionIds)) {
+        if (row[0] != null) {
+          gameIndexUpToHere.put((Long) row[0], ((Number) row[1]).intValue());
+        }
       }
     }
     boolean currentIncluded =

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -893,6 +893,13 @@ tr:hover td {
   opacity: 0.7;
 }
 
+.rp-bonus {
+  color: var(--accent, #ff9800);
+  font-weight: 500;
+  font-size: 0.85em;
+  margin-left: 4px;
+}
+
 /* ===== Mobile responsive ===== */
 @media (max-width: 640px) {
   .app-header {

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -12,8 +12,8 @@ export default function AdminPage() {
   const [editingId, setEditingId] = useState<number | null>(null)
   const [editFirst, setEditFirst] = useState('')
   const [editLast, setEditLast] = useState('')
-  const [bonus, setBonus] = useState('5')
-  const [savedBonus, setSavedBonus] = useState('5')
+  const [bonus, setBonus] = useState('0')
+  const [savedBonus, setSavedBonus] = useState('0')
   const [savingSettings, setSavingSettings] = useState(false)
 
   const handleLogin = async (e: React.FormEvent) => {

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -813,8 +813,16 @@ export default function SessionPage() {
                         <div className="total-val">{displayVal}</div>
                         {session.rounds.length > 0 &&
                           (() => {
-                            const rp = rankMap[p.id]?.rp ?? 0
-                            return <div className="rp-val">{rp > 0 ? `+${rp.toFixed(1)}` : rp.toFixed(1)} RP</div>
+                            const baseRp = rankMap[p.id]?.rp ?? 0
+                            const bonus = session.playerBonuses?.[p.id] ?? 0
+                            return (
+                              <div className="rp-val">
+                                {baseRp > 0 ? `+${baseRp.toFixed(1)}` : baseRp.toFixed(1)} RP
+                                {bonus > 0 && (
+                                  <span className="rp-bonus">(+{bonus.toFixed(bonus % 1 === 0 ? 0 : 1)})</span>
+                                )}
+                              </div>
+                            )
                           })()}
                       </div>
                     </td>
@@ -837,16 +845,14 @@ export default function SessionPage() {
                   <th>名次</th>
                   <th>玩家</th>
                   <th style={{ textAlign: 'right' }}>分数</th>
-                  <th style={{ textAlign: 'right' }}>
-                    积分(RP)
-                    <div className="th-subtitle">含局数奖励</div>
-                  </th>
+                  <th style={{ textAlign: 'right' }}>积分(RP)</th>
                 </tr>
               </thead>
               <tbody>
                 {sortedPlayers.map((p, i) => {
                   const val = session.totalScores[p.id] || 0
-                  const rp = rankMap[p.id]?.rp ?? 0
+                  const baseRp = rankMap[p.id]?.rp ?? 0
+                  const bonus = session.playerBonuses?.[p.id] ?? 0
                   const rank = rankMap[p.id]?.rank ?? i + 1
                   return (
                     <tr key={p.id}>
@@ -871,7 +877,8 @@ export default function SessionPage() {
                           color: 'var(--primary)',
                         }}
                       >
-                        {rp > 0 ? `+${rp.toFixed(1)}` : rp.toFixed(1)}
+                        {baseRp > 0 ? `+${baseRp.toFixed(1)}` : baseRp.toFixed(1)}
+                        {bonus > 0 && <span className="rp-bonus">(+{bonus.toFixed(bonus % 1 === 0 ? 0 : 1)})</span>}
                       </td>
                     </tr>
                   )

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -256,10 +256,7 @@ export default function StatsPage() {
                       <th>玩家</th>
                       <th style={{ textAlign: 'right' }}>场次</th>
                       <th style={{ textAlign: 'right' }}>胜场</th>
-                      <th style={{ textAlign: 'right' }}>
-                        积分(RP)
-                        <div className="th-subtitle">含局数奖励</div>
-                      </th>
+                      <th style={{ textAlign: 'right' }}>积分(RP)</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -85,6 +85,7 @@ export interface SessionDetail {
   rpFactor: number
   rpOrigin: number
   umaDist: number[]
+  playerBonuses?: Record<number, number>
 }
 
 export interface AddRoundData {
@@ -114,6 +115,10 @@ export interface PlayerStats {
   gamesPlayed: number
   totalScore: number
   totalRP: number
+  baseRP: number
+  tieredBonus: number
+  adminBonus: number
+  fanDiscoveryBonus: number
   avgScore: number
   wins: number
 }


### PR DESCRIPTION
## Summary
- Add tiered RP bonus per `(season, mode, player)`: +10 for games 1-10, +5 for games 11-20, 0 after. Each game mode tracks its own 20-game tier per season.
- Default admin participation bonus changed from 5 → 0. Admin-set value still stacks per session on top of the tiered bonus (non-retroactive; applies to new sessions only).
- Session detail API now returns a `playerBonuses` map so the UI can render RP as `+18.7(+10)` — base RP plus bonus callout in accent color. Empty sessions produce no bonus.
- `PlayerStatsResponse` now exposes the breakdown (`baseRP`, `tieredBonus`, `adminBonus`, `fanDiscoveryBonus`); `totalRP` is still their sum.

Closes #92

## Test plan
- [ ] Visit `/admin` — bonus field defaults to 0 on first load. Save 0 on existing installs.
- [ ] Create 12 Riichi sessions in the current season for one player → verify first 10 sessions contribute +10 each, sessions 11-12 contribute +5 each, and the session page shows `(+10)` / `(+5)` accordingly.
- [ ] Play Riichi and Guobiao sessions with the same player → each mode's tier counts independently.
- [ ] Cross into a new month → tier resets to game 1 (+10).
- [ ] Set admin bonus to 3 from `/admin` → new sessions' bonus callouts show `(+13)` for games 1-10; old sessions unchanged.
- [ ] Create an empty session (no rounds) → rank table not shown and no phantom bonus anywhere.
- [ ] Verify totals on stats page = sum of session-page contributions for the season/mode filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RP scoring now displays detailed breakdowns by component: base RP, tiered bonus, admin bonus, and fan discovery bonus.
  * Session pages show per-player bonus contributions alongside base scores.

* **Bug Fixes**
  * Corrected default participation bonus value.

* **UI/UX**
  * Enhanced stats and session table displays to clearly show bonus components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmdtoycar/mahjong-omakase/pull/93)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->