### PR TITLE
refactor(guobiao): remove redundant removeFan('无字') in hasFan('全中')

### DIFF
--- a/ui/src/logic/guobiao/fan.ts
+++ b/ui/src/logic/guobiao/fan.ts
@@ -1062,7 +1062,6 @@ export function scoreCombination(
   }
   if (hasFan('全中')) {
     removeFan('断幺')
-    removeFan('无字')
   }
   if (hasFan('全带五')) {
     removeFan('断幺')


### PR DESCRIPTION
This pull request removes the redundant '无字' exclusion from the '全中' block. As 'addFan('无字', 1)' already checks '!hasFan('全中')', it is impossible for '无字' to be present when '全中' is scored. Therefore, the explicit 'removeFan('无字')' inside 'hasFan('全中')' is dead/redundant code. This PR removes this redundant call to keep the logic clean and optimal.