### PR TITLE
feat(stats): 区分线上练习赛与线下正式比赛，并剥离积分/成就奖励系统

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -29,10 +29,11 @@ public class StatsController {
   public List<PlayerStatsResponse> getStats(
       @RequestParam(required = false) String gameMode,
       @RequestParam(required = false) Integer year,
-      @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Boolean isOnline) {
     GameMode mode = parseGameMode(gameMode);
     LocalDateTime[] range = parseDateRange(year, month);
-    return gameService.getPlayerStats(mode, range[0], range[1]);
+    return gameService.getPlayerStats(mode, range[0], range[1], isOnline);
   }
 
   @GetMapping("/seasons")

--- a/server/src/main/java/com/mahjong/omakase/dto/CreateSessionRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/CreateSessionRequest.java
@@ -16,6 +16,8 @@ public class CreateSessionRequest {
   @Size(min = 3, max = 4, message = "Game requires 3 or 4 players")
   private List<Long> playerIds;
 
+  private Boolean isOnline;
+
   public String getName() {
     return name;
   }
@@ -38,5 +40,13 @@ public class CreateSessionRequest {
 
   public void setPlayerIds(List<Long> playerIds) {
     this.playerIds = playerIds;
+  }
+
+  public Boolean getIsOnline() {
+    return isOnline;
+  }
+
+  public void setIsOnline(Boolean isOnline) {
+    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -21,6 +21,7 @@ public class SessionDetailResponse {
   private double[] umaDist;
   private Double participationBonus;
   private Map<Long, Double> playerBonuses = Collections.emptyMap();
+  private Boolean isOnline;
 
   public static class PlayerInfo {
     private Long id;
@@ -263,5 +264,13 @@ public class SessionDetailResponse {
 
   public void setPlayerBonuses(Map<Long, Double> playerBonuses) {
     this.playerBonuses = playerBonuses;
+  }
+
+  public Boolean getIsOnline() {
+    return isOnline;
+  }
+
+  public void setIsOnline(Boolean isOnline) {
+    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
@@ -17,6 +17,7 @@ public class SessionSummaryResponse {
   private Double participationBonus;
   private int roundCount;
   private List<PlayerPerformanceDTO> rankings;
+  private Boolean isOnline;
 
   public static SessionSummaryResponse from(GameSession session) {
     SessionSummaryResponse r = new SessionSummaryResponse();
@@ -29,6 +30,7 @@ public class SessionSummaryResponse {
     r.createdAt = session.getCreatedAt();
     r.participationBonus = session.getParticipationBonus();
     r.roundCount = session.getRounds() != null ? session.getRounds().size() : 0;
+    r.isOnline = session.getIsOnline();
 
     // Calculate rankings and RP
     r.rankings = calculateRankings(session);
@@ -116,5 +118,13 @@ public class SessionSummaryResponse {
 
   public List<PlayerPerformanceDTO> getRankings() {
     return rankings;
+  }
+
+  public Boolean getIsOnline() {
+    return isOnline;
+  }
+
+  public void setIsOnline(Boolean isOnline) {
+    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/model/GameSession.java
+++ b/server/src/main/java/com/mahjong/omakase/model/GameSession.java
@@ -31,6 +31,8 @@ public class GameSession {
 
   private Double participationBonus;
 
+  private Boolean isOnline = false;
+
   @JsonIgnore
   @OneToMany(mappedBy = "gameSession", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<GameSessionPlayer> players = new ArrayList<>();
@@ -110,5 +112,13 @@ public class GameSession {
 
   public void setParticipationBonus(Double participationBonus) {
     this.participationBonus = participationBonus;
+  }
+
+  public Boolean getIsOnline() {
+    return isOnline;
+  }
+
+  public void setIsOnline(Boolean isOnline) {
+    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -14,68 +14,72 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
   int countByGameSessionId(Long gameSessionId);
 
   @Query(
-      "SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL")
-  Integer findMaxFanCount();
+      "SELECT MAX(r.fanCount) FROM Round r WHERE :isOnline IS NULL OR r.gameSession.isOnline = :isOnline")
+  Integer findMaxFanCount(@Param("isOnline") Boolean isOnline);
 
   @Query(
-      "SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.gameMode = :mode AND (r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL)")
-  Integer findMaxFanCountByMode(@Param("mode") GameMode mode);
+      "SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.gameMode = :mode AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
+  Integer findMaxFanCountByMode(@Param("mode") GameMode mode, @Param("isOnline") Boolean isOnline);
 
   @Query(
-      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND (r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL)")
-  List<Round> findByFanCount(Integer fanCount);
+      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
+  List<Round> findByFanCount(@Param("fanCount") Integer fanCount, @Param("isOnline") Boolean isOnline);
 
   @Query(
-      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode AND (r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL)")
+      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
   List<Round> findByFanCountAndMode(
-      @Param("fanCount") Integer fanCount, @Param("mode") GameMode mode);
+      @Param("fanCount") Integer fanCount, @Param("mode") GameMode mode, @Param("isOnline") Boolean isOnline);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
-          + " WHERE s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
+          + " WHERE s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
   Integer findMaxFanCountByDateRange(
-      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end, @Param("isOnline") Boolean isOnline);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
-          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
+          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
   Integer findMaxFanCountByModeAndDateRange(
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end);
+      @Param("end") LocalDateTime end,
+      @Param("isOnline") Boolean isOnline);
 
   @Query(
       "SELECT r FROM Round r JOIN r.gameSession s"
-          + " WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
+          + " WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
   List<Round> findByFanCountAndDateRange(
       @Param("fanCount") Integer fanCount,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end);
+      @Param("end") LocalDateTime end,
+      @Param("isOnline") Boolean isOnline);
 
   @Query(
       "SELECT r FROM Round r JOIN r.gameSession s"
           + " WHERE r.fanCount = :fanCount AND s.gameMode = :mode"
-          + " AND s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
+          + " AND s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
   List<Round> findByFanCountAndModeAndDateRange(
       @Param("fanCount") Integer fanCount,
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end);
+      @Param("end") LocalDateTime end,
+      @Param("isOnline") Boolean isOnline);
 
   @Query(
       value =
-          "SELECT r FROM Round r JOIN FETCH r.gameSession s WHERE s.isOnline = false OR s.isOnline IS NULL ORDER BY s.createdAt ASC, r.roundNumber ASC",
+          "SELECT r FROM Round r JOIN FETCH r.gameSession s WHERE (:isOnline IS NULL OR s.isOnline = :isOnline) ORDER BY s.createdAt ASC, r.roundNumber ASC",
       countQuery =
-          "SELECT count(r) FROM Round r WHERE r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL")
-  Page<Round> findAllOrderByTime(Pageable pageable);
+          "SELECT count(r) FROM Round r JOIN r.gameSession s WHERE (:isOnline IS NULL OR s.isOnline = :isOnline)")
+  Page<Round> findAllOrderByTime(@Param("isOnline") Boolean isOnline, Pageable pageable);
 
   @Query(
       "SELECT r FROM Round r JOIN FETCH r.gameSession s"
           + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end"
-          + " AND (s.isOnline = false OR s.isOnline IS NULL)"
+          + " AND (:isOnline IS NULL OR s.isOnline = :isOnline)"
           + " ORDER BY s.createdAt ASC, r.roundNumber ASC")
   List<Round> findByGameModeAndSessionDateRangeOrderByTime(
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end);
+      @Param("end") LocalDateTime end,
+      @Param("isOnline") Boolean isOnline);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -13,27 +13,32 @@ import org.springframework.data.repository.query.Param;
 public interface RoundRepository extends JpaRepository<Round, Long> {
   int countByGameSessionId(Long gameSessionId);
 
-  @Query("SELECT MAX(r.fanCount) FROM Round r")
+  @Query(
+      "SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL")
   Integer findMaxFanCount();
 
-  @Query("SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.gameMode = :mode")
+  @Query(
+      "SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.gameMode = :mode AND (r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL)")
   Integer findMaxFanCountByMode(@Param("mode") GameMode mode);
 
+  @Query(
+      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND (r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL)")
   List<Round> findByFanCount(Integer fanCount);
 
-  @Query("SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode")
+  @Query(
+      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode AND (r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL)")
   List<Round> findByFanCountAndMode(
       @Param("fanCount") Integer fanCount, @Param("mode") GameMode mode);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
-          + " WHERE s.createdAt >= :start AND s.createdAt < :end")
+          + " WHERE s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
   Integer findMaxFanCountByDateRange(
       @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
-          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end")
+          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
   Integer findMaxFanCountByModeAndDateRange(
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
@@ -41,7 +46,7 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
 
   @Query(
       "SELECT r FROM Round r JOIN r.gameSession s"
-          + " WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end")
+          + " WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
   List<Round> findByFanCountAndDateRange(
       @Param("fanCount") Integer fanCount,
       @Param("start") LocalDateTime start,
@@ -50,7 +55,7 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
   @Query(
       "SELECT r FROM Round r JOIN r.gameSession s"
           + " WHERE r.fanCount = :fanCount AND s.gameMode = :mode"
-          + " AND s.createdAt >= :start AND s.createdAt < :end")
+          + " AND s.createdAt >= :start AND s.createdAt < :end AND (s.isOnline = false OR s.isOnline IS NULL)")
   List<Round> findByFanCountAndModeAndDateRange(
       @Param("fanCount") Integer fanCount,
       @Param("mode") GameMode mode,
@@ -59,13 +64,15 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
 
   @Query(
       value =
-          "SELECT r FROM Round r JOIN FETCH r.gameSession s ORDER BY s.createdAt ASC, r.roundNumber ASC",
-      countQuery = "SELECT count(r) FROM Round r")
+          "SELECT r FROM Round r JOIN FETCH r.gameSession s WHERE s.isOnline = false OR s.isOnline IS NULL ORDER BY s.createdAt ASC, r.roundNumber ASC",
+      countQuery =
+          "SELECT count(r) FROM Round r WHERE r.gameSession.isOnline = false OR r.gameSession.isOnline IS NULL")
   Page<Round> findAllOrderByTime(Pageable pageable);
 
   @Query(
       "SELECT r FROM Round r JOIN FETCH r.gameSession s"
           + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end"
+          + " AND (s.isOnline = false OR s.isOnline IS NULL)"
           + " ORDER BY s.createdAt ASC, r.roundNumber ASC")
   List<Round> findByGameModeAndSessionDateRangeOrderByTime(
       @Param("mode") GameMode mode,

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -23,18 +23,23 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
 
   @Query(
       "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
-  List<Round> findByFanCount(@Param("fanCount") Integer fanCount, @Param("isOnline") Boolean isOnline);
+  List<Round> findByFanCount(
+      @Param("fanCount") Integer fanCount, @Param("isOnline") Boolean isOnline);
 
   @Query(
       "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
   List<Round> findByFanCountAndMode(
-      @Param("fanCount") Integer fanCount, @Param("mode") GameMode mode, @Param("isOnline") Boolean isOnline);
+      @Param("fanCount") Integer fanCount,
+      @Param("mode") GameMode mode,
+      @Param("isOnline") Boolean isOnline);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
           + " WHERE s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
   Integer findMaxFanCountByDateRange(
-      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end, @Param("isOnline") Boolean isOnline);
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end,
+      @Param("isOnline") Boolean isOnline);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -75,7 +75,7 @@ public class GameService {
 
     while (hasMore) {
       Pageable pageable = PageRequest.of(page, size);
-      Page<Round> roundPage = roundRepo.findAllOrderByTime(pageable);
+      Page<Round> roundPage = roundRepo.findAllOrderByTime(false, pageable);
       List<Round> rounds = roundPage.getContent();
 
       if (rounds.isEmpty()) {
@@ -86,6 +86,7 @@ public class GameService {
       for (Round round : rounds) {
         if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
         if (round.getGameSession().getGameMode() != GameMode.GUOBIAO) continue;
+        if (Boolean.TRUE.equals(round.getGameSession().getIsOnline())) continue;
         Player winner =
             playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
         if (winner == null || winner.isBot()) continue;
@@ -356,6 +357,9 @@ public class GameService {
    */
   private Map<Long, Double> computeSessionPlayerBonuses(GameSession session) {
     Map<Long, Double> bonuses = new HashMap<>();
+    if (Boolean.TRUE.equals(session.getIsOnline())) {
+      return bonuses;
+    }
 
     List<Object[]> currentSessionScores = roundScoreRepo.getTotalScoresBySession(session.getId());
     if (currentSessionScores.isEmpty()) {
@@ -368,6 +372,7 @@ public class GameService {
         sessionRepo.findAll().stream()
             .filter(s -> s.getStatus() == SessionStatus.COMPLETED)
             .filter(s -> s.getGameMode() == session.getGameMode())
+            .filter(s -> !Boolean.TRUE.equals(s.getIsOnline()))
             .filter(s -> getSeasonStringFromUtc(s.getCreatedAt()).equals(season))
             .filter(s -> !s.getCreatedAt().isAfter(session.getCreatedAt()))
             .sorted(Comparator.comparing(GameSession::getCreatedAt))
@@ -522,8 +527,9 @@ public class GameService {
     String season = ym.toString();
     int rederived = 0;
     for (Round round :
-        roundRepo.findByGameModeAndSessionDateRangeOrderByTime(mode, startUtc, endUtc)) {
+        roundRepo.findByGameModeAndSessionDateRangeOrderByTime(mode, startUtc, endUtc, false)) {
       if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
+      if (Boolean.TRUE.equals(round.getGameSession().getIsOnline())) continue;
       Player winner = playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
       if (winner == null || winner.isBot()) continue;
       rederived +=
@@ -557,26 +563,26 @@ public class GameService {
 
     Integer maxFan;
     if (hasMode && hasDate) {
-      maxFan = roundRepo.findMaxFanCountByModeAndDateRange(gameMode, startUtc, endUtc);
+      maxFan = roundRepo.findMaxFanCountByModeAndDateRange(gameMode, startUtc, endUtc, false);
     } else if (hasMode) {
-      maxFan = roundRepo.findMaxFanCountByMode(gameMode);
+      maxFan = roundRepo.findMaxFanCountByMode(gameMode, false);
     } else if (hasDate) {
-      maxFan = roundRepo.findMaxFanCountByDateRange(startUtc, endUtc);
+      maxFan = roundRepo.findMaxFanCountByDateRange(startUtc, endUtc, false);
     } else {
-      maxFan = roundRepo.findMaxFanCount();
+      maxFan = roundRepo.findMaxFanCount(false);
     }
 
     if (maxFan == null || maxFan == 0) return Collections.emptyList();
 
     List<Round> bestRounds;
     if (hasMode && hasDate) {
-      bestRounds = roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, startUtc, endUtc);
+      bestRounds = roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, startUtc, endUtc, false);
     } else if (hasMode) {
-      bestRounds = roundRepo.findByFanCountAndMode(maxFan, gameMode);
+      bestRounds = roundRepo.findByFanCountAndMode(maxFan, gameMode, false);
     } else if (hasDate) {
-      bestRounds = roundRepo.findByFanCountAndDateRange(maxFan, startUtc, endUtc);
+      bestRounds = roundRepo.findByFanCountAndDateRange(maxFan, startUtc, endUtc, false);
     } else {
-      bestRounds = roundRepo.findByFanCount(maxFan);
+      bestRounds = roundRepo.findByFanCount(maxFan, false);
     }
 
     return bestRounds.stream()

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -576,7 +576,8 @@ public class GameService {
 
     List<Round> bestRounds;
     if (hasMode && hasDate) {
-      bestRounds = roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, startUtc, endUtc, false);
+      bestRounds =
+          roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, startUtc, endUtc, false);
     } else if (hasMode) {
       bestRounds = roundRepo.findByFanCountAndMode(maxFan, gameMode, false);
     } else if (hasDate) {

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -233,6 +233,7 @@ public class GameService {
     session.setGameMode(GameMode.valueOf(request.getGameMode()));
     session.setPlayerCount(request.getPlayerIds().size());
     session.setParticipationBonus(this.participationBonus);
+    session.setIsOnline(request.getIsOnline() != null ? request.getIsOnline() : false);
     session = sessionRepo.save(session);
 
     int seat = 1;
@@ -267,6 +268,7 @@ public class GameService {
     resp.setPlayerCount(session.getPlayerCount());
     resp.setStatus(session.getStatus().name());
     resp.setCreatedAt(session.getCreatedAt());
+    resp.setIsOnline(session.getIsOnline());
 
     resp.setPlayers(
         session.getPlayers().stream()
@@ -647,48 +649,27 @@ public class GameService {
    *     getSeasonStringFromUtc.
    */
   public List<PlayerStatsResponse> getPlayerStats(
-      GameMode gameMode, LocalDateTime start, LocalDateTime end) {
+      GameMode gameMode, LocalDateTime start, LocalDateTime end, Boolean isOnline) {
     List<Player> players = playerRepo.findAll();
     boolean hasDateRange = start != null && end != null;
     LocalDateTime startUtc = toUtcTime(start);
     LocalDateTime endUtc = toUtcTime(end);
 
     Map<Long, Integer> totalScores = new HashMap<>();
-    List<Object[]> scoreRows;
-    if (gameMode != null && hasDateRange) {
-      scoreRows = roundScoreRepo.getTotalScoresByGameModeAndDateRange(gameMode, startUtc, endUtc);
-    } else if (gameMode != null) {
-      scoreRows = roundScoreRepo.getTotalScoresByGameMode(gameMode);
-    } else {
-      scoreRows = roundScoreRepo.getTotalScoresAllTime();
-    }
-    for (Object[] row : scoreRows) {
-      if (row[0] != null) totalScores.put((Long) row[0], ((Number) row[1]).intValue());
-    }
-
     Map<Long, Integer> gamesPlayed = new HashMap<>();
-    List<Object[]> gamesRows;
-    if (gameMode != null && hasDateRange) {
-      gamesRows =
-          roundScoreRepo.getGamesPlayedPerPlayerByGameModeAndDateRange(gameMode, startUtc, endUtc);
-    } else if (gameMode != null) {
-      gamesRows = roundScoreRepo.getGamesPlayedPerPlayerByGameMode(gameMode);
-    } else {
-      gamesRows = roundScoreRepo.getGamesPlayedPerPlayer();
-    }
-    for (Object[] row : gamesRows) {
-      if (row[0] != null) gamesPlayed.put((Long) row[0], ((Number) row[1]).intValue());
-    }
-
     Map<Long, Integer> wins = new HashMap<>();
     Map<Long, Double> totalRP = new HashMap<>();
     Map<Long, Double> tieredBonusPerPlayer = new HashMap<>();
     Map<Long, Double> adminBonusPerPlayer = new HashMap<>();
     Map<Long, Double> fanBonusPerPlayer = new HashMap<>();
+
+    boolean targetOnline = Boolean.TRUE.equals(isOnline);
+
     List<GameSession> completedSessions =
         sessionRepo.findAll().stream()
             .filter(s -> s.getStatus() == SessionStatus.COMPLETED)
             .filter(s -> gameMode == null || s.getGameMode() == gameMode)
+            .filter(s -> targetOnline == Boolean.TRUE.equals(s.getIsOnline()))
             .filter(
                 s ->
                     !hasDateRange
@@ -701,8 +682,8 @@ public class GameService {
     // Keyed separately by mode so each game mode has its own 20-game tier per season.
     Map<String, Map<Long, Integer>> gameIndexBySeasonModePlayer = new HashMap<>();
 
-    // Add Fan Discovery Bonuses (GUOBIAO only)
-    if (gameMode == null || gameMode == GameMode.GUOBIAO) {
+    // Add Fan Discovery Bonuses (GUOBIAO only, offline only)
+    if (!targetOnline && (gameMode == null || gameMode == GameMode.GUOBIAO)) {
       if (hasDateRange) {
         // Callers supply start in Pacific timezone; convert to UTC to consistently derive season
         String season = getSeasonStringFromUtc(startUtc);
@@ -730,19 +711,30 @@ public class GameService {
         String seasonModeKey = season + ":" + session.getGameMode().name();
         Map<Long, Integer> seasonCounts =
             gameIndexBySeasonModePlayer.computeIfAbsent(seasonModeKey, k -> new HashMap<>());
+
+        boolean isSessionOnline = Boolean.TRUE.equals(session.getIsOnline());
         double adminBonus =
-            session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0;
+            (!isSessionOnline && session.getParticipationBonus() != null)
+                ? session.getParticipationBonus()
+                : 0.0;
+
         for (Object[] row : sessionScores) {
           if (row[0] != null) {
             Long playerId = (Long) row[0];
+            int score = ((Number) row[1]).intValue();
+
+            // Accumulate gamesPlayed and totalScores dynamically for accurate filter
+            gamesPlayed.merge(playerId, 1, Integer::sum);
+            totalScores.merge(playerId, score, Integer::sum);
+
             int gameIndex = seasonCounts.merge(playerId, 1, Integer::sum);
-            double tieredBonus;
-            if (gameIndex <= 10) {
-              tieredBonus = 10.0;
-            } else if (gameIndex <= 20) {
-              tieredBonus = 5.0;
-            } else {
-              tieredBonus = 0.0;
+            double tieredBonus = 0.0;
+            if (!isSessionOnline) {
+              if (gameIndex <= 10) {
+                tieredBonus = 10.0;
+              } else if (gameIndex <= 20) {
+                tieredBonus = 5.0;
+              }
             }
             tieredBonusPerPlayer.merge(playerId, tieredBonus, (a, b) -> a + b);
             adminBonusPerPlayer.merge(playerId, adminBonus, (a, b) -> a + b);
@@ -894,11 +886,12 @@ public class GameService {
       roundScoreRepo.save(rs);
     }
 
-    // Process Fan Discoveries (GUOBIAO only, skip BOT winners, skip chombo)
+    // Process Fan Discoveries (GUOBIAO only, skip BOT winners, skip chombo, skip online sessions)
     if (winnerId != null
         && fanDetails != null
         && !fanDetails.isBlank()
-        && session.getGameMode() == GameMode.GUOBIAO) {
+        && session.getGameMode() == GameMode.GUOBIAO
+        && !Boolean.TRUE.equals(session.getIsOnline())) {
       Integer winnerScoreChange = computedScores.get(winnerId);
       if (winnerScoreChange != null && winnerScoreChange > 0) {
         Player winner = playerRepo.findById(winnerId).orElse(null);

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -86,11 +86,16 @@ export async function fetchSessions(signal?: AbortSignal): Promise<GameSession[]
   return cachedFetch(`${API}/sessions`, signal)
 }
 
-export async function createSession(name: string, gameMode: string, playerIds: number[]): Promise<GameSession> {
+export async function createSession(
+  name: string,
+  gameMode: string,
+  playerIds: number[],
+  isOnline?: boolean
+): Promise<GameSession> {
   const res = await fetch(`${API}/sessions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, gameMode, playerIds }),
+    body: JSON.stringify({ name, gameMode, playerIds, isOnline }),
   })
   const data = await handleResponse<GameSession>(res)
   invalidateCache()
@@ -131,6 +136,7 @@ export async function fetchStats(
   gameMode?: string,
   year?: number,
   month?: number,
+  isOnline?: boolean,
   signal?: AbortSignal
 ): Promise<PlayerStats[]> {
   const params = new URLSearchParams()
@@ -138,6 +144,9 @@ export async function fetchStats(
   if (year != null && month != null) {
     params.set('year', String(year))
     params.set('month', String(month))
+  }
+  if (isOnline != null) {
+    params.set('isOnline', String(isOnline))
   }
   const qs = params.toString()
   return cachedFetch(`${API}/stats${qs ? `?${qs}` : ''}`, signal)

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -17,14 +17,28 @@ interface Props {
   roundLabel: string
   isActive: boolean
   players: PlayerEntry[]
+  isOnline?: boolean
 }
 
-export const GameCard: React.FC<Props> = ({ id, gameModeDisplayName, createdAt, roundLabel, isActive, players }) => {
+export const GameCard: React.FC<Props> = ({
+  id,
+  gameModeDisplayName,
+  createdAt,
+  roundLabel,
+  isActive,
+  players,
+  isOnline,
+}) => {
   return (
     <Link to={`/session/${id}`} className="game-card">
       <div className="session-card-header">
         <div className="session-card-mode">
           <span className="mode-text">{gameModeDisplayName}</span>
+          {isOnline && (
+            <span className="badge badge-sm" style={{ backgroundColor: 'var(--accent)', marginLeft: 8, color: '#fff' }}>
+              线上
+            </span>
+          )}
         </div>
         <div className="session-card-meta">
           <span className="session-card-date">

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -115,6 +115,7 @@ export default function DashboardPage() {
               createdAt={s.createdAt}
               roundLabel={`${s.roundCount}局 已结束`}
               isActive={false}
+              isOnline={s.isOnline}
               players={
                 s.rankings
                   ? s.rankings.map((p, idx) => ({

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -35,7 +35,7 @@ export default function HomePage() {
           GAME_MODES.map(async (mode) => {
             try {
               const [stats, bestRounds] = await Promise.all([
-                fetchStats(mode.key, currentSeason.year, currentSeason.month, controller.signal),
+                fetchStats(mode.key, currentSeason.year, currentSeason.month, false, controller.signal),
                 fetchBestRounds(mode.key, currentSeason.year, currentSeason.month, controller.signal),
               ])
 
@@ -112,6 +112,7 @@ export default function HomePage() {
                   createdAt={s.createdAt}
                   roundLabel={`${state.displayName} 进行中`}
                   isActive={true}
+                  isOnline={s.isOnline}
                   players={sortedPlayers.map((p) => {
                     const score = s.totalScores[p.id] || 0
                     const rank = sortedScores.indexOf(score) + 1

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -18,6 +18,7 @@ export default function NewSessionPage() {
   const [error, setError] = useState('')
   const [creating, setCreating] = useState(false)
   const [loaded, setLoaded] = useState(false)
+  const [isOnline, setIsOnline] = useState(false)
 
   useEffect(() => {
     fetchPlayers()
@@ -62,7 +63,7 @@ export default function NewSessionPage() {
         2,
         '0'
       )}`
-      const session = await createSession(defaultName, gameMode, selectedIds)
+      const session = await createSession(defaultName, gameMode, selectedIds, isOnline)
       navigate(`/session/${session.id}`)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : MSG.ERROR)
@@ -89,6 +90,21 @@ export default function NewSessionPage() {
               {m.label}
             </button>
           ))}
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label>对局属性</label>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 8 }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontWeight: 'normal' }}>
+            <input
+              type="checkbox"
+              checked={isOnline}
+              onChange={(e) => setIsOnline(e.target.checked)}
+              style={{ width: 18, height: 18, cursor: 'pointer' }}
+            />
+            <span>线上练习赛</span>
+          </label>
         </div>
       </div>
 

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -306,7 +306,7 @@ export default function StatsPage() {
             </div>
           )}
 
-          {seasonKey !== 'all' && (
+          {!isOnline && seasonKey !== 'all' && (
             <div className="card best-hand-card">
               <div className="best-hand-header">
                 <span className="best-hand-crown">🌟</span>
@@ -340,7 +340,7 @@ export default function StatsPage() {
             </div>
           )}
 
-          {(bestRounds.length > 0 || !!bestRoundsError) && (
+          {!isOnline && (bestRounds.length > 0 || !!bestRoundsError) && (
             <div className="card best-hand-card">
               <div className="best-hand-header">
                 <span className="best-hand-crown">👑</span>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -38,8 +38,9 @@ export default function StatsPage() {
 
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.month}`)
+  const [isOnline, setIsOnline] = useState<boolean>(false)
 
-  const loadStats = (mode: GameModeKey, sKey: string) => {
+  const loadStats = (mode: GameModeKey, sKey: string, online: boolean) => {
     setError('')
     setLoading(true)
     let year: number | undefined
@@ -49,7 +50,7 @@ export default function StatsPage() {
       year = y
       month = m
     }
-    fetchStats(mode, year, month)
+    fetchStats(mode, year, month, online)
       .then((s) => {
         setStats(s.sort((a, b) => b.totalRP - a.totalRP || b.totalScore - a.totalScore))
         setLoading(false)
@@ -98,11 +99,11 @@ export default function StatsPage() {
 
   useEffect(() => {
     if (tab === 'games') {
-      loadStats(gameMode, seasonKey)
+      loadStats(gameMode, seasonKey, isOnline)
     } else {
       loadPlayers()
     }
-  }, [gameMode, seasonKey, tab])
+  }, [gameMode, seasonKey, tab, isOnline])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -209,6 +210,20 @@ export default function StatsPage() {
                     {m.label}
                   </option>
                 ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="flex-between">
+              <h2>对局类型</h2>
+              <select
+                value={isOnline ? 'online' : 'offline'}
+                onChange={(e) => setIsOnline(e.target.value === 'online')}
+                className="select-inline"
+              >
+                <option value="offline">线下正式赛</option>
+                <option value="online">线上练习赛</option>
               </select>
             </div>
           </div>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -39,6 +39,7 @@ export interface GameSession {
   createdAt: string
   roundCount: number
   rankings?: PlayerPerformance[]
+  isOnline?: boolean
 }
 
 export interface PlayerPerformance {
@@ -86,6 +87,7 @@ export interface SessionDetail {
   rpOrigin: number
   umaDist: number[]
   playerBonuses?: Record<number, number>
+  isOnline?: boolean
 }
 
 export interface AddRoundData {


### PR DESCRIPTION
### 背景与目的 (Background & Motivation)
当前联赛系统中，线下正式比赛与线上的练习赛对局是混同在一起计算积分与排行的。为了满足联赛日常运营需求并提高参与度，本次开发实现了**线上练习赛与线下正式比赛的全面分流与隔离**：
- **首页排行榜与殿堂**：默认仅计算并展示“线下正式比赛”的数据。
- **成就与参与奖**：线上练习赛剥离所有的“番种收集成就”及“参与奖（管理员参与奖与阶梯场次奖）”，仅在计算对局后象征性累计练习赛积分并参与练习赛排名；线下对局所有原有奖励逻辑保持不变。
- **统计分析中心**：在“统计”页新增了“对局类型”的可选下拉过滤项，供联赛成员自由、可选地切换查阅“线上练习赛名次”。

### 具体修改 (Detailed Changes)

#### 1. 数据库模型与传输实体 (Models & DTOs)
- **实体层**: 在 [`GameSession.java`](file:///c:/Users/admin/repo/mahjong-omakase/server/src/main/java/com/mahjong/omakase/model/GameSession.java) 实体中新增了 `Boolean isOnline` 字段，默认值为 `false`，允许为 `null` 以防止任何数据库迁移或老数据结构崩溃的问题。
- **DTO传输**: 
  - 修改 [`CreateSessionRequest.java`](file:///c:/Users/admin/repo/mahjong-omakase/server/src/main/java/com/mahjong/omakase/dto/CreateSessionRequest.java) 接收 `isOnline` 布尔输入。
  - 修改 [`SessionSummaryResponse.java`](file:///c:/Users/admin/repo/mahjong-omakase/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java) 和 [`SessionDetailResponse.java`](file:///c:/Users/admin/repo/mahjong-omakase/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java) 暴露 `isOnline` 的属性回传。
  - 更新前端 TypeScript 接口声明 [`ui/src/types/index.ts`](file:///c:/Users/admin/repo/mahjong-omakase/ui/src/types/index.ts)。

#### 2. 后端排行榜、积分与奖励逻辑重构 (Backend Core Logic)
- **排行榜分流 (`getPlayerStats`)**:
  - `StatsController` 与 `GameService` 接口签名增加了可选参数 `isOnline`，默认过滤线下正式赛。
  - 重构了累加计算，将玩家的对局总场次 (`gamesPlayed`) 和总得点 (`totalScores`) 改为在 `completedSessions` 的遍历逻辑中实时归纳，完全消除了此前直接调用不含时区和性质隔离的 JPA 原生聚合查询所带来的混同计算隐患。
  - **奖励剥离限制**：当对局被认定为线上练习赛（`isOnline == true`）时，对局在结算时直接跳过 `tieredBonus` (场次阶梯奖) 与 `adminBonus` (管理员分成)，且不予增加 `fanBonus`，仅计算象征性的排位基本分（`baseRP`）。
- **成就剥离**: 拦截了 `addRound` 阶段对线上对局进行番种收集成就 (`processFanDiscoveries`) 的操作，彻底屏蔽了练习赛下的番种发现入库。
- **高分屏蔽**: 对 [`RoundRepository.java`](file:///c:/Users/admin/repo/mahjong-omakase/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java) 中所有用于寻找全服最高番、历史最佳手牌的 JPQL 查询增加了 `AND (s.isOnline = false OR s.isOnline IS NULL)` 的过滤，从底层保证线上练习赛的逆天高番手牌不会沾染竞技榜单。

#### 3. 前端界面完美更新 (Frontend UI)
- **新建游戏 (`NewSessionPage.tsx`)**: 在游戏模式下方新增了醒目的“线上练习赛”属性勾选框。
- **对局卡片 (`GameCard.tsx`)**: 列表卡片重构，如果对局被设置为线上练习赛，将在其名称右侧实时渲染带有专属质感的“线上”微章。
- **历史记录看板 (`DashboardPage.tsx`) & 首页 (`HomePage.tsx`)**: 面板卡片支持回显线上对局。
- **统计页面 (`StatsPage.tsx`)**: 新增了“对局类型”卡片，提供“线下正式赛”与“线上练习赛”的极速下拉切换，完美呈现实时排行与数据统计。

### 自动化验证与测试 (Verification & Tests)
- **Spotless 排版约束**: 运行 `.\gradlew.bat spotlessApply` 完美格式化所有修改的代码文件。
- **全量测试与 Vite 静态资源构建**: 运行 `.\gradlew.bat compileJava test npmBuild` 保证全量 JUnit 单元测试和生产打包，**100% 成功 (BUILD SUCCESSFUL)**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Sessions can now be designated as online practice matches or offline formal games
* Game cards display an "online" indicator for online sessions
* Added online/offline filter on the stats page to view statistics by session type
* Session creation now includes an option to mark games as online practice matches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->