### PR TITLE
fix(guobiao): stop double-counting flower fan score in chombo check

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/service/handler/GuobiaoModeHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/service/handler/GuobiaoModeHandler.java
@@ -88,21 +88,13 @@ public class GuobiaoModeHandler implements GameModeHandler {
         int closeParen = part.indexOf(')');
         if (openParen != -1 && closeParen != -1 && closeParen > openParen + 1) {
           String content = part.substring(openParen + 1, closeParen);
-          if (content.contains("x")) {
-            String[] mult = content.split("x");
-            try {
-              int val = Integer.parseInt(mult[0].trim());
-              int count = Integer.parseInt(mult[1].trim());
-              flowerScore += val * count;
-            } catch (NumberFormatException e) {
-              // ignore
-            }
-          } else {
-            try {
-              flowerScore += Integer.parseInt(content.trim());
-            } catch (NumberFormatException e) {
-              // ignore
-            }
+          // Format: "花牌(N)" when count == 1, or "花牌(NxC)" when count > 1.
+          // N is the already-summed total score; C is the count and is informational only.
+          String totalPart = content.contains("x") ? content.split("x")[0] : content;
+          try {
+            flowerScore += Integer.parseInt(totalPart.trim());
+          } catch (NumberFormatException e) {
+            // ignore
           }
         }
       }

--- a/server/src/test/java/com/mahjong/omakase/service/handler/GuobiaoModeHandlerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/handler/GuobiaoModeHandlerTest.java
@@ -145,4 +145,55 @@ public class GuobiaoModeHandlerTest {
     assertEquals("Score is required", exception.getMessage());
     verifyNoInteractions(calculator);
   }
+
+  @Test
+  public void testValidWinWithFlowersUsingMultiCountFormat() {
+    // Regression: the UI emits "花牌(NxC)" where N is the already-summed total flower score and
+    // C is the flower count. Server must read N alone (not N*C), otherwise a legitimate 8-fan
+    // hand with multiple flowers gets falsely flagged as chombo.
+    AddRoundRequest request = new AddRoundRequest();
+    request.setRoundType("WIN");
+    request.setWinnerId(1L);
+    request.setDealInPlayerId(null);
+    request.setScore(10);
+    // 8 base fan + 2 flowers (huaCount=2) → flowers serialize as 花牌(2x2), total 10.
+    request.setFanDetails("平和(2), 断幺(2), 自摸(1), 双暗刻(2), 单钓将(1), 花牌(2x2)");
+
+    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L, 4L);
+
+    Map<Long, Integer> expectedScores = new HashMap<>();
+    expectedScores.put(1L, 54);
+    expectedScores.put(2L, -18);
+    expectedScores.put(3L, -18);
+    expectedScores.put(4L, -18);
+
+    when(calculator.calculate(eq(sessionPlayerIds), eq(1L), eq(null), anyMap()))
+        .thenReturn(expectedScores);
+
+    Map<Long, Integer> actualScores = handler.calculateRoundScores(request, sessionPlayerIds);
+    assertEquals(expectedScores, actualScores);
+  }
+
+  @Test
+  public void testChomboWithMultiCountFlowerFormat() {
+    // 6 base fan + 4 flowers (huaCount=4 → 花牌(4x4)). Base 6 < 8 ⇒ chombo.
+    // Pre-fix server computed flowerScore = 4*4 = 16 and scoreWithoutFlowers = 10 - 16 = -6
+    // (still chombo, but for the wrong reason). Post-fix: flowerScore = 4, scoreWithoutFlowers = 6.
+    AddRoundRequest request = new AddRoundRequest();
+    request.setRoundType("WIN");
+    request.setWinnerId(1L);
+    request.setDealInPlayerId(null);
+    request.setScore(10);
+    request.setFanDetails("平和(2), 断幺(2), 自摸(1), 单钓将(1), 花牌(4x4)");
+
+    List<Long> sessionPlayerIds = Arrays.asList(1L, 2L, 3L, 4L);
+
+    Map<Long, Integer> actualScores = handler.calculateRoundScores(request, sessionPlayerIds);
+
+    assertEquals(-45, actualScores.get(1L));
+    assertEquals(15, actualScores.get(2L));
+    assertEquals(15, actualScores.get(3L));
+    assertEquals(15, actualScores.get(4L));
+    verifyNoInteractions(calculator);
+  }
 }


### PR DESCRIPTION
## Summary
- The UI emits `花牌(NxC)` where `N` is the already-summed total flower score and `C` is the flower count (see `MahjongHand.tsx:137-138`). `GuobiaoModeHandler.parseFlowerScore` was treating `N` as per-unit and multiplying by `C`, over-counting flower contribution whenever `huaCount >= 2`.
- Result: a legitimate ≥8-base-fan win plus 2+ flowers was scored back as a chombo penalty (e.g. 8 base + 2 flowers = 10 total: server saw `flowerScore = 2*2 = 4`, `scoreWithoutFlowers = 6 < 8`, falsely triggering the chombo branch).
- Fix: read only the first number inside the parentheses; the count is informational. `花牌(N)` single-form path is unchanged.
- Add regression tests using the real UI format `花牌(NxC)`: one valid 8-base win with 2 flowers, one genuine 6-base chombo with 4 flowers.

## Test plan
- [x] `./gradlew test` — 51 tests, 0 failures (43 Riichi + 8 Guobiao)
- [x] `./gradlew spotlessJavaCheck`
- [x] `(cd ui && npx tsc --noEmit)`
- [x] `./gradlew compileJava`

🤖 Generated with [Claude Code](https://claude.com/claude-code)