### PR TITLE
fix: 统一前端所有时间与日期显示为洛杉矶太平洋时间 (America/Los_Angeles)

### DIFF
--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -43,6 +43,7 @@ export const GameCard: React.FC<Props> = ({
         <div className="session-card-meta">
           <span className="session-card-date">
             {new Date(createdAt).toLocaleString([], {
+              timeZone: 'America/Los_Angeles',
               month: '2-digit',
               day: '2-digit',
               hour: '2-digit',

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -290,7 +290,7 @@ export default function AdminPage() {
                       </>
                     )}
                   </td>
-                  <td>{new Date(p.createdAt).toLocaleDateString()}</td>
+                  <td>{new Date(p.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
                   <td>
                     {editingId === p.id ? (
                       <div style={{ display: 'flex', gap: 4 }}>
@@ -344,7 +344,7 @@ export default function AdminPage() {
                   <td>{s.name}</td>
                   <td>{s.gameModeDisplayName}</td>
                   <td>{s.roundCount}</td>
-                  <td>{new Date(s.createdAt).toLocaleDateString()}</td>
+                  <td>{new Date(s.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
                   <td>
                     <button
                       className="btn btn-danger btn-small"

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -59,7 +59,15 @@ export default function DashboardPage() {
     .filter((s) => {
       if (seasonKey === 'all') return true
       const d = new Date(s.createdAt)
-      const key = `${d.getFullYear()}-${d.getMonth() + 1}`
+      const formatter = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/Los_Angeles',
+        year: 'numeric',
+        month: 'numeric',
+      })
+      const parts = formatter.formatToParts(d)
+      const year = parts.find((p) => p.type === 'year')?.value
+      const month = parts.find((p) => p.type === 'month')?.value
+      const key = `${year}-${month}`
       return key === seasonKey
     })
 

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -59,10 +59,14 @@ export default function NewSessionPage() {
     setError('')
     try {
       const now = new Date()
-      const defaultName = `Game ${now.toLocaleDateString()} ${now.getHours()}:${String(now.getMinutes()).padStart(
-        2,
-        '0'
-      )}`
+      const dateStr = now.toLocaleDateString([], { timeZone: 'America/Los_Angeles' })
+      const timeStr = now.toLocaleTimeString([], {
+        timeZone: 'America/Los_Angeles',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      })
+      const defaultName = `Game ${dateStr} ${timeStr}`
       const session = await createSession(defaultName, gameMode, selectedIds, isOnline)
       navigate(`/session/${session.id}`)
     } catch (e: unknown) {

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -74,7 +74,7 @@ export default function PlayerDetailPage() {
                   >
                     <td>{g.sessionName || `Game #${g.sessionId}`}</td>
                     <td>{g.gameModeDisplayName}</td>
-                    <td>{new Date(g.createdAt).toLocaleDateString()}</td>
+                    <td>{new Date(g.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
                     <td>
                       <span className={`badge ${g.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
                         {g.status === 'IN_PROGRESS' ? '进行中' : '已结束'}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -759,7 +759,8 @@ export default function SessionPage() {
           <h2 style={{ marginBottom: 0 }}>计分板</h2>
           <div style={{ textAlign: 'right', display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
             <span className="session-meta" style={{ margin: 0, fontSize: '0.85rem' }}>
-              {session.gameModeDisplayName} &middot; {new Date(session.createdAt).toLocaleDateString()}
+              {session.gameModeDisplayName} &middot;{' '}
+              {new Date(session.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
               &nbsp;
               <span className={`badge ${session.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
                 {session.status === 'IN_PROGRESS' ? '进行中' : '已结束'}

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -395,7 +395,7 @@ export default function StatsPage() {
                       <td>{i + 1}</td>
                       <td style={{ color: 'var(--primary)', fontWeight: 600 }}>{p.userName}</td>
                       <td>{abbrName(p.firstName + ' ' + p.lastName)}</td>
-                      <td>{new Date(p.createdAt).toLocaleDateString()}</td>
+                      <td>{new Date(p.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -153,8 +153,15 @@ export function getSeasonLabel(year: number, month: number): string {
 
 export function getCurrentSeason(): Season {
   const now = new Date()
-  const month = now.getMonth() + 1
-  return { year: now.getFullYear(), month, label: getSeasonLabel(now.getFullYear(), month) }
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: 'numeric',
+  })
+  const parts = formatter.formatToParts(now)
+  const year = parseInt(parts.find((p) => p.type === 'year')?.value || '', 10)
+  const month = parseInt(parts.find((p) => p.type === 'month')?.value || '', 10)
+  return { year, month, label: getSeasonLabel(year, month) }
 }
 
 export interface PlayerGameEntry {


### PR DESCRIPTION
## 摘要 (Summary)
本项目在之前的后端时区重构中已经将计算与数据库层统一为洛杉矶太平洋时区（`America/Los_Angeles`）。然而，前端的部分展示与逻辑仍然使用了 UTC 时间或用户浏览器的本地时间，导致出现了展示差异（如跨赛季的界限点不一致，默认对局名时间不合拍，或列表中的时间渲染发生漂移）。

本 PR 彻底统一了前端所有显示和计算时间的地方为**洛杉矶太平洋时间**，消除了由于客户端时区不同导致的不一致问题。

## 变更详情 (Detailed Changes)

### 1. 对局时间显示与生成统一化
* **对局卡片展示 (`ui/src/components/GameCard.tsx`)**：在 `toLocaleString` 选项中添加 `timeZone: 'America/Los_Angeles'`，使得首页对局列表中显示的时间点统一按太平洋时间进行渲染。
* **默认对局名称 (`ui/src/pages/NewSessionPage.tsx`)**：生成新对局时自动拼接的默认名称（如 `Game 6/1/2026 10:30`）改用太平洋时间格式。
* **对局计分板 (`ui/src/pages/SessionPage.tsx`)**：计分板右上角的对局创建日期渲染统一配置太平洋时区。

### 2. 用户与赛季计算一致性
* **赛季划分与过滤 (`ui/src/pages/DashboardPage.tsx`)**：主页赛季下拉过滤之前是通过客户端的 `getFullYear()` 和 `getMonth()` 进行过滤，该方式可能导致特定时区的用户看到的分区结果与后端拉取的数据不吻合。现全部改用 `Intl.DateTimeFormat` 严格按太平洋时区提取当前对局的年、月并计算 Key。
* **当前赛季确定 (`ui/src/types/index.ts`)**：对 `getCurrentSeason` 进行重构，不再直接采用客户端本地时间，而是按太平洋时区确定当前的年、月，防止边缘时区下客户端提前或延后跨赛季。

### 3. 数据中心与管理面板统一
* **管理面板 (`ui/src/pages/AdminPage.tsx`)**：玩家注册时间与已完成对局时间的 `toLocaleDateString` 均加入了太平洋时区强制参数。
* **玩家详情 (`ui/src/pages/PlayerDetailPage.tsx`)**：玩家对局记录表中的日期列统一为太平洋时区显示。
* **统计列表 (`ui/src/pages/StatsPage.tsx`)**：注册玩家的注册时间统一配置为太平洋时区。

## 验证与测试 (Verification & Testing)
* **代码格式**：执行了 `.\gradlew.bat spotlessApply` 自动美化格式。
* **类型校验**：执行了 `.\gradlew.bat npmBuild --rerun-tasks`，前端 TS 编译与 Vite 打包成功，无任何语法或类型错误。
* **单元测试**：执行了 `.\gradlew.bat test`，所有后端 JUnit 测试顺利通过。
