### PR TITLE
test(riichi): enable JUnit Platform and cover tsumo scoring corner cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
 // ==========================================================================
 // UI (ui/) — React app built with Vite, output copied into Spring Boot jar
 // ==========================================================================

--- a/server/src/test/java/com/mahjong/omakase/service/handler/RiichiModeHandlerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/handler/RiichiModeHandlerTest.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.Test;
 
 public class RiichiModeHandlerTest {
 
+  private static final List<Long> YONMA = Arrays.asList(1L, 2L, 3L, 4L);
+  private static final List<Long> SANMA = Arrays.asList(1L, 2L, 3L);
+
   private RiichiScoreCalculator calculator;
   private RiichiModeHandler handler;
 
@@ -23,69 +26,104 @@ public class RiichiModeHandlerTest {
     handler = new RiichiModeHandler(calculator);
   }
 
+  private AddRoundRequest tsumo(Long winnerId, Long dealerId, int score) {
+    AddRoundRequest request = new AddRoundRequest();
+    request.setRoundType("WIN");
+    request.setWinnerId(winnerId);
+    request.setDealerId(dealerId);
+    request.setDealInPlayerId(null);
+    request.setScore(score);
+    request.setHonba(0);
+    request.setKyoutaku(0);
+    return request;
+  }
+
+  private void assertZeroSum(Map<Long, Integer> scores, int kyoutaku) {
+    int sum = scores.values().stream().mapToInt(Integer::intValue).sum();
+    assertEquals(kyoutaku, sum, "scores must sum to kyoutaku (carried-over riichi sticks)");
+  }
+
   @Test
   public void testGetGameMode() {
     assertEquals(GameMode.RIICHI, handler.getGameMode());
   }
 
+  // ============================================================
+  // Yonma — Dealer self-draw (Oya tsumo): each non-dealer pays p
+  // ============================================================
+
   @Test
-  public void testDirectScoreDealerTsumoSanma() {
-    // Sanma: 3 players (1L, 2L, 3L). 1L is winner & dealer (Oya).
-    AddRoundRequest request = new AddRoundRequest();
-    request.setRoundType("WIN");
-    request.setWinnerId(1L);
-    request.setDealerId(1L);
-    request.setDealInPlayerId(null);
-    request.setScore(24000); // 12000 * 2
-    request.setHonba(0);
-    request.setKyoutaku(0);
-
-    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L);
-
-    Map<Long, Integer> scores = handler.calculateRoundScores(request, sessionPlayerIds);
-
-    assertEquals(24000, scores.get(1L));
-    assertEquals(-12000, scores.get(2L));
-    assertEquals(-12000, scores.get(3L));
+  public void testYonmaDealerTsumo_1Han30Fu() {
+    // basicPoints = 30 * 2^3 = 240; each pays ceil(480/100)*100 = 500; total 1500
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 1500), YONMA);
+    assertEquals(1500, scores.get(1L));
+    assertEquals(-500, scores.get(2L));
+    assertEquals(-500, scores.get(3L));
+    assertEquals(-500, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
-  public void testDirectScoreNonDealerTsumoSanma() {
-    // Sanma: 3 players (1L, 2L, 3L). 1L is winner, 2L is dealer (Oya).
-    AddRoundRequest request = new AddRoundRequest();
-    request.setRoundType("WIN");
-    request.setWinnerId(1L);
-    request.setDealerId(2L);
-    request.setDealInPlayerId(null);
-    request.setScore(18000); // 12000 from dealer, 6000 from non-dealer
-    request.setHonba(0);
-    request.setKyoutaku(0);
+  public void testYonmaDealerTsumo_2Han30Fu() {
+    // basicPoints = 480; each pays 1000; total 3000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 3000), YONMA);
+    assertEquals(3000, scores.get(1L));
+    assertEquals(-1000, scores.get(2L));
+    assertEquals(-1000, scores.get(3L));
+    assertEquals(-1000, scores.get(4L));
+  }
 
-    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L);
+  @Test
+  public void testYonmaDealerTsumo_3Han20FuPinfu() {
+    // basicPoints = 20 * 2^5 = 640; each pays ceil(1280/100)*100 = 1300; total 3900
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 3900), YONMA);
+    assertEquals(3900, scores.get(1L));
+    assertEquals(-1300, scores.get(2L));
+    assertEquals(-1300, scores.get(3L));
+    assertEquals(-1300, scores.get(4L));
+  }
 
-    Map<Long, Integer> scores = handler.calculateRoundScores(request, sessionPlayerIds);
+  @Test
+  public void testYonmaDealerTsumo_4Han30Fu() {
+    // basicPoints = 30 * 2^6 = 1920 (below mangan cap); each pays ceil(3840/100)*100 = 3900; total
+    // 11700
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 11700), YONMA);
+    assertEquals(11700, scores.get(1L));
+    assertEquals(-3900, scores.get(2L));
+    assertEquals(-3900, scores.get(3L));
+    assertEquals(-3900, scores.get(4L));
+  }
 
+  @Test
+  public void testYonmaDealerTsumo_Mangan() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 12000), YONMA);
+    assertEquals(12000, scores.get(1L));
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-4000, scores.get(3L));
+    assertEquals(-4000, scores.get(4L));
+  }
+
+  @Test
+  public void testYonmaDealerTsumo_Haneman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 18000), YONMA);
     assertEquals(18000, scores.get(1L));
-    assertEquals(-12000, scores.get(2L)); // Dealer pays 2/3 of 18000
-    assertEquals(-6000, scores.get(3L)); // Non-dealer pays 1/3 of 18000
+    assertEquals(-6000, scores.get(2L));
+    assertEquals(-6000, scores.get(3L));
+    assertEquals(-6000, scores.get(4L));
   }
 
   @Test
-  public void testDirectScoreDealerTsumoYonma() {
-    // Yonma: 4 players. 1L is winner & dealer.
-    AddRoundRequest request = new AddRoundRequest();
-    request.setRoundType("WIN");
-    request.setWinnerId(1L);
-    request.setDealerId(1L);
-    request.setDealInPlayerId(null);
-    request.setScore(36000);
-    request.setHonba(0);
-    request.setKyoutaku(0);
+  public void testYonmaDealerTsumo_Baiman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 24000), YONMA);
+    assertEquals(24000, scores.get(1L));
+    assertEquals(-8000, scores.get(2L));
+    assertEquals(-8000, scores.get(3L));
+    assertEquals(-8000, scores.get(4L));
+  }
 
-    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L, 4L);
-
-    Map<Long, Integer> scores = handler.calculateRoundScores(request, sessionPlayerIds);
-
+  @Test
+  public void testYonmaDealerTsumo_Sanbaiman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 36000), YONMA);
     assertEquals(36000, scores.get(1L));
     assertEquals(-12000, scores.get(2L));
     assertEquals(-12000, scores.get(3L));
@@ -93,75 +131,383 @@ public class RiichiModeHandlerTest {
   }
 
   @Test
-  public void testDirectScoreNonDealerTsumoYonma() {
-    // Yonma: 4 players. 1L is winner, 2L is dealer.
-    AddRoundRequest request = new AddRoundRequest();
-    request.setRoundType("WIN");
-    request.setWinnerId(1L);
-    request.setDealerId(2L);
-    request.setDealInPlayerId(null);
-    request.setScore(24000);
-    request.setHonba(0);
-    request.setKyoutaku(0);
+  public void testYonmaDealerTsumo_Yakuman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 48000), YONMA);
+    assertEquals(48000, scores.get(1L));
+    assertEquals(-16000, scores.get(2L));
+    assertEquals(-16000, scores.get(3L));
+    assertEquals(-16000, scores.get(4L));
+  }
 
-    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L, 4L);
+  // ====================================================================
+  // Yonma — Non-dealer self-draw (Ko tsumo): dealer pays d, others pay n
+  // ====================================================================
 
-    Map<Long, Integer> scores = handler.calculateRoundScores(request, sessionPlayerIds);
-
-    assertEquals(24000, scores.get(1L));
-    assertEquals(-12000, scores.get(2L)); // Dealer pays 2/4 of 24000
-    assertEquals(-6000, scores.get(3L)); // Non-dealer pays 1/4 of 24000
-    assertEquals(-6000, scores.get(4L)); // Non-dealer pays 1/4 of 24000
+  @Test
+  public void testYonmaNonDealerTsumo_1Han30Fu() {
+    // basicPoints = 240; d = ceil(480/100)*100 = 500, n = 300; total 1100
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 1100), YONMA);
+    assertEquals(1100, scores.get(1L));
+    assertEquals(-500, scores.get(2L));
+    assertEquals(-300, scores.get(3L));
+    assertEquals(-300, scores.get(4L));
   }
 
   @Test
-  public void testDirectScoreNonDealerTsumoWithRiichi() {
-    // Yonma: 4 players. 1L is winner, 2L is dealer.
-    // Non-dealer Tsumo Mangan (base score 8000). Player 3L declared Riichi.
-    AddRoundRequest request = new AddRoundRequest();
-    request.setRoundType("WIN");
-    request.setWinnerId(1L);
-    request.setDealerId(2L);
-    request.setDealInPlayerId(null);
-    request.setScore(8000);
-    request.setHonba(0);
-    request.setKyoutaku(0);
-    request.setRiichiPlayerIds(Arrays.asList(3L)); // Player 3L declared Riichi
+  public void testYonmaNonDealerTsumo_1Han40Fu() {
+    // basicPoints = 320; d = ceil(640/100)*100 = 700, n = 400; total 1500
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 1500), YONMA);
+    assertEquals(1500, scores.get(1L));
+    assertEquals(-700, scores.get(2L));
+    assertEquals(-400, scores.get(3L));
+    assertEquals(-400, scores.get(4L));
+  }
 
-    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L, 4L);
+  @Test
+  public void testYonmaNonDealerTsumo_2Han30Fu() {
+    // basicPoints = 480; d = 1000, n = 500; total 2000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 2000), YONMA);
+    assertEquals(2000, scores.get(1L));
+    assertEquals(-1000, scores.get(2L));
+    assertEquals(-500, scores.get(3L));
+    assertEquals(-500, scores.get(4L));
+  }
 
-    Map<Long, Integer> scores = handler.calculateRoundScores(request, sessionPlayerIds);
+  @Test
+  public void testYonmaNonDealerTsumo_2Han40Fu() {
+    // basicPoints = 640; d = 1300, n = 700; total 2700
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 2700), YONMA);
+    assertEquals(2700, scores.get(1L));
+    assertEquals(-1300, scores.get(2L));
+    assertEquals(-700, scores.get(3L));
+    assertEquals(-700, scores.get(4L));
+  }
 
-    // Winner 1L gets 8000 (Tsumo base) + 1000 (Riichi stick) = 9000
-    assertEquals(9000, scores.get(1L));
-    // Dealer 2L pays 2/4 of 8000 = 4000
-    assertEquals(-4000, scores.get(2L));
-    // Player 3L pays 1/4 of 8000 (2000) + 1000 (Riichi stick) = 3000
-    assertEquals(-3000, scores.get(3L));
-    // Player 4L pays 1/4 of 8000 = 2000
+  @Test
+  public void testYonmaNonDealerTsumo_3Han30Fu() {
+    // basicPoints = 960; d = ceil(1920/100)*100 = 2000, n = 1000; total 4000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 4000), YONMA);
+    assertEquals(4000, scores.get(1L));
+    assertEquals(-2000, scores.get(2L));
+    assertEquals(-1000, scores.get(3L));
+    assertEquals(-1000, scores.get(4L));
+  }
+
+  @Test
+  public void testYonmaNonDealerTsumo_4Han20FuPinfu() {
+    // basicPoints = 20 * 2^6 = 1280; d = ceil(2560/100)*100 = 2600, n = 1300; total 5200
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 5200), YONMA);
+    assertEquals(5200, scores.get(1L));
+    assertEquals(-2600, scores.get(2L));
+    assertEquals(-1300, scores.get(3L));
+    assertEquals(-1300, scores.get(4L));
+  }
+
+  @Test
+  public void testYonmaNonDealerTsumo_4Han30Fu() {
+    // basicPoints = 1920 (just under mangan); d = ceil(3840/100)*100 = 3900, n = 2000; total 7900
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 7900), YONMA);
+    assertEquals(7900, scores.get(1L));
+    assertEquals(-3900, scores.get(2L));
+    assertEquals(-2000, scores.get(3L));
     assertEquals(-2000, scores.get(4L));
   }
 
   @Test
-  public void testDirectScoreNonDealerTsumoWithPinfu3Han() {
-    // Yonma: 4 players. 1L is winner, 2L is dealer.
-    // Non-dealer Tsumo Pinfu 3 Han (2700 total: 1300 from dealer, 700 from each other non-dealer).
-    AddRoundRequest request = new AddRoundRequest();
-    request.setRoundType("WIN");
-    request.setWinnerId(1L);
-    request.setDealerId(2L);
-    request.setDealInPlayerId(null);
-    request.setScore(2700);
-    request.setHonba(0);
-    request.setKyoutaku(0);
+  public void testYonmaNonDealerTsumo_Mangan() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 8000), YONMA);
+    assertEquals(8000, scores.get(1L));
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-2000, scores.get(3L));
+    assertEquals(-2000, scores.get(4L));
+  }
 
-    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L, 4L);
+  @Test
+  public void testYonmaNonDealerTsumo_Haneman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 12000), YONMA);
+    assertEquals(12000, scores.get(1L));
+    assertEquals(-6000, scores.get(2L));
+    assertEquals(-3000, scores.get(3L));
+    assertEquals(-3000, scores.get(4L));
+  }
 
-    Map<Long, Integer> scores = handler.calculateRoundScores(request, sessionPlayerIds);
+  @Test
+  public void testYonmaNonDealerTsumo_Baiman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 16000), YONMA);
+    assertEquals(16000, scores.get(1L));
+    assertEquals(-8000, scores.get(2L));
+    assertEquals(-4000, scores.get(3L));
+    assertEquals(-4000, scores.get(4L));
+  }
 
+  @Test
+  public void testYonmaNonDealerTsumo_Sanbaiman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 24000), YONMA);
+    assertEquals(24000, scores.get(1L));
+    assertEquals(-12000, scores.get(2L));
+    assertEquals(-6000, scores.get(3L));
+    assertEquals(-6000, scores.get(4L));
+  }
+
+  @Test
+  public void testYonmaNonDealerTsumo_Yakuman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 32000), YONMA);
+    assertEquals(32000, scores.get(1L));
+    assertEquals(-16000, scores.get(2L));
+    assertEquals(-8000, scores.get(3L));
+    assertEquals(-8000, scores.get(4L));
+  }
+
+  @Test
+  public void testYonmaNonDealerTsumo_DealerIsLastInPlayerOrder() {
+    // Verify that share assignment is by role (dealer vs non-dealer), not by player iteration
+    // order.
+    // Here 4L is dealer (last in the list) and 1L is winner.
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 4L, 2700), YONMA);
     assertEquals(2700, scores.get(1L));
-    assertEquals(-1300, scores.get(2L)); // Dealer pays 1300
-    assertEquals(-700, scores.get(3L)); // Non-dealer pays 700
-    assertEquals(-700, scores.get(4L)); // Non-dealer pays 700
+    assertEquals(-700, scores.get(2L));
+    assertEquals(-700, scores.get(3L));
+    assertEquals(-1300, scores.get(4L)); // dealer
+  }
+
+  // ====================================================================
+  // Sanma — Dealer self-draw: each of the 2 non-dealers pays p
+  // ====================================================================
+
+  @Test
+  public void testSanmaDealerTsumo_3Han20FuPinfu() {
+    // each pays 1300; total 2600
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 2600), SANMA);
+    assertEquals(2600, scores.get(1L));
+    assertEquals(-1300, scores.get(2L));
+    assertEquals(-1300, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaDealerTsumo_Mangan() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 8000), SANMA);
+    assertEquals(8000, scores.get(1L));
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-4000, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaDealerTsumo_Haneman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 12000), SANMA);
+    assertEquals(12000, scores.get(1L));
+    assertEquals(-6000, scores.get(2L));
+    assertEquals(-6000, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaDealerTsumo_Baiman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 16000), SANMA);
+    assertEquals(16000, scores.get(1L));
+    assertEquals(-8000, scores.get(2L));
+    assertEquals(-8000, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaDealerTsumo_Yakuman() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 1L, 32000), SANMA);
+    assertEquals(32000, scores.get(1L));
+    assertEquals(-16000, scores.get(2L));
+    assertEquals(-16000, scores.get(3L));
+  }
+
+  // ====================================================================
+  // Sanma — Non-dealer self-draw: dealer pays d, the other non-dealer pays n
+  // ====================================================================
+
+  @Test
+  public void testSanmaNonDealerTsumo_3Han20FuPinfu() {
+    // d = 1300, n = 700; total 2000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 2000), SANMA);
+    assertEquals(2000, scores.get(1L));
+    assertEquals(-1300, scores.get(2L));
+    assertEquals(-700, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaNonDealerTsumo_2Han40Fu() {
+    // d = 1300, n = 700; total 2000 (same payment shape as 3han20fu)
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 3L, 2000), SANMA);
+    assertEquals(2000, scores.get(1L));
+    assertEquals(-700, scores.get(2L));
+    assertEquals(-1300, scores.get(3L)); // dealer
+  }
+
+  @Test
+  public void testSanmaNonDealerTsumo_Mangan() {
+    // d = 4000, n = 2000; total 6000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 6000), SANMA);
+    assertEquals(6000, scores.get(1L));
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-2000, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaNonDealerTsumo_Haneman() {
+    // d = 6000, n = 3000; total 9000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 9000), SANMA);
+    assertEquals(9000, scores.get(1L));
+    assertEquals(-6000, scores.get(2L));
+    assertEquals(-3000, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaNonDealerTsumo_Baiman() {
+    // d = 8000, n = 4000; total 12000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 12000), SANMA);
+    assertEquals(12000, scores.get(1L));
+    assertEquals(-8000, scores.get(2L));
+    assertEquals(-4000, scores.get(3L));
+  }
+
+  @Test
+  public void testSanmaNonDealerTsumo_Yakuman() {
+    // d = 16000, n = 8000; total 24000
+    Map<Long, Integer> scores = handler.calculateRoundScores(tsumo(1L, 2L, 24000), SANMA);
+    assertEquals(24000, scores.get(1L));
+    assertEquals(-16000, scores.get(2L));
+    assertEquals(-8000, scores.get(3L));
+  }
+
+  // ====================================================================
+  // Honba: tsumo adds 100 yen per non-winner per honba
+  // ====================================================================
+
+  @Test
+  public void testYonmaDealerTsumo_ManganWith2Honba() {
+    AddRoundRequest request = tsumo(1L, 1L, 12000);
+    request.setHonba(2);
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, YONMA);
+    // each non-dealer: 4000 + 200 = 4200; winner: 12000 + 600 = 12600
+    assertEquals(12600, scores.get(1L));
+    assertEquals(-4200, scores.get(2L));
+    assertEquals(-4200, scores.get(3L));
+    assertEquals(-4200, scores.get(4L));
+    assertZeroSum(scores, 0);
+  }
+
+  @Test
+  public void testYonmaNonDealerTsumo_ManganWith3Honba() {
+    AddRoundRequest request = tsumo(1L, 2L, 8000);
+    request.setHonba(3);
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, YONMA);
+    // dealer: 4000 + 300 = 4300; non-dealers: 2000 + 300 = 2300; winner: 8000 + 900 = 8900
+    assertEquals(8900, scores.get(1L));
+    assertEquals(-4300, scores.get(2L));
+    assertEquals(-2300, scores.get(3L));
+    assertEquals(-2300, scores.get(4L));
+    assertZeroSum(scores, 0);
+  }
+
+  @Test
+  public void testSanmaNonDealerTsumo_ManganWith1Honba() {
+    AddRoundRequest request = tsumo(1L, 2L, 6000);
+    request.setHonba(1);
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, SANMA);
+    // dealer: 4000 + 100 = 4100; other non-dealer: 2000 + 100 = 2100; winner: 6000 + 200 = 6200
+    assertEquals(6200, scores.get(1L));
+    assertEquals(-4100, scores.get(2L));
+    assertEquals(-2100, scores.get(3L));
+    assertZeroSum(scores, 0);
+  }
+
+  // ====================================================================
+  // Kyoutaku: carried-over riichi sticks go to winner only
+  // ====================================================================
+
+  @Test
+  public void testTsumoWith2Kyoutaku() {
+    AddRoundRequest request = tsumo(1L, 2L, 8000);
+    request.setKyoutaku(2000); // 2 sticks worth, expressed in yen
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, YONMA);
+    // winner gets 8000 + 2000 (kyoutaku); per-player payments unchanged
+    assertEquals(10000, scores.get(1L));
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-2000, scores.get(3L));
+    assertEquals(-2000, scores.get(4L));
+    assertZeroSum(scores, 2000);
+  }
+
+  // ====================================================================
+  // Riichi sticks declared this round
+  // ====================================================================
+
+  @Test
+  public void testTsumoWithWinnerOnlyRiichi() {
+    // Winner self-declared riichi: pays -1000, then receives back +1000 from riichi pool → net 0
+    // from stick
+    AddRoundRequest request = tsumo(1L, 2L, 8000);
+    request.setRiichiPlayerIds(Arrays.asList(1L));
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, YONMA);
+    assertEquals(8000, scores.get(1L));
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-2000, scores.get(3L));
+    assertEquals(-2000, scores.get(4L));
+    assertZeroSum(scores, 0);
+  }
+
+  @Test
+  public void testTsumoWithMultipleNonWinnerRiichi() {
+    // Two non-winners declare riichi; winner receives the 2000-yen pool.
+    AddRoundRequest request = tsumo(1L, 2L, 8000);
+    request.setRiichiPlayerIds(Arrays.asList(3L, 4L));
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, YONMA);
+    assertEquals(10000, scores.get(1L)); // 8000 + 2000 from riichi pool
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-3000, scores.get(3L)); // -2000 share + -1000 stick
+    assertEquals(-3000, scores.get(4L));
+    assertZeroSum(scores, 0);
+  }
+
+  @Test
+  public void testTsumoWithDuplicateRiichiIdsCountedOnce() {
+    // Dedup: same id appearing twice should still only count as one stick.
+    AddRoundRequest request = tsumo(1L, 2L, 8000);
+    request.setRiichiPlayerIds(Arrays.asList(3L, 3L));
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, YONMA);
+    assertEquals(9000, scores.get(1L));
+    assertEquals(-4000, scores.get(2L));
+    assertEquals(-3000, scores.get(3L));
+    assertEquals(-2000, scores.get(4L));
+    assertZeroSum(scores, 0);
+  }
+
+  @Test
+  public void testTsumoWithRiichiAndKyoutakuAndHonba() {
+    // Composite: non-dealer mangan tsumo + 1 honba + 1 carried-over kyoutaku stick + 3L declared
+    // riichi this round.
+    AddRoundRequest request = tsumo(1L, 2L, 8000);
+    request.setHonba(1);
+    request.setKyoutaku(1000); // 1 stick worth, expressed in yen
+    request.setRiichiPlayerIds(Arrays.asList(3L));
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, YONMA);
+    // dealer: -(4000 + 100) = -4100
+    // 3L: -(2000 + 100) - 1000 = -3100
+    // 4L: -(2000 + 100) = -2100
+    // winner: 8000 + 300 (honba) + 1000 (kyoutaku) + 1000 (this-round riichi pool) = 10300
+    assertEquals(10300, scores.get(1L));
+    assertEquals(-4100, scores.get(2L));
+    assertEquals(-3100, scores.get(3L));
+    assertEquals(-2100, scores.get(4L));
+    assertZeroSum(scores, 1000);
+  }
+
+  @Test
+  public void testSanmaNonDealerTsumoWithHonbaAndRiichi() {
+    AddRoundRequest request = tsumo(1L, 2L, 6000); // mangan non-dealer in sanma
+    request.setHonba(2);
+    request.setRiichiPlayerIds(Arrays.asList(3L));
+    Map<Long, Integer> scores = handler.calculateRoundScores(request, SANMA);
+    // dealer: -(4000 + 200) = -4200
+    // 3L: -(2000 + 200) - 1000 = -3200
+    // winner: 6000 + 400 (honba) + 1000 (this-round riichi) = 7400
+    assertEquals(7400, scores.get(1L));
+    assertEquals(-4200, scores.get(2L));
+    assertEquals(-3200, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 }

--- a/server/src/test/java/com/mahjong/omakase/service/handler/RiichiModeHandlerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/handler/RiichiModeHandlerTest.java
@@ -71,6 +71,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-1000, scores.get(2L));
     assertEquals(-1000, scores.get(3L));
     assertEquals(-1000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -81,6 +82,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-1300, scores.get(2L));
     assertEquals(-1300, scores.get(3L));
     assertEquals(-1300, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -92,6 +94,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-3900, scores.get(2L));
     assertEquals(-3900, scores.get(3L));
     assertEquals(-3900, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -101,6 +104,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-4000, scores.get(2L));
     assertEquals(-4000, scores.get(3L));
     assertEquals(-4000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -110,6 +114,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-6000, scores.get(2L));
     assertEquals(-6000, scores.get(3L));
     assertEquals(-6000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -119,6 +124,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-8000, scores.get(2L));
     assertEquals(-8000, scores.get(3L));
     assertEquals(-8000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -128,6 +134,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-12000, scores.get(2L));
     assertEquals(-12000, scores.get(3L));
     assertEquals(-12000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -137,6 +144,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-16000, scores.get(2L));
     assertEquals(-16000, scores.get(3L));
     assertEquals(-16000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   // ====================================================================
@@ -151,6 +159,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-500, scores.get(2L));
     assertEquals(-300, scores.get(3L));
     assertEquals(-300, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -161,6 +170,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-700, scores.get(2L));
     assertEquals(-400, scores.get(3L));
     assertEquals(-400, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -171,6 +181,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-1000, scores.get(2L));
     assertEquals(-500, scores.get(3L));
     assertEquals(-500, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -181,6 +192,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-1300, scores.get(2L));
     assertEquals(-700, scores.get(3L));
     assertEquals(-700, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -191,6 +203,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-2000, scores.get(2L));
     assertEquals(-1000, scores.get(3L));
     assertEquals(-1000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -201,6 +214,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-2600, scores.get(2L));
     assertEquals(-1300, scores.get(3L));
     assertEquals(-1300, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -211,6 +225,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-3900, scores.get(2L));
     assertEquals(-2000, scores.get(3L));
     assertEquals(-2000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -220,6 +235,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-4000, scores.get(2L));
     assertEquals(-2000, scores.get(3L));
     assertEquals(-2000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -229,6 +245,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-6000, scores.get(2L));
     assertEquals(-3000, scores.get(3L));
     assertEquals(-3000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -238,6 +255,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-8000, scores.get(2L));
     assertEquals(-4000, scores.get(3L));
     assertEquals(-4000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -247,6 +265,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-12000, scores.get(2L));
     assertEquals(-6000, scores.get(3L));
     assertEquals(-6000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -256,6 +275,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-16000, scores.get(2L));
     assertEquals(-8000, scores.get(3L));
     assertEquals(-8000, scores.get(4L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -268,6 +288,7 @@ public class RiichiModeHandlerTest {
     assertEquals(-700, scores.get(2L));
     assertEquals(-700, scores.get(3L));
     assertEquals(-1300, scores.get(4L)); // dealer
+    assertZeroSum(scores, 0);
   }
 
   // ====================================================================
@@ -281,6 +302,7 @@ public class RiichiModeHandlerTest {
     assertEquals(2600, scores.get(1L));
     assertEquals(-1300, scores.get(2L));
     assertEquals(-1300, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -289,6 +311,7 @@ public class RiichiModeHandlerTest {
     assertEquals(8000, scores.get(1L));
     assertEquals(-4000, scores.get(2L));
     assertEquals(-4000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -297,6 +320,7 @@ public class RiichiModeHandlerTest {
     assertEquals(12000, scores.get(1L));
     assertEquals(-6000, scores.get(2L));
     assertEquals(-6000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -305,6 +329,7 @@ public class RiichiModeHandlerTest {
     assertEquals(16000, scores.get(1L));
     assertEquals(-8000, scores.get(2L));
     assertEquals(-8000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -313,6 +338,7 @@ public class RiichiModeHandlerTest {
     assertEquals(32000, scores.get(1L));
     assertEquals(-16000, scores.get(2L));
     assertEquals(-16000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   // ====================================================================
@@ -326,6 +352,7 @@ public class RiichiModeHandlerTest {
     assertEquals(2000, scores.get(1L));
     assertEquals(-1300, scores.get(2L));
     assertEquals(-700, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -335,6 +362,7 @@ public class RiichiModeHandlerTest {
     assertEquals(2000, scores.get(1L));
     assertEquals(-700, scores.get(2L));
     assertEquals(-1300, scores.get(3L)); // dealer
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -344,6 +372,7 @@ public class RiichiModeHandlerTest {
     assertEquals(6000, scores.get(1L));
     assertEquals(-4000, scores.get(2L));
     assertEquals(-2000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -353,6 +382,7 @@ public class RiichiModeHandlerTest {
     assertEquals(9000, scores.get(1L));
     assertEquals(-6000, scores.get(2L));
     assertEquals(-3000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -362,6 +392,7 @@ public class RiichiModeHandlerTest {
     assertEquals(12000, scores.get(1L));
     assertEquals(-8000, scores.get(2L));
     assertEquals(-4000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   @Test
@@ -371,6 +402,7 @@ public class RiichiModeHandlerTest {
     assertEquals(24000, scores.get(1L));
     assertEquals(-16000, scores.get(2L));
     assertEquals(-8000, scores.get(3L));
+    assertZeroSum(scores, 0);
   }
 
   // ====================================================================


### PR DESCRIPTION
## Summary
- Enable `useJUnitPlatform()` so JUnit 5 tests in `RiichiModeHandlerTest` and `GuobiaoModeHandlerTest` actually run (they were silently skipped in CI before).
- Add 37 corner-case tests for direct-score tsumo distribution covering yonma/sanma, dealer/non-dealer winners, every standard fan/fu rounding shape (1han30fu through yakuman), honba, kyoutaku, and riichi-stick scenarios.
- Validates the dealer/non-dealer 2:1 split from #95/#96 and the 100-yen stick reconstruction from #97 against concrete payment shapes (e.g. 1100 = 500/300/300, 2700 = 1300/700/700, 7900 = 3900/2000/2000).

## Test plan
- [x] `./gradlew test` — 49 tests, 0 failures
- [x] `./gradlew spotlessJavaCheck`
- [x] `(cd ui && npx tsc --noEmit)`
- [x] `./gradlew compileJava`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for game scoring scenarios across multiple player configurations and score tiers, including handling of bonus payments and riichi stick distribution.

* **Chores**
  * Updated build configuration to ensure tests run on the latest testing platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmdtoycar/mahjong-omakase/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->