### PR TITLE
feat(admin): add session deletion with cascading cleanup

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -75,7 +75,9 @@ public class AdminController {
   public List<SessionSummaryResponse> listSessions(
       @RequestHeader("X-Admin-Password") String password) {
     checkPassword(password);
-    return gameService.getAllSessionSummaries();
+    return gameService.getAllSessionSummaries().stream()
+        .filter(s -> "COMPLETED".equals(s.getStatus()))
+        .toList();
   }
 
   @DeleteMapping("/sessions/{id}")

--- a/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.mahjong.omakase.controller;
 
+import com.mahjong.omakase.dto.SessionSummaryResponse;
 import com.mahjong.omakase.model.AppSetting;
 import com.mahjong.omakase.model.Player;
 import com.mahjong.omakase.repository.AppSettingRepository;
@@ -68,6 +69,22 @@ public class AdminController {
     Player updated = gameService.updatePlayer(id, body.get("firstName"), body.get("lastName"));
     log.info("Admin updated player id={}", id);
     return updated;
+  }
+
+  @GetMapping("/sessions")
+  public List<SessionSummaryResponse> listSessions(
+      @RequestHeader("X-Admin-Password") String password) {
+    checkPassword(password);
+    return gameService.getAllSessionSummaries();
+  }
+
+  @DeleteMapping("/sessions/{id}")
+  public Map<String, String> deleteSession(
+      @PathVariable Long id, @RequestHeader("X-Admin-Password") String password) {
+    checkPassword(password);
+    gameService.deleteSession(id);
+    log.info("Admin deleted session id={}", id);
+    return Map.of("message", "Session deleted");
   }
 
   @GetMapping("/settings")

--- a/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -7,6 +7,7 @@ import com.mahjong.omakase.repository.AppSettingRepository;
 import com.mahjong.omakase.service.GameService;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -121,7 +122,7 @@ public class AdminController {
           }
           AppSetting setting =
               appSettingRepo
-                  .findById(java.util.Objects.requireNonNull(key))
+                  .findById(Objects.requireNonNull(key))
                   .orElse(new AppSetting(key, value));
           setting.setValue(value);
           appSettingRepo.save(setting);

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -62,4 +62,13 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
           "SELECT r FROM Round r JOIN FETCH r.gameSession s ORDER BY s.createdAt ASC, r.roundNumber ASC",
       countQuery = "SELECT count(r) FROM Round r")
   Page<Round> findAllOrderByTime(Pageable pageable);
+
+  @Query(
+      "SELECT r FROM Round r JOIN FETCH r.gameSession s"
+          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end"
+          + " ORDER BY s.createdAt ASC, r.roundNumber ASC")
+  List<Round> findByGameModeAndSessionDateRangeOrderByTime(
+      @Param("mode") GameMode mode,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -482,18 +482,12 @@ public class GameService {
   public void deleteSession(Long sessionId) {
     GameSession session =
         sessionRepo
-            .findByIdForUpdate(java.util.Objects.requireNonNull(sessionId))
+            .findById(java.util.Objects.requireNonNull(sessionId))
             .orElseThrow(() -> new NoSuchElementException("Session not found"));
-    if (session.getStatus() == SessionStatus.IN_PROGRESS) {
-      log.warn("Cannot delete in-progress session id={}", sessionId);
-      throw new IllegalStateException("Cannot delete an in-progress session; complete it first");
-    }
     GameMode mode = session.getGameMode();
     LocalDateTime sessionTime = session.getCreatedAt();
     sessionRepo.delete(session);
     log.info("Deleted session id={}", sessionId);
-    // A deleted session may have held first-of-season fan discoveries; re-derive scoped to
-    // the affected season + mode so unaffected history isn't re-scanned.
     rederiveDiscoveriesForSeason(mode, sessionTime);
   }
 

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -482,13 +482,43 @@ public class GameService {
   public void deleteSession(Long sessionId) {
     GameSession session =
         sessionRepo
-            .findById(java.util.Objects.requireNonNull(sessionId))
+            .findByIdForUpdate(java.util.Objects.requireNonNull(sessionId))
             .orElseThrow(() -> new NoSuchElementException("Session not found"));
+    if (session.getStatus() == SessionStatus.IN_PROGRESS) {
+      log.warn("Cannot delete in-progress session id={}", sessionId);
+      throw new IllegalStateException("Cannot delete an in-progress session; complete it first");
+    }
+    GameMode mode = session.getGameMode();
+    LocalDateTime sessionTime = session.getCreatedAt();
     sessionRepo.delete(session);
     log.info("Deleted session id={}", sessionId);
-    // A deleted session may have held first-of-season fan discoveries; re-derive from remaining
-    // rounds.
-    initializeDiscoveries();
+    // A deleted session may have held first-of-season fan discoveries; re-derive scoped to
+    // the affected season + mode so unaffected history isn't re-scanned.
+    rederiveDiscoveriesForSeason(mode, sessionTime);
+  }
+
+  private void rederiveDiscoveriesForSeason(GameMode mode, LocalDateTime sessionTime) {
+    if (mode != GameMode.GUOBIAO) return;
+    YearMonth ym = YearMonth.from(sessionTime);
+    LocalDateTime start = ym.atDay(1).atStartOfDay();
+    LocalDateTime end = ym.plusMonths(1).atDay(1).atStartOfDay();
+    String season = ym.toString();
+    int rederived = 0;
+    for (Round round : roundRepo.findByGameModeAndSessionDateRangeOrderByTime(mode, start, end)) {
+      if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
+      Player winner =
+          playerRepo.findById(java.util.Objects.requireNonNull(round.getWinnerId())).orElse(null);
+      if (winner == null || winner.isBot()) continue;
+      rederived +=
+          processFanDiscoveries(
+              round.getFanDetails(),
+              season,
+              winner,
+              round,
+              round.getWinHand(),
+              round.getGameSession().getCreatedAt());
+    }
+    log.info("Re-derived {} fan discoveries for season '{}' mode={}", rederived, season, mode);
   }
 
   public List<BestRoundResponse> getBestRounds(

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -84,7 +84,7 @@ public class GameService {
         if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
         if (round.getGameSession().getGameMode() != GameMode.GUOBIAO) continue;
         Player winner =
-            playerRepo.findById(java.util.Objects.requireNonNull(round.getWinnerId())).orElse(null);
+            playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
         if (winner == null || winner.isBot()) continue;
 
         String season = getSeasonString(round.getGameSession().getCreatedAt());
@@ -159,7 +159,7 @@ public class GameService {
   public Player updatePlayer(Long id, String firstName, String lastName) {
     Player player =
         playerRepo
-            .findById(java.util.Objects.requireNonNull(id))
+            .findById(Objects.requireNonNull(id))
             .orElseThrow(() -> new IllegalArgumentException("Player not found"));
     if (firstName != null && !firstName.isBlank()) {
       player.setFirstName(firstName.trim());
@@ -186,7 +186,7 @@ public class GameService {
 
     roundScoreRepo.nullifyPlayerScores(id);
     gameSessionPlayerRepo.deleteByPlayerId(id);
-    playerRepo.deleteById(java.util.Objects.requireNonNull(id));
+    playerRepo.deleteById(Objects.requireNonNull(id));
   }
 
   @org.springframework.transaction.annotation.Transactional(readOnly = true)
@@ -202,8 +202,7 @@ public class GameService {
 
   public GameSession createSession(CreateSessionRequest request) {
     Map<Long, Player> playerMap = new HashMap<>();
-    for (Player p :
-        playerRepo.findAllById(java.util.Objects.requireNonNull(request.getPlayerIds()))) {
+    for (Player p : playerRepo.findAllById(Objects.requireNonNull(request.getPlayerIds()))) {
       playerMap.put(p.getId(), p);
     }
     if (playerMap.size() != request.getPlayerIds().size()) {
@@ -238,7 +237,7 @@ public class GameService {
   public SessionDetailResponse getSessionDetail(Long sessionId) {
     GameSession session =
         sessionRepo
-            .findById(java.util.Objects.requireNonNull(sessionId))
+            .findById(Objects.requireNonNull(sessionId))
             .orElseThrow(() -> new NoSuchElementException("Session not found"));
 
     SessionDetailResponse resp = new SessionDetailResponse();
@@ -460,7 +459,7 @@ public class GameService {
             .orElseThrow(() -> new NoSuchElementException("Round not found"));
 
     session.getRounds().remove(round);
-    roundRepo.delete(java.util.Objects.requireNonNull(round));
+    roundRepo.delete(Objects.requireNonNull(round));
 
     int num = 1;
     for (Round r : session.getRounds()) {
@@ -482,7 +481,7 @@ public class GameService {
   public void deleteSession(Long sessionId) {
     GameSession session =
         sessionRepo
-            .findById(java.util.Objects.requireNonNull(sessionId))
+            .findById(Objects.requireNonNull(sessionId))
             .orElseThrow(() -> new NoSuchElementException("Session not found"));
     GameMode mode = session.getGameMode();
     LocalDateTime sessionTime = session.getCreatedAt();
@@ -500,8 +499,7 @@ public class GameService {
     int rederived = 0;
     for (Round round : roundRepo.findByGameModeAndSessionDateRangeOrderByTime(mode, start, end)) {
       if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
-      Player winner =
-          playerRepo.findById(java.util.Objects.requireNonNull(round.getWinnerId())).orElse(null);
+      Player winner = playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
       if (winner == null || winner.isBot()) continue;
       rederived +=
           processFanDiscoveries(
@@ -556,7 +554,7 @@ public class GameService {
               String winnerName =
                   round.getWinnerId() != null
                       ? playerRepo
-                          .findById(java.util.Objects.requireNonNull(round.getWinnerId()))
+                          .findById(Objects.requireNonNull(round.getWinnerId()))
                           .map(Player::getUserName)
                           .orElse("?")
                       : null;
@@ -753,7 +751,7 @@ public class GameService {
   public PlayerDetailResponse getPlayerDetail(Long playerId) {
     Player player =
         playerRepo
-            .findById(java.util.Objects.requireNonNull(playerId))
+            .findById(Objects.requireNonNull(playerId))
             .orElseThrow(() -> new NoSuchElementException("Player not found"));
 
     List<GameSession> sessions = sessionRepo.findByPlayersPlayerIdOrderByCreatedAtDesc(playerId);
@@ -831,7 +829,7 @@ public class GameService {
     for (Map.Entry<Long, Integer> entry : computedScores.entrySet()) {
       Player player =
           playerRepo
-              .findById(java.util.Objects.requireNonNull(entry.getKey()))
+              .findById(Objects.requireNonNull(entry.getKey()))
               .orElseThrow(() -> new NoSuchElementException("Player not found: " + entry.getKey()));
       RoundScore rs = new RoundScore();
       rs.setRound(round);

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -479,6 +479,18 @@ public class GameService {
     log.info("Completed session id={}", sessionId);
   }
 
+  public void deleteSession(Long sessionId) {
+    GameSession session =
+        sessionRepo
+            .findById(java.util.Objects.requireNonNull(sessionId))
+            .orElseThrow(() -> new NoSuchElementException("Session not found"));
+    sessionRepo.delete(session);
+    log.info("Deleted session id={}", sessionId);
+    // A deleted session may have held first-of-season fan discoveries; re-derive from remaining
+    // rounds.
+    initializeDiscoveries();
+  }
+
   public List<BestRoundResponse> getBestRounds(
       GameMode gameMode, LocalDateTime start, LocalDateTime end) {
     boolean hasMode = gameMode != null;

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Player } from '../types'
+import { Player, GameSession } from '../types'
 
 const API = '/api/admin'
 
@@ -8,6 +8,7 @@ export default function AdminPage() {
   const [authenticated, setAuthenticated] = useState(false)
   const [error, setError] = useState('')
   const [players, setPlayers] = useState<Player[]>([])
+  const [sessions, setSessions] = useState<GameSession[]>([])
   const [loading, setLoading] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
   const [editFirst, setEditFirst] = useState('')
@@ -15,6 +16,7 @@ export default function AdminPage() {
   const [bonus, setBonus] = useState('0')
   const [savedBonus, setSavedBonus] = useState('0')
   const [savingSettings, setSavingSettings] = useState(false)
+  const [deletingSessionId, setDeletingSessionId] = useState<number | null>(null)
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -46,6 +48,15 @@ export default function AdminPage() {
     setLoading(false)
   }
 
+  const loadSessions = async () => {
+    const res = await fetch(`${API}/sessions`, {
+      headers: { 'X-Admin-Password': password },
+    })
+    if (res.ok) {
+      setSessions(await res.json())
+    }
+  }
+
   const loadSettings = async () => {
     const res = await fetch(`${API}/settings`, {
       headers: { 'X-Admin-Password': password },
@@ -65,6 +76,7 @@ export default function AdminPage() {
   useEffect(() => {
     if (authenticated) {
       loadPlayers()
+      loadSessions()
       loadSettings()
     }
   }, [authenticated])
@@ -115,6 +127,27 @@ export default function AdminPage() {
       const data = await res.json().catch(() => ({ message: 'Delete failed' }))
       alert(data.message || 'Delete failed')
     }
+  }
+
+  const handleDeleteSession = async (id: number, name: string) => {
+    if (
+      !confirm(
+        `Delete session "${name}"? This cannot be undone. All rounds, scores, and fan discoveries from this session will be permanently removed.`
+      )
+    )
+      return
+    setDeletingSessionId(id)
+    const res = await fetch(`${API}/sessions/${id}`, {
+      method: 'DELETE',
+      headers: { 'X-Admin-Password': password },
+    })
+    if (res.ok) {
+      setSessions(sessions.filter((s) => s.id !== id))
+    } else {
+      const data = await res.json().catch(() => ({ message: 'Delete failed' }))
+      alert(data.message || 'Delete failed')
+    }
+    setDeletingSessionId(null)
   }
 
   const startEdit = (p: Player) => {
@@ -278,6 +311,50 @@ export default function AdminPage() {
                         </button>
                       </div>
                     )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="card">
+        <h2>Sessions ({sessions.length})</h2>
+        <p className="page-subtitle">
+          Deleting a session permanently removes all of its rounds, round scores, and fan discoveries (achievements).
+          This cannot be undone.
+        </p>
+        <div className="score-table">
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Mode</th>
+                <th>Status</th>
+                <th>Rounds</th>
+                <th>Created</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((s) => (
+                <tr key={s.id}>
+                  <td>{s.id}</td>
+                  <td>{s.name}</td>
+                  <td>{s.gameModeDisplayName}</td>
+                  <td>{s.status}</td>
+                  <td>{s.roundCount}</td>
+                  <td>{new Date(s.createdAt).toLocaleDateString()}</td>
+                  <td>
+                    <button
+                      className="btn btn-danger btn-small"
+                      onClick={() => handleDeleteSession(s.id, s.name)}
+                      disabled={deletingSessionId === s.id}
+                    >
+                      {deletingSessionId === s.id ? 'Deleting...' : 'Delete'}
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -320,10 +320,10 @@ export default function AdminPage() {
       </div>
 
       <div className="card">
-        <h2>Sessions ({sessions.length})</h2>
+        <h2>Completed Sessions ({sessions.length})</h2>
         <p className="page-subtitle">
           Deleting a session permanently removes all of its rounds, round scores, and fan discoveries (achievements).
-          This cannot be undone.
+          This cannot be undone. In-progress sessions are not shown.
         </p>
         <div className="score-table">
           <table>
@@ -332,7 +332,6 @@ export default function AdminPage() {
                 <th>ID</th>
                 <th>Name</th>
                 <th>Mode</th>
-                <th>Status</th>
                 <th>Rounds</th>
                 <th>Created</th>
                 <th></th>
@@ -344,7 +343,6 @@ export default function AdminPage() {
                   <td>{s.id}</td>
                   <td>{s.name}</td>
                   <td>{s.gameModeDisplayName}</td>
-                  <td>{s.status}</td>
                   <td>{s.roundCount}</td>
                   <td>{new Date(s.createdAt).toLocaleDateString()}</td>
                   <td>


### PR DESCRIPTION
## Summary
- New **Sessions** section in the admin page lists every session (ID, name, mode, status, round count, created date) with a per-row Delete button gated by a confirmation prompt
- New `DELETE /api/admin/sessions/{id}` endpoint (admin-protected) plus a `GET /api/admin/sessions` listing
- `GameService.deleteSession` relies on existing JPA cascades (`GameSession` → `Round` → `RoundScore` / `FanDiscovery`) to remove rounds, scores, and achievements; afterward it re-runs `initializeDiscoveries()` so first-of-season fan discoveries that lived in the deleted session are re-derived from remaining rounds

## Test plan
- [ ] Login to `/admin`, see the new Sessions section listing all sessions
- [ ] Click Delete on a session, confirm the prompt — session disappears from the list
- [ ] Verify the session no longer appears in the public sessions list and player stats / RP totals are recomputed without it
- [ ] Verify fan discoveries owned by the deleted session are gone and any fans that should have been discovered in surviving rounds are now attributed to those rounds
- [ ] Cancel the confirmation dialog — session is unchanged
- [ ] `./gradlew compileJava test spotlessApply` passes
- [ ] `(cd ui && npx tsc --noEmit)` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session management capabilities to the admin panel
  * Admins can now view all active game sessions in a table displaying key details (id, name, mode, status, rounds, and creation date)
  * Added ability to delete individual sessions with confirmation prompt

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmdtoycar/mahjong-omakase/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->