### PR TITLE
revert: 区分线上练习赛与线下正式比赛 (#109)

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/StatsController.java
@@ -29,11 +29,10 @@ public class StatsController {
   public List<PlayerStatsResponse> getStats(
       @RequestParam(required = false) String gameMode,
       @RequestParam(required = false) Integer year,
-      @RequestParam(required = false) Integer month,
-      @RequestParam(required = false) Boolean isOnline) {
+      @RequestParam(required = false) Integer month) {
     GameMode mode = parseGameMode(gameMode);
     LocalDateTime[] range = parseDateRange(year, month);
-    return gameService.getPlayerStats(mode, range[0], range[1], isOnline);
+    return gameService.getPlayerStats(mode, range[0], range[1]);
   }
 
   @GetMapping("/seasons")

--- a/server/src/main/java/com/mahjong/omakase/dto/CreateSessionRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/CreateSessionRequest.java
@@ -16,8 +16,6 @@ public class CreateSessionRequest {
   @Size(min = 3, max = 4, message = "Game requires 3 or 4 players")
   private List<Long> playerIds;
 
-  private Boolean isOnline;
-
   public String getName() {
     return name;
   }
@@ -40,13 +38,5 @@ public class CreateSessionRequest {
 
   public void setPlayerIds(List<Long> playerIds) {
     this.playerIds = playerIds;
-  }
-
-  public Boolean getIsOnline() {
-    return isOnline;
-  }
-
-  public void setIsOnline(Boolean isOnline) {
-    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -21,7 +21,6 @@ public class SessionDetailResponse {
   private double[] umaDist;
   private Double participationBonus;
   private Map<Long, Double> playerBonuses = Collections.emptyMap();
-  private Boolean isOnline;
 
   public static class PlayerInfo {
     private Long id;
@@ -264,13 +263,5 @@ public class SessionDetailResponse {
 
   public void setPlayerBonuses(Map<Long, Double> playerBonuses) {
     this.playerBonuses = playerBonuses;
-  }
-
-  public Boolean getIsOnline() {
-    return isOnline;
-  }
-
-  public void setIsOnline(Boolean isOnline) {
-    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
@@ -17,7 +17,6 @@ public class SessionSummaryResponse {
   private Double participationBonus;
   private int roundCount;
   private List<PlayerPerformanceDTO> rankings;
-  private Boolean isOnline;
 
   public static SessionSummaryResponse from(GameSession session) {
     SessionSummaryResponse r = new SessionSummaryResponse();
@@ -30,7 +29,6 @@ public class SessionSummaryResponse {
     r.createdAt = session.getCreatedAt();
     r.participationBonus = session.getParticipationBonus();
     r.roundCount = session.getRounds() != null ? session.getRounds().size() : 0;
-    r.isOnline = session.getIsOnline();
 
     // Calculate rankings and RP
     r.rankings = calculateRankings(session);
@@ -118,13 +116,5 @@ public class SessionSummaryResponse {
 
   public List<PlayerPerformanceDTO> getRankings() {
     return rankings;
-  }
-
-  public Boolean getIsOnline() {
-    return isOnline;
-  }
-
-  public void setIsOnline(Boolean isOnline) {
-    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/model/GameSession.java
+++ b/server/src/main/java/com/mahjong/omakase/model/GameSession.java
@@ -31,8 +31,6 @@ public class GameSession {
 
   private Double participationBonus;
 
-  private Boolean isOnline = false;
-
   @JsonIgnore
   @OneToMany(mappedBy = "gameSession", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<GameSessionPlayer> players = new ArrayList<>();
@@ -112,13 +110,5 @@ public class GameSession {
 
   public void setParticipationBonus(Double participationBonus) {
     this.participationBonus = participationBonus;
-  }
-
-  public Boolean getIsOnline() {
-    return isOnline;
-  }
-
-  public void setIsOnline(Boolean isOnline) {
-    this.isOnline = isOnline;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -13,78 +13,62 @@ import org.springframework.data.repository.query.Param;
 public interface RoundRepository extends JpaRepository<Round, Long> {
   int countByGameSessionId(Long gameSessionId);
 
-  @Query(
-      "SELECT MAX(r.fanCount) FROM Round r WHERE :isOnline IS NULL OR r.gameSession.isOnline = :isOnline")
-  Integer findMaxFanCount(@Param("isOnline") Boolean isOnline);
+  @Query("SELECT MAX(r.fanCount) FROM Round r")
+  Integer findMaxFanCount();
 
-  @Query(
-      "SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.gameMode = :mode AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
-  Integer findMaxFanCountByMode(@Param("mode") GameMode mode, @Param("isOnline") Boolean isOnline);
+  @Query("SELECT MAX(r.fanCount) FROM Round r WHERE r.gameSession.gameMode = :mode")
+  Integer findMaxFanCountByMode(@Param("mode") GameMode mode);
 
-  @Query(
-      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
-  List<Round> findByFanCount(
-      @Param("fanCount") Integer fanCount, @Param("isOnline") Boolean isOnline);
+  List<Round> findByFanCount(Integer fanCount);
 
-  @Query(
-      "SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode AND (:isOnline IS NULL OR r.gameSession.isOnline = :isOnline)")
+  @Query("SELECT r FROM Round r WHERE r.fanCount = :fanCount AND r.gameSession.gameMode = :mode")
   List<Round> findByFanCountAndMode(
-      @Param("fanCount") Integer fanCount,
-      @Param("mode") GameMode mode,
-      @Param("isOnline") Boolean isOnline);
+      @Param("fanCount") Integer fanCount, @Param("mode") GameMode mode);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
-          + " WHERE s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
+          + " WHERE s.createdAt >= :start AND s.createdAt < :end")
   Integer findMaxFanCountByDateRange(
-      @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end,
-      @Param("isOnline") Boolean isOnline);
+      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
   @Query(
       "SELECT MAX(r.fanCount) FROM Round r JOIN r.gameSession s"
-          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
+          + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end")
   Integer findMaxFanCountByModeAndDateRange(
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end,
-      @Param("isOnline") Boolean isOnline);
+      @Param("end") LocalDateTime end);
 
   @Query(
       "SELECT r FROM Round r JOIN r.gameSession s"
-          + " WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
+          + " WHERE r.fanCount = :fanCount AND s.createdAt >= :start AND s.createdAt < :end")
   List<Round> findByFanCountAndDateRange(
       @Param("fanCount") Integer fanCount,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end,
-      @Param("isOnline") Boolean isOnline);
+      @Param("end") LocalDateTime end);
 
   @Query(
       "SELECT r FROM Round r JOIN r.gameSession s"
           + " WHERE r.fanCount = :fanCount AND s.gameMode = :mode"
-          + " AND s.createdAt >= :start AND s.createdAt < :end AND (:isOnline IS NULL OR s.isOnline = :isOnline)")
+          + " AND s.createdAt >= :start AND s.createdAt < :end")
   List<Round> findByFanCountAndModeAndDateRange(
       @Param("fanCount") Integer fanCount,
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end,
-      @Param("isOnline") Boolean isOnline);
+      @Param("end") LocalDateTime end);
 
   @Query(
       value =
-          "SELECT r FROM Round r JOIN FETCH r.gameSession s WHERE (:isOnline IS NULL OR s.isOnline = :isOnline) ORDER BY s.createdAt ASC, r.roundNumber ASC",
-      countQuery =
-          "SELECT count(r) FROM Round r JOIN r.gameSession s WHERE (:isOnline IS NULL OR s.isOnline = :isOnline)")
-  Page<Round> findAllOrderByTime(@Param("isOnline") Boolean isOnline, Pageable pageable);
+          "SELECT r FROM Round r JOIN FETCH r.gameSession s ORDER BY s.createdAt ASC, r.roundNumber ASC",
+      countQuery = "SELECT count(r) FROM Round r")
+  Page<Round> findAllOrderByTime(Pageable pageable);
 
   @Query(
       "SELECT r FROM Round r JOIN FETCH r.gameSession s"
           + " WHERE s.gameMode = :mode AND s.createdAt >= :start AND s.createdAt < :end"
-          + " AND (:isOnline IS NULL OR s.isOnline = :isOnline)"
           + " ORDER BY s.createdAt ASC, r.roundNumber ASC")
   List<Round> findByGameModeAndSessionDateRangeOrderByTime(
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end,
-      @Param("isOnline") Boolean isOnline);
+      @Param("end") LocalDateTime end);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -1,8 +1,6 @@
 package com.mahjong.omakase.repository;
 
-import com.mahjong.omakase.model.GameMode;
 import com.mahjong.omakase.model.RoundScore;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -19,60 +17,7 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
           + "WHERE rs.round.gameSession.id IN :sessionIds GROUP BY rs.player.id")
   List<Object[]> getGamesPlayedPerPlayerInSessions(List<Long> sessionIds);
 
-  @Query("SELECT rs.player.id, SUM(rs.score) FROM RoundScore rs GROUP BY rs.player.id")
-  List<Object[]> getTotalScoresAllTime();
-
-  @Query(
-      "SELECT rs.player.id, SUM(rs.score) FROM RoundScore rs "
-          + "WHERE rs.round.gameSession.gameMode = :gameMode GROUP BY rs.player.id")
-  List<Object[]> getTotalScoresByGameMode(GameMode gameMode);
-
-  @Query(
-      "SELECT rs.player.id, SUM(rs.score) FROM RoundScore rs "
-          + "WHERE rs.round.gameSession.gameMode = :gameMode "
-          + "AND rs.round.gameSession.createdAt >= :start "
-          + "AND rs.round.gameSession.createdAt < :end "
-          + "GROUP BY rs.player.id")
-  List<Object[]> getTotalScoresByGameModeAndDateRange(
-      GameMode gameMode, LocalDateTime start, LocalDateTime end);
-
-  @Query(
-      "SELECT rs.player.id, COUNT(DISTINCT rs.round.gameSession.id) FROM RoundScore rs "
-          + "GROUP BY rs.player.id")
-  List<Object[]> getGamesPlayedPerPlayer();
-
-  @Query(
-      "SELECT rs.player.id, COUNT(DISTINCT rs.round.gameSession.id) FROM RoundScore rs "
-          + "WHERE rs.round.gameSession.gameMode = :gameMode GROUP BY rs.player.id")
-  List<Object[]> getGamesPlayedPerPlayerByGameMode(GameMode gameMode);
-
-  @Query(
-      "SELECT rs.player.id, COUNT(DISTINCT rs.round.gameSession.id) FROM RoundScore rs "
-          + "WHERE rs.round.gameSession.gameMode = :gameMode "
-          + "AND rs.round.gameSession.createdAt >= :start "
-          + "AND rs.round.gameSession.createdAt < :end "
-          + "GROUP BY rs.player.id")
-  List<Object[]> getGamesPlayedPerPlayerByGameModeAndDateRange(
-      GameMode gameMode, LocalDateTime start, LocalDateTime end);
-
   @Modifying
   @Query("UPDATE RoundScore rs SET rs.player = null WHERE rs.player.id = :playerId")
   void nullifyPlayerScores(Long playerId);
-
-  @Query("SELECT rs.player.id, COUNT(rs.id) FROM RoundScore rs " + "GROUP BY rs.player.id")
-  List<Object[]> getRoundsPlayedPerPlayer();
-
-  @Query(
-      "SELECT rs.player.id, COUNT(rs.id) FROM RoundScore rs "
-          + "WHERE rs.round.gameSession.gameMode = :gameMode GROUP BY rs.player.id")
-  List<Object[]> getRoundsPlayedPerPlayerByGameMode(GameMode gameMode);
-
-  @Query(
-      "SELECT rs.player.id, COUNT(rs.id) FROM RoundScore rs "
-          + "WHERE rs.round.gameSession.gameMode = :gameMode "
-          + "AND rs.round.gameSession.createdAt >= :start "
-          + "AND rs.round.gameSession.createdAt < :end "
-          + "GROUP BY rs.player.id")
-  List<Object[]> getRoundsPlayedPerPlayerByGameModeAndDateRange(
-      GameMode gameMode, LocalDateTime start, LocalDateTime end);
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -75,7 +75,7 @@ public class GameService {
 
     while (hasMore) {
       Pageable pageable = PageRequest.of(page, size);
-      Page<Round> roundPage = roundRepo.findAllOrderByTime(false, pageable);
+      Page<Round> roundPage = roundRepo.findAllOrderByTime(pageable);
       List<Round> rounds = roundPage.getContent();
 
       if (rounds.isEmpty()) {
@@ -86,7 +86,6 @@ public class GameService {
       for (Round round : rounds) {
         if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
         if (round.getGameSession().getGameMode() != GameMode.GUOBIAO) continue;
-        if (Boolean.TRUE.equals(round.getGameSession().getIsOnline())) continue;
         Player winner =
             playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
         if (winner == null || winner.isBot()) continue;
@@ -234,7 +233,6 @@ public class GameService {
     session.setGameMode(GameMode.valueOf(request.getGameMode()));
     session.setPlayerCount(request.getPlayerIds().size());
     session.setParticipationBonus(this.participationBonus);
-    session.setIsOnline(request.getIsOnline() != null ? request.getIsOnline() : false);
     session = sessionRepo.save(session);
 
     int seat = 1;
@@ -269,7 +267,6 @@ public class GameService {
     resp.setPlayerCount(session.getPlayerCount());
     resp.setStatus(session.getStatus().name());
     resp.setCreatedAt(session.getCreatedAt());
-    resp.setIsOnline(session.getIsOnline());
 
     resp.setPlayers(
         session.getPlayers().stream()
@@ -357,9 +354,6 @@ public class GameService {
    */
   private Map<Long, Double> computeSessionPlayerBonuses(GameSession session) {
     Map<Long, Double> bonuses = new HashMap<>();
-    if (Boolean.TRUE.equals(session.getIsOnline())) {
-      return bonuses;
-    }
 
     List<Object[]> currentSessionScores = roundScoreRepo.getTotalScoresBySession(session.getId());
     if (currentSessionScores.isEmpty()) {
@@ -372,7 +366,6 @@ public class GameService {
         sessionRepo.findAll().stream()
             .filter(s -> s.getStatus() == SessionStatus.COMPLETED)
             .filter(s -> s.getGameMode() == session.getGameMode())
-            .filter(s -> !Boolean.TRUE.equals(s.getIsOnline()))
             .filter(s -> getSeasonStringFromUtc(s.getCreatedAt()).equals(season))
             .filter(s -> !s.getCreatedAt().isAfter(session.getCreatedAt()))
             .sorted(Comparator.comparing(GameSession::getCreatedAt))
@@ -527,9 +520,8 @@ public class GameService {
     String season = ym.toString();
     int rederived = 0;
     for (Round round :
-        roundRepo.findByGameModeAndSessionDateRangeOrderByTime(mode, startUtc, endUtc, false)) {
+        roundRepo.findByGameModeAndSessionDateRangeOrderByTime(mode, startUtc, endUtc)) {
       if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
-      if (Boolean.TRUE.equals(round.getGameSession().getIsOnline())) continue;
       Player winner = playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
       if (winner == null || winner.isBot()) continue;
       rederived +=
@@ -563,27 +555,26 @@ public class GameService {
 
     Integer maxFan;
     if (hasMode && hasDate) {
-      maxFan = roundRepo.findMaxFanCountByModeAndDateRange(gameMode, startUtc, endUtc, false);
+      maxFan = roundRepo.findMaxFanCountByModeAndDateRange(gameMode, startUtc, endUtc);
     } else if (hasMode) {
-      maxFan = roundRepo.findMaxFanCountByMode(gameMode, false);
+      maxFan = roundRepo.findMaxFanCountByMode(gameMode);
     } else if (hasDate) {
-      maxFan = roundRepo.findMaxFanCountByDateRange(startUtc, endUtc, false);
+      maxFan = roundRepo.findMaxFanCountByDateRange(startUtc, endUtc);
     } else {
-      maxFan = roundRepo.findMaxFanCount(false);
+      maxFan = roundRepo.findMaxFanCount();
     }
 
     if (maxFan == null || maxFan == 0) return Collections.emptyList();
 
     List<Round> bestRounds;
     if (hasMode && hasDate) {
-      bestRounds =
-          roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, startUtc, endUtc, false);
+      bestRounds = roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, startUtc, endUtc);
     } else if (hasMode) {
-      bestRounds = roundRepo.findByFanCountAndMode(maxFan, gameMode, false);
+      bestRounds = roundRepo.findByFanCountAndMode(maxFan, gameMode);
     } else if (hasDate) {
-      bestRounds = roundRepo.findByFanCountAndDateRange(maxFan, startUtc, endUtc, false);
+      bestRounds = roundRepo.findByFanCountAndDateRange(maxFan, startUtc, endUtc);
     } else {
-      bestRounds = roundRepo.findByFanCount(maxFan, false);
+      bestRounds = roundRepo.findByFanCount(maxFan);
     }
 
     return bestRounds.stream()
@@ -656,27 +647,48 @@ public class GameService {
    *     getSeasonStringFromUtc.
    */
   public List<PlayerStatsResponse> getPlayerStats(
-      GameMode gameMode, LocalDateTime start, LocalDateTime end, Boolean isOnline) {
+      GameMode gameMode, LocalDateTime start, LocalDateTime end) {
     List<Player> players = playerRepo.findAll();
     boolean hasDateRange = start != null && end != null;
     LocalDateTime startUtc = toUtcTime(start);
     LocalDateTime endUtc = toUtcTime(end);
 
     Map<Long, Integer> totalScores = new HashMap<>();
+    List<Object[]> scoreRows;
+    if (gameMode != null && hasDateRange) {
+      scoreRows = roundScoreRepo.getTotalScoresByGameModeAndDateRange(gameMode, startUtc, endUtc);
+    } else if (gameMode != null) {
+      scoreRows = roundScoreRepo.getTotalScoresByGameMode(gameMode);
+    } else {
+      scoreRows = roundScoreRepo.getTotalScoresAllTime();
+    }
+    for (Object[] row : scoreRows) {
+      if (row[0] != null) totalScores.put((Long) row[0], ((Number) row[1]).intValue());
+    }
+
     Map<Long, Integer> gamesPlayed = new HashMap<>();
+    List<Object[]> gamesRows;
+    if (gameMode != null && hasDateRange) {
+      gamesRows =
+          roundScoreRepo.getGamesPlayedPerPlayerByGameModeAndDateRange(gameMode, startUtc, endUtc);
+    } else if (gameMode != null) {
+      gamesRows = roundScoreRepo.getGamesPlayedPerPlayerByGameMode(gameMode);
+    } else {
+      gamesRows = roundScoreRepo.getGamesPlayedPerPlayer();
+    }
+    for (Object[] row : gamesRows) {
+      if (row[0] != null) gamesPlayed.put((Long) row[0], ((Number) row[1]).intValue());
+    }
+
     Map<Long, Integer> wins = new HashMap<>();
     Map<Long, Double> totalRP = new HashMap<>();
     Map<Long, Double> tieredBonusPerPlayer = new HashMap<>();
     Map<Long, Double> adminBonusPerPlayer = new HashMap<>();
     Map<Long, Double> fanBonusPerPlayer = new HashMap<>();
-
-    boolean targetOnline = Boolean.TRUE.equals(isOnline);
-
     List<GameSession> completedSessions =
         sessionRepo.findAll().stream()
             .filter(s -> s.getStatus() == SessionStatus.COMPLETED)
             .filter(s -> gameMode == null || s.getGameMode() == gameMode)
-            .filter(s -> targetOnline == Boolean.TRUE.equals(s.getIsOnline()))
             .filter(
                 s ->
                     !hasDateRange
@@ -689,8 +701,8 @@ public class GameService {
     // Keyed separately by mode so each game mode has its own 20-game tier per season.
     Map<String, Map<Long, Integer>> gameIndexBySeasonModePlayer = new HashMap<>();
 
-    // Add Fan Discovery Bonuses (GUOBIAO only, offline only)
-    if (!targetOnline && (gameMode == null || gameMode == GameMode.GUOBIAO)) {
+    // Add Fan Discovery Bonuses (GUOBIAO only)
+    if (gameMode == null || gameMode == GameMode.GUOBIAO) {
       if (hasDateRange) {
         // Callers supply start in Pacific timezone; convert to UTC to consistently derive season
         String season = getSeasonStringFromUtc(startUtc);
@@ -718,30 +730,19 @@ public class GameService {
         String seasonModeKey = season + ":" + session.getGameMode().name();
         Map<Long, Integer> seasonCounts =
             gameIndexBySeasonModePlayer.computeIfAbsent(seasonModeKey, k -> new HashMap<>());
-
-        boolean isSessionOnline = Boolean.TRUE.equals(session.getIsOnline());
         double adminBonus =
-            (!isSessionOnline && session.getParticipationBonus() != null)
-                ? session.getParticipationBonus()
-                : 0.0;
-
+            session.getParticipationBonus() != null ? session.getParticipationBonus() : 0.0;
         for (Object[] row : sessionScores) {
           if (row[0] != null) {
             Long playerId = (Long) row[0];
-            int score = ((Number) row[1]).intValue();
-
-            // Accumulate gamesPlayed and totalScores dynamically for accurate filter
-            gamesPlayed.merge(playerId, 1, Integer::sum);
-            totalScores.merge(playerId, score, Integer::sum);
-
             int gameIndex = seasonCounts.merge(playerId, 1, Integer::sum);
-            double tieredBonus = 0.0;
-            if (!isSessionOnline) {
-              if (gameIndex <= 10) {
-                tieredBonus = 10.0;
-              } else if (gameIndex <= 20) {
-                tieredBonus = 5.0;
-              }
+            double tieredBonus;
+            if (gameIndex <= 10) {
+              tieredBonus = 10.0;
+            } else if (gameIndex <= 20) {
+              tieredBonus = 5.0;
+            } else {
+              tieredBonus = 0.0;
             }
             tieredBonusPerPlayer.merge(playerId, tieredBonus, (a, b) -> a + b);
             adminBonusPerPlayer.merge(playerId, adminBonus, (a, b) -> a + b);
@@ -893,12 +894,11 @@ public class GameService {
       roundScoreRepo.save(rs);
     }
 
-    // Process Fan Discoveries (GUOBIAO only, skip BOT winners, skip chombo, skip online sessions)
+    // Process Fan Discoveries (GUOBIAO only, skip BOT winners, skip chombo)
     if (winnerId != null
         && fanDetails != null
         && !fanDetails.isBlank()
-        && session.getGameMode() == GameMode.GUOBIAO
-        && !Boolean.TRUE.equals(session.getIsOnline())) {
+        && session.getGameMode() == GameMode.GUOBIAO) {
       Integer winnerScoreChange = computedScores.get(winnerId);
       if (winnerScoreChange != null && winnerScoreChange > 0) {
         Player winner = playerRepo.findById(winnerId).orElse(null);

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -654,32 +654,7 @@ public class GameService {
     LocalDateTime endUtc = toUtcTime(end);
 
     Map<Long, Integer> totalScores = new HashMap<>();
-    List<Object[]> scoreRows;
-    if (gameMode != null && hasDateRange) {
-      scoreRows = roundScoreRepo.getTotalScoresByGameModeAndDateRange(gameMode, startUtc, endUtc);
-    } else if (gameMode != null) {
-      scoreRows = roundScoreRepo.getTotalScoresByGameMode(gameMode);
-    } else {
-      scoreRows = roundScoreRepo.getTotalScoresAllTime();
-    }
-    for (Object[] row : scoreRows) {
-      if (row[0] != null) totalScores.put((Long) row[0], ((Number) row[1]).intValue());
-    }
-
     Map<Long, Integer> gamesPlayed = new HashMap<>();
-    List<Object[]> gamesRows;
-    if (gameMode != null && hasDateRange) {
-      gamesRows =
-          roundScoreRepo.getGamesPlayedPerPlayerByGameModeAndDateRange(gameMode, startUtc, endUtc);
-    } else if (gameMode != null) {
-      gamesRows = roundScoreRepo.getGamesPlayedPerPlayerByGameMode(gameMode);
-    } else {
-      gamesRows = roundScoreRepo.getGamesPlayedPerPlayer();
-    }
-    for (Object[] row : gamesRows) {
-      if (row[0] != null) gamesPlayed.put((Long) row[0], ((Number) row[1]).intValue());
-    }
-
     Map<Long, Integer> wins = new HashMap<>();
     Map<Long, Double> totalRP = new HashMap<>();
     Map<Long, Double> tieredBonusPerPlayer = new HashMap<>();
@@ -735,6 +710,14 @@ public class GameService {
         for (Object[] row : sessionScores) {
           if (row[0] != null) {
             Long playerId = (Long) row[0];
+            int score = ((Number) row[1]).intValue();
+
+            // Accumulate gamesPlayed and totalScores dynamically so they share the same
+            // session set as wins/bonuses below (otherwise mode-or-date-only filters can
+            // mix all-time totals with date-filtered wins).
+            gamesPlayed.merge(playerId, 1, Integer::sum);
+            totalScores.merge(playerId, score, Integer::sum);
+
             int gameIndex = seasonCounts.merge(playerId, 1, Integer::sum);
             double tieredBonus;
             if (gameIndex <= 10) {

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -86,16 +86,11 @@ export async function fetchSessions(signal?: AbortSignal): Promise<GameSession[]
   return cachedFetch(`${API}/sessions`, signal)
 }
 
-export async function createSession(
-  name: string,
-  gameMode: string,
-  playerIds: number[],
-  isOnline?: boolean
-): Promise<GameSession> {
+export async function createSession(name: string, gameMode: string, playerIds: number[]): Promise<GameSession> {
   const res = await fetch(`${API}/sessions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, gameMode, playerIds, isOnline }),
+    body: JSON.stringify({ name, gameMode, playerIds }),
   })
   const data = await handleResponse<GameSession>(res)
   invalidateCache()
@@ -136,7 +131,6 @@ export async function fetchStats(
   gameMode?: string,
   year?: number,
   month?: number,
-  isOnline?: boolean,
   signal?: AbortSignal
 ): Promise<PlayerStats[]> {
   const params = new URLSearchParams()
@@ -144,9 +138,6 @@ export async function fetchStats(
   if (year != null && month != null) {
     params.set('year', String(year))
     params.set('month', String(month))
-  }
-  if (isOnline != null) {
-    params.set('isOnline', String(isOnline))
   }
   const qs = params.toString()
   return cachedFetch(`${API}/stats${qs ? `?${qs}` : ''}`, signal)

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -17,28 +17,14 @@ interface Props {
   roundLabel: string
   isActive: boolean
   players: PlayerEntry[]
-  isOnline?: boolean
 }
 
-export const GameCard: React.FC<Props> = ({
-  id,
-  gameModeDisplayName,
-  createdAt,
-  roundLabel,
-  isActive,
-  players,
-  isOnline,
-}) => {
+export const GameCard: React.FC<Props> = ({ id, gameModeDisplayName, createdAt, roundLabel, isActive, players }) => {
   return (
     <Link to={`/session/${id}`} className="game-card">
       <div className="session-card-header">
         <div className="session-card-mode">
           <span className="mode-text">{gameModeDisplayName}</span>
-          {isOnline && (
-            <span className="badge badge-sm" style={{ backgroundColor: 'var(--accent)', marginLeft: 8, color: '#fff' }}>
-              线上
-            </span>
-          )}
         </div>
         <div className="session-card-meta">
           <span className="session-card-date">

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -123,7 +123,6 @@ export default function DashboardPage() {
               createdAt={s.createdAt}
               roundLabel={`${s.roundCount}局 已结束`}
               isActive={false}
-              isOnline={s.isOnline}
               players={
                 s.rankings
                   ? s.rankings.map((p, idx) => ({

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -35,7 +35,7 @@ export default function HomePage() {
           GAME_MODES.map(async (mode) => {
             try {
               const [stats, bestRounds] = await Promise.all([
-                fetchStats(mode.key, currentSeason.year, currentSeason.month, false, controller.signal),
+                fetchStats(mode.key, currentSeason.year, currentSeason.month, controller.signal),
                 fetchBestRounds(mode.key, currentSeason.year, currentSeason.month, controller.signal),
               ])
 
@@ -112,7 +112,6 @@ export default function HomePage() {
                   createdAt={s.createdAt}
                   roundLabel={`${state.displayName} 进行中`}
                   isActive={true}
-                  isOnline={s.isOnline}
                   players={sortedPlayers.map((p) => {
                     const score = s.totalScores[p.id] || 0
                     const rank = sortedScores.indexOf(score) + 1

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -18,7 +18,6 @@ export default function NewSessionPage() {
   const [error, setError] = useState('')
   const [creating, setCreating] = useState(false)
   const [loaded, setLoaded] = useState(false)
-  const [isOnline, setIsOnline] = useState(false)
 
   useEffect(() => {
     fetchPlayers()
@@ -67,7 +66,7 @@ export default function NewSessionPage() {
         hour12: false,
       })
       const defaultName = `Game ${dateStr} ${timeStr}`
-      const session = await createSession(defaultName, gameMode, selectedIds, isOnline)
+      const session = await createSession(defaultName, gameMode, selectedIds)
       navigate(`/session/${session.id}`)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : MSG.ERROR)
@@ -94,21 +93,6 @@ export default function NewSessionPage() {
               {m.label}
             </button>
           ))}
-        </div>
-      </div>
-
-      <div className="form-group">
-        <label>对局属性</label>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 8 }}>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontWeight: 'normal' }}>
-            <input
-              type="checkbox"
-              checked={isOnline}
-              onChange={(e) => setIsOnline(e.target.checked)}
-              style={{ width: 18, height: 18, cursor: 'pointer' }}
-            />
-            <span>线上练习赛</span>
-          </label>
         </div>
       </div>
 

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -38,9 +38,8 @@ export default function StatsPage() {
 
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.month}`)
-  const [isOnline, setIsOnline] = useState<boolean>(false)
 
-  const loadStats = (mode: GameModeKey, sKey: string, online: boolean) => {
+  const loadStats = (mode: GameModeKey, sKey: string) => {
     setError('')
     setLoading(true)
     let year: number | undefined
@@ -50,7 +49,7 @@ export default function StatsPage() {
       year = y
       month = m
     }
-    fetchStats(mode, year, month, online)
+    fetchStats(mode, year, month)
       .then((s) => {
         setStats(s.sort((a, b) => b.totalRP - a.totalRP || b.totalScore - a.totalScore))
         setLoading(false)
@@ -99,11 +98,11 @@ export default function StatsPage() {
 
   useEffect(() => {
     if (tab === 'games') {
-      loadStats(gameMode, seasonKey, isOnline)
+      loadStats(gameMode, seasonKey)
     } else {
       loadPlayers()
     }
-  }, [gameMode, seasonKey, tab, isOnline])
+  }, [gameMode, seasonKey, tab])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -214,20 +213,6 @@ export default function StatsPage() {
             </div>
           </div>
 
-          <div className="card">
-            <div className="flex-between">
-              <h2>对局类型</h2>
-              <select
-                value={isOnline ? 'online' : 'offline'}
-                onChange={(e) => setIsOnline(e.target.value === 'online')}
-                className="select-inline"
-              >
-                <option value="offline">线下正式赛</option>
-                <option value="online">线上练习赛</option>
-              </select>
-            </div>
-          </div>
-
           <div className="stats-grid">
             <div className="stat-card">
               <div className="stat-value">{activeStats.length}</div>
@@ -306,7 +291,7 @@ export default function StatsPage() {
             </div>
           )}
 
-          {!isOnline && seasonKey !== 'all' && (
+          {seasonKey !== 'all' && (
             <div className="card best-hand-card">
               <div className="best-hand-header">
                 <span className="best-hand-crown">🌟</span>
@@ -340,7 +325,7 @@ export default function StatsPage() {
             </div>
           )}
 
-          {!isOnline && (bestRounds.length > 0 || !!bestRoundsError) && (
+          {(bestRounds.length > 0 || !!bestRoundsError) && (
             <div className="card best-hand-card">
               <div className="best-hand-header">
                 <span className="best-hand-crown">👑</span>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -39,7 +39,6 @@ export interface GameSession {
   createdAt: string
   roundCount: number
   rankings?: PlayerPerformance[]
-  isOnline?: boolean
 }
 
 export interface PlayerPerformance {
@@ -87,7 +86,6 @@ export interface SessionDetail {
   rpOrigin: number
   umaDist: number[]
   playerBonuses?: Record<number, number>
-  isOnline?: boolean
 }
 
 export interface AddRoundData {


### PR DESCRIPTION
## Summary
- Reverts commit 447ff77 (PR #109), which split game sessions into online/offline modes and stripped the RP/achievement reward system.
- Conflict in `ui/src/pages/NewSessionPage.tsx` resolved manually to keep the `America/Los_Angeles` timezone formatting introduced by #111 — only the `isOnline` state, form group, and `createSession` argument from #109 are removed.
- All other auto-merged files (`GameCard.tsx`, `DashboardPage.tsx`, `StatsPage.tsx`, `types/index.ts`) cleanly drop the `isOnline` plumbing while leaving #111's timezone changes untouched.

## Test plan
- [x] `./gradlew spotlessApply` — clean
- [x] `./gradlew compileJava -q` — compiles
- [x] `(cd ui && npx tsc --noEmit)` — type-checks
- [x] `grep isOnline` across `ui/src` and `server/src` — no orphan references
- [ ] Manual smoke: create a new session, view dashboard and stats pages, confirm dates render in PT and no online/offline toggle is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved inconsistencies in game statistics and bonus calculations by unifying how all games are processed.

* **UI Updates**
  * Removed online/offline game classification. All games are now treated uniformly.
  * Removed online status badges from game cards.
  * Removed online/offline filtering options from stats pages.
  * Simplified game creation by eliminating the online game selection option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->