### PR TITLE
style(ui): codebase audit cleanup — dead CSS, theme vars, hooks, dedupe

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -74,6 +74,20 @@ find server/src -name "*.java" | while read f; do
 done
 ```
 
+### Java fully-qualified names (should be imports)
+Flag any `java.<pkg>.<TypeName>` reference in the file body — these should be
+imported and used as the simple type name. Common offenders: `java.time.ZoneId`,
+`java.util.function.Predicate`, `java.util.function.Supplier`. The body of a
+class should never spell out a `java.*` package; if it does, move the type to
+the import block.
+```bash
+grep -rn 'java\.[a-z][a-z]*\.[A-Z]' server/src --include='*.java' \
+  | grep -v '^[^:]*:[0-9]*:import ' \
+  | grep -v '^[^:]*:[0-9]*: \* '
+```
+Each line returned is a violation. Fix by adding an `import java.<pkg>.<Type>;`
+and replacing the FQN with `Type` at every use site in that file.
+
 ### Java unused private methods
 Read each Java service/controller/handler file and check if every private method is called within the same class.
 

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -81,7 +81,7 @@ imported and used as the simple type name. Common offenders: `java.time.ZoneId`,
 class should never spell out a `java.*` package; if it does, move the type to
 the import block.
 ```bash
-grep -rn 'java\.[a-z][a-z]*\.[A-Z]' server/src --include='*.java' \
+grep -rnE 'java(\.[a-z][a-z0-9_]*)+\.[A-Z][A-Za-z0-9_]*' server/src --include='*.java' \
   | grep -v '^[^:]*:[0-9]*:import ' \
   | grep -v '^[^:]*:[0-9]*: \* '
 ```

--- a/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -8,6 +8,7 @@ import com.mahjong.omakase.service.GameService;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -97,7 +98,7 @@ public class AdminController {
         .collect(Collectors.toMap(AppSetting::getKey, AppSetting::getValue));
   }
 
-  private static final Map<String, java.util.function.Predicate<String>> SETTING_VALIDATORS =
+  private static final Map<String, Predicate<String>> SETTING_VALIDATORS =
       Map.of(
           "participation_bonus",
           v -> {

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
@@ -2,6 +2,7 @@ package com.mahjong.omakase.repository;
 
 import com.mahjong.omakase.model.GameSession;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,5 +25,5 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
   List<Object[]> findDistinctSeasons();
 
   @Query("SELECT s.createdAt FROM GameSession s WHERE s.rounds IS NOT EMPTY")
-  List<java.time.LocalDateTime> findSessionCreationTimesWithRounds();
+  List<LocalDateTime> findSessionCreationTimesWithRounds();
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -86,9 +87,8 @@ public class GameService {
       for (Round round : rounds) {
         if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
         if (round.getGameSession().getGameMode() != GameMode.GUOBIAO) continue;
-        Player winner =
-            playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
-        if (winner == null || winner.isBot()) continue;
+        Player winner = loadActivePlayer(round.getWinnerId());
+        if (winner == null) continue;
 
         String season = getSeasonStringFromUtc(round.getGameSession().getCreatedAt());
         newDiscoveries +=
@@ -123,6 +123,30 @@ public class GameService {
   private String getSeasonStringFromPacific(LocalDateTime pacificTime) {
     if (pacificTime == null) return null;
     return YearMonth.from(pacificTime).toString();
+  }
+
+  /** Returns the player if found and not a bot, else null. */
+  private Player loadActivePlayer(Long playerId) {
+    if (playerId == null) return null;
+    Player p = playerRepo.findById(playerId).orElse(null);
+    return (p != null && !p.isBot()) ? p : null;
+  }
+
+  /**
+   * Picks one of four query suppliers based on whether mode/date filters are present. Used to
+   * collapse parallel if/else ladders that all branch on (hasMode, hasDate).
+   */
+  private <T> T queryByModeAndDate(
+      boolean hasMode,
+      boolean hasDate,
+      Supplier<T> modeAndDate,
+      Supplier<T> modeOnly,
+      Supplier<T> dateOnly,
+      Supplier<T> none) {
+    if (hasMode && hasDate) return modeAndDate.get();
+    if (hasMode) return modeOnly.get();
+    if (hasDate) return dateOnly.get();
+    return none.get();
   }
 
   public void reloadSettings() {
@@ -522,8 +546,8 @@ public class GameService {
     for (Round round :
         roundRepo.findByGameModeAndSessionDateRangeOrderByTime(mode, startUtc, endUtc)) {
       if (round.getWinnerId() == null || round.getFanDetails() == null) continue;
-      Player winner = playerRepo.findById(Objects.requireNonNull(round.getWinnerId())).orElse(null);
-      if (winner == null || winner.isBot()) continue;
+      Player winner = loadActivePlayer(round.getWinnerId());
+      if (winner == null) continue;
       rederived +=
           processFanDiscoveries(
               round.getFanDetails(),
@@ -553,29 +577,26 @@ public class GameService {
     LocalDateTime startUtc = toUtcTime(start);
     LocalDateTime endUtc = toUtcTime(end);
 
-    Integer maxFan;
-    if (hasMode && hasDate) {
-      maxFan = roundRepo.findMaxFanCountByModeAndDateRange(gameMode, startUtc, endUtc);
-    } else if (hasMode) {
-      maxFan = roundRepo.findMaxFanCountByMode(gameMode);
-    } else if (hasDate) {
-      maxFan = roundRepo.findMaxFanCountByDateRange(startUtc, endUtc);
-    } else {
-      maxFan = roundRepo.findMaxFanCount();
-    }
+    Integer maxFan =
+        queryByModeAndDate(
+            hasMode,
+            hasDate,
+            () -> roundRepo.findMaxFanCountByModeAndDateRange(gameMode, startUtc, endUtc),
+            () -> roundRepo.findMaxFanCountByMode(gameMode),
+            () -> roundRepo.findMaxFanCountByDateRange(startUtc, endUtc),
+            () -> roundRepo.findMaxFanCount());
 
     if (maxFan == null || maxFan == 0) return Collections.emptyList();
 
-    List<Round> bestRounds;
-    if (hasMode && hasDate) {
-      bestRounds = roundRepo.findByFanCountAndModeAndDateRange(maxFan, gameMode, startUtc, endUtc);
-    } else if (hasMode) {
-      bestRounds = roundRepo.findByFanCountAndMode(maxFan, gameMode);
-    } else if (hasDate) {
-      bestRounds = roundRepo.findByFanCountAndDateRange(maxFan, startUtc, endUtc);
-    } else {
-      bestRounds = roundRepo.findByFanCount(maxFan);
-    }
+    final Integer fan = maxFan;
+    List<Round> bestRounds =
+        queryByModeAndDate(
+            hasMode,
+            hasDate,
+            () -> roundRepo.findByFanCountAndModeAndDateRange(fan, gameMode, startUtc, endUtc),
+            () -> roundRepo.findByFanCountAndMode(fan, gameMode),
+            () -> roundRepo.findByFanCountAndDateRange(fan, startUtc, endUtc),
+            () -> roundRepo.findByFanCount(fan));
 
     return bestRounds.stream()
         .map(
@@ -884,8 +905,8 @@ public class GameService {
         && session.getGameMode() == GameMode.GUOBIAO) {
       Integer winnerScoreChange = computedScores.get(winnerId);
       if (winnerScoreChange != null && winnerScoreChange > 0) {
-        Player winner = playerRepo.findById(winnerId).orElse(null);
-        if (winner != null && !winner.isBot()) {
+        Player winner = loadActivePlayer(winnerId);
+        if (winner != null) {
           String season = getSeasonStringFromUtc(session.getCreatedAt());
           processFanDiscoveries(fanDetails, season, winner, round, winHand, session.getCreatedAt());
         }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -7,6 +7,7 @@ import com.mahjong.omakase.service.handler.GameModeHandler;
 import com.mahjong.omakase.service.scoring.RpCalculator;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -26,8 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class GameService {
 
-  private static final java.time.ZoneId ZONE_UTC = java.time.ZoneId.of("UTC");
-  private static final java.time.ZoneId ZONE_PACIFIC = java.time.ZoneId.of("America/Los_Angeles");
+  private static final ZoneId ZONE_UTC = ZoneId.of("UTC");
+  private static final ZoneId ZONE_PACIFIC = ZoneId.of("America/Los_Angeles");
 
   private final PlayerRepository playerRepo;
   private final GameSessionRepository sessionRepo;

--- a/ui/src/components/WindSelectorRow.tsx
+++ b/ui/src/components/WindSelectorRow.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+interface Props {
+  label: string
+  value: number
+  onChange: (value: number) => void
+}
+
+const WIND_NAMES: Record<number, string> = { 1: '东', 2: '南', 3: '西', 4: '北' }
+
+export const WindSelectorRow: React.FC<Props> = ({ label, value, onChange }) => (
+  <div className="configs-row-section" style={{ gap: 4 }}>
+    <span className="config-row-label">{label}:</span>
+    {[1, 2, 3, 4].map((w) => (
+      <button
+        key={w}
+        className={`compact-toggle-btn ${value === w ? 'active' : ''}`}
+        onClick={() => onChange(w)}
+      >
+        {WIND_NAMES[w]}
+      </button>
+    ))}
+  </div>
+)

--- a/ui/src/components/WindSelectorRow.tsx
+++ b/ui/src/components/WindSelectorRow.tsx
@@ -12,11 +12,7 @@ export const WindSelectorRow: React.FC<Props> = ({ label, value, onChange }) => 
   <div className="configs-row-section" style={{ gap: 4 }}>
     <span className="config-row-label">{label}:</span>
     {[1, 2, 3, 4].map((w) => (
-      <button
-        key={w}
-        className={`compact-toggle-btn ${value === w ? 'active' : ''}`}
-        onClick={() => onChange(w)}
-      >
+      <button key={w} className={`compact-toggle-btn ${value === w ? 'active' : ''}`} onClick={() => onChange(w)}>
         {WIND_NAMES[w]}
       </button>
     ))}

--- a/ui/src/hooks/useActiveSeasons.ts
+++ b/ui/src/hooks/useActiveSeasons.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { fetchActiveSeasons } from '../api'
 import { Season, getSeasonLabel } from '../types'
+import { parseError } from '../utils/format'
 
 export interface ActiveSeasonsResult {
   seasons: Season[]
@@ -34,7 +35,7 @@ export function useActiveSeasons(): ActiveSeasonsResult {
       })
       .catch((e: unknown) => {
         if (!mounted) return
-        setError(e instanceof Error ? e.message : 'Failed to load seasons')
+        setError(parseError(e))
       })
       .finally(() => {
         if (mounted) setLoading(false)

--- a/ui/src/hooks/useActiveSeasons.ts
+++ b/ui/src/hooks/useActiveSeasons.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import { fetchActiveSeasons } from '../api'
+import { Season, getSeasonLabel } from '../types'
+
+export interface ActiveSeasonsResult {
+  seasons: Season[]
+  loading: boolean
+  error: string
+}
+
+/**
+ * Fetches the active seasons list once on mount and labels each entry.
+ * Used by Stats / FanTable / Dashboard pages — they all do the same fetch
+ * with identical mounted-flag protection.
+ */
+export function useActiveSeasons(): ActiveSeasonsResult {
+  const [seasons, setSeasons] = useState<Season[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let mounted = true
+    fetchActiveSeasons()
+      .then((data) => {
+        if (!mounted) return
+        const list = data
+          .map((s) => ({
+            year: s.year,
+            month: s.month,
+            label: getSeasonLabel(s.year, s.month),
+          }))
+          .sort((a, b) => b.year - a.year || b.month - a.month)
+        setSeasons(list)
+      })
+      .catch((e: unknown) => {
+        if (!mounted) return
+        setError(e instanceof Error ? e.message : 'Failed to load seasons')
+      })
+      .finally(() => {
+        if (mounted) setLoading(false)
+      })
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  return { seasons, loading, error }
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1057,6 +1057,10 @@ tr:hover td {
     min-width: 0;
   }
 
+  .dashboard-header {
+    padding: 12px 16px;
+  }
+
   .dashboard-header-actions {
     width: 100%;
     flex-direction: column;
@@ -2304,7 +2308,26 @@ tr:hover td {
   font-size: 0.9rem;
 }
 
+.best-hand-summary-detail {
+  font-size: 0.75rem;
+  margin-top: 4px;
+  color: var(--sol-base01);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Dashboard Header */
+.dashboard-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.dashboard-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+}
+
 .dashboard-header-actions {
   display: flex;
   align-items: center;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1250,8 +1250,11 @@ tr:hover td {
   .quick-win-container {
     margin-bottom: 12px;
   }
+}
 
-  /* Calculator page responsive */
+/* Calculator page uses a wider breakpoint because the dense toggle/wind
+   row needs to compress earlier than the rest of the app. */
+@media (max-width: 768px) {
   .calc-page-wrapper {
     padding: 4px;
   }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -920,6 +920,90 @@ tr:hover td {
   margin-left: 4px;
 }
 
+/* ===== Calculator page ===== */
+.calc-page-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 12px;
+}
+
+.calc-page-wrapper .tabs {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 12px;
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 2px;
+}
+
+.calc-mode-tab-btn {
+  font-size: 1.1rem;
+  font-weight: 700;
+  padding: 10px 24px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-bottom: 4px solid transparent;
+  color: var(--text-muted);
+  transition: all 0.2s ease;
+  margin: 0 4px;
+}
+
+.calc-mode-tab-btn.active {
+  border-bottom-color: var(--primary);
+  color: var(--primary);
+}
+
+.calc-card {
+  padding: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.04);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.compact-toggle-btn {
+  padding: 4px 10px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.compact-toggle-btn.active {
+  background: var(--primary);
+  color: var(--card);
+  border-color: var(--primary);
+}
+
+.compact-toggle-btn-reset {
+  margin-left: auto;
+  background: var(--bg-muted);
+  color: var(--text-muted);
+  border-color: var(--border-muted);
+}
+
+.configs-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+  align-items: center;
+  background: var(--bg-muted);
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.configs-row-section {
+  display: flex;
+  align-items: center;
+}
+
 /* ===== Mobile responsive ===== */
 @media (max-width: 640px) {
   .app-header {
@@ -1161,6 +1245,29 @@ tr:hover td {
 
   .quick-win-container {
     margin-bottom: 12px;
+  }
+
+  /* Calculator page responsive */
+  .calc-page-wrapper {
+    padding: 4px;
+  }
+
+  .calc-mode-tab-btn {
+    font-size: 0.95rem;
+    padding: 8px 14px;
+    margin: 0 2px;
+  }
+
+  .configs-row {
+    gap: 8px;
+    padding: 6px 10px;
+    margin-bottom: 8px;
+  }
+
+  .compact-toggle-btn {
+    padding: 3px 6px;
+    font-size: 0.78rem;
+    border-radius: 4px;
   }
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -548,6 +548,28 @@ tr:hover td {
   margin-bottom: 0;
 }
 
+.text-right {
+  text-align: right;
+}
+
+.num-cell {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.num-cell-rp {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: bold;
+  color: var(--primary);
+}
+
+.config-row-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
 .rank-1 {
   color: var(--mj-gold);
   font-weight: 700;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -936,6 +936,8 @@ tr:hover td {
 }
 
 .calc-mode-tab-btn {
+  flex: 1;
+  text-align: center;
   font-size: 1.1rem;
   font-weight: 700;
   padding: 10px 24px;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -886,13 +886,6 @@ tr:hover td {
   cursor: not-allowed;
 }
 
-.th-subtitle {
-  display: block;
-  font-size: 0.6rem;
-  font-weight: 400;
-  opacity: 0.7;
-}
-
 .rp-bonus {
   color: var(--accent, #ff9800);
   font-weight: 500;
@@ -1070,10 +1063,6 @@ tr:hover td {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .th-subtitle {
-    display: none;
   }
 
   .fan-item-example {
@@ -1610,13 +1599,6 @@ tr:hover td {
   border-radius: 4px;
   color: var(--primary);
   white-space: nowrap;
-}
-
-.use-score-btn {
-  flex: 1;
-  padding: 10px;
-  font-size: 0.95rem;
-  font-weight: 700;
 }
 
 .score-badge.small.badge-error {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -32,10 +32,15 @@
   --primary-light: var(--sol-base01);
   --accent: var(--sol-yellow);
   --bg: var(--sol-base3);
+  --bg-muted: #eaeaea;
   --card: #ffffff;
   --text: var(--sol-base01);
   --text-light: var(--sol-base0);
+  --text-muted: #555;
   --border: var(--sol-base2);
+  --border-muted: #dcdcdc;
+  --rank-silver: #95a5a6;
+  --rank-bronze: #cd7f32;
   --danger: var(--sol-red);
   --success: var(--sol-green);
   --radius: 12px;
@@ -549,12 +554,12 @@ tr:hover td {
 }
 
 .rank-2 {
-  color: #95a5a6;
+  color: var(--rank-silver);
   font-weight: 600;
 }
 
 .rank-3 {
-  color: #cd7f32;
+  color: var(--rank-bronze);
   font-weight: 600;
 }
 

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import { GuobiaoCalculator } from '../components/GuobiaoCalculator'
 import { RiichiCalculator } from '../components/RiichiCalculator'
+import { WindSelectorRow } from '../components/WindSelectorRow'
 
 type GameMode = 'GUOBIAO' | 'RIICHI'
 
@@ -19,29 +20,8 @@ const CalculatorPage: React.FC = () => {
   const [riichiZifeng, setRiichiZifeng] = useState(1)
   const [riichiResetTrigger, setRiichiResetTrigger] = useState(0)
 
-  // Reset callbacks
-  const handleGbReset = useCallback(() => {
-    setGbResetTrigger((prev) => prev + 1)
-  }, [])
-
-  const handleRiichiReset = useCallback(() => {
-    setRiichiResetTrigger((prev) => prev + 1)
-  }, [])
-
-  const getWindName = (val: number) => {
-    switch (val) {
-      case 1:
-        return '东'
-      case 2:
-        return '南'
-      case 3:
-        return '西'
-      case 4:
-        return '北'
-      default:
-        return '东'
-    }
-  }
+  const handleGbReset = useCallback(() => setGbResetTrigger((p) => p + 1), [])
+  const handleRiichiReset = useCallback(() => setRiichiResetTrigger((p) => p + 1), [])
 
   // Dummy callback since direct output is rendered internally by the components
   const handleSelectScore = () => {}
@@ -82,30 +62,8 @@ const CalculatorPage: React.FC = () => {
                   自摸
                 </button>
               </div>
-              <div className="configs-row-section" style={{ gap: 4 }}>
-                <span className="config-row-label">圈风:</span>
-                {[1, 2, 3, 4].map((w) => (
-                  <button
-                    key={w}
-                    className={`compact-toggle-btn ${gbQuanfeng === w ? 'active' : ''}`}
-                    onClick={() => setGbQuanfeng(w)}
-                  >
-                    {getWindName(w)}
-                  </button>
-                ))}
-              </div>
-              <div className="configs-row-section" style={{ gap: 4 }}>
-                <span className="config-row-label">门风:</span>
-                {[1, 2, 3, 4].map((w) => (
-                  <button
-                    key={w}
-                    className={`compact-toggle-btn ${gbMenfeng === w ? 'active' : ''}`}
-                    onClick={() => setGbMenfeng(w)}
-                  >
-                    {getWindName(w)}
-                  </button>
-                ))}
-              </div>
+              <WindSelectorRow label="圈风" value={gbQuanfeng} onChange={setGbQuanfeng} />
+              <WindSelectorRow label="门风" value={gbMenfeng} onChange={setGbMenfeng} />
               <button className="compact-toggle-btn compact-toggle-btn-reset" onClick={handleGbReset}>
                 清空
               </button>
@@ -141,30 +99,8 @@ const CalculatorPage: React.FC = () => {
                   自摸
                 </button>
               </div>
-              <div className="configs-row-section" style={{ gap: 4 }}>
-                <span className="config-row-label">场风:</span>
-                {[1, 2, 3, 4].map((w) => (
-                  <button
-                    key={w}
-                    className={`compact-toggle-btn ${riichiChangfeng === w ? 'active' : ''}`}
-                    onClick={() => setRiichiChangfeng(w)}
-                  >
-                    {getWindName(w)}
-                  </button>
-                ))}
-              </div>
-              <div className="configs-row-section" style={{ gap: 4 }}>
-                <span className="config-row-label">自风:</span>
-                {[1, 2, 3, 4].map((w) => (
-                  <button
-                    key={w}
-                    className={`compact-toggle-btn ${riichiZifeng === w ? 'active' : ''}`}
-                    onClick={() => setRiichiZifeng(w)}
-                  >
-                    {getWindName(w)}
-                  </button>
-                ))}
-              </div>
+              <WindSelectorRow label="场风" value={riichiChangfeng} onChange={setRiichiChangfeng} />
+              <WindSelectorRow label="自风" value={riichiZifeng} onChange={setRiichiZifeng} />
               <button className="compact-toggle-btn compact-toggle-btn-reset" onClick={handleRiichiReset}>
                 清空
               </button>

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -12,7 +12,7 @@ const CalculatorPage: React.FC = () => {
   const [gbIsSelfDraw, setGbIsSelfDraw] = useState(false)
   const [gbQuanfeng, setGbQuanfeng] = useState(1)
   const [gbMenfeng, setGbMenfeng] = useState(1)
-  const [gbResetTrigger, setGbResetTrigger] = useState(0)
+  const [gbResetTrigger,  setGbResetTrigger] = useState(0)
 
   // Standalone state for Riichi
   const [riichiIsSelfDraw, setRiichiIsSelfDraw] = useState(false)

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -212,7 +212,7 @@ const CalculatorPage: React.FC = () => {
               </div>
               <button
                 className="compact-toggle-btn"
-                style={{ marginLeft: 'auto', background: '#eaeaea', color: '#555', borderColor: '#dcdcdc' }}
+                style={{ marginLeft: 'auto', background: 'var(--bg-muted)', color: 'var(--text-muted)', borderColor: 'var(--border-muted)' }}
                 onClick={handleGbReset}
               >
                 清空
@@ -277,7 +277,7 @@ const CalculatorPage: React.FC = () => {
               </div>
               <button
                 className="compact-toggle-btn"
-                style={{ marginLeft: 'auto', background: '#eaeaea', color: '#555', borderColor: '#dcdcdc' }}
+                style={{ marginLeft: 'auto', background: 'var(--bg-muted)', color: 'var(--text-muted)', borderColor: 'var(--border-muted)' }}
                 onClick={handleRiichiReset}
               >
                 清空

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -114,9 +114,9 @@ const CalculatorPage: React.FC = () => {
         style={{
           display: 'flex',
           justifyContent: 'center',
-          marginBottom: '12px',
+          marginBottom: 12,
           borderBottom: '2px solid var(--border)',
-          paddingBottom: '2px',
+          paddingBottom: 2,
         }}
       >
         <button
@@ -172,7 +172,7 @@ const CalculatorPage: React.FC = () => {
             {/* Super Compact Configurations Row */}
             <div className="configs-row">
               <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-muted)' }}>和牌:</span>
+                <span className="config-row-label">和牌:</span>
                 <button
                   className={`compact-toggle-btn ${!gbIsSelfDraw ? 'active' : ''}`}
                   onClick={() => setGbIsSelfDraw(false)}
@@ -187,7 +187,7 @@ const CalculatorPage: React.FC = () => {
                 </button>
               </div>
               <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-muted)' }}>圈风:</span>
+                <span className="config-row-label">圈风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
                     key={w}
@@ -199,7 +199,7 @@ const CalculatorPage: React.FC = () => {
                 ))}
               </div>
               <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-muted)' }}>门风:</span>
+                <span className="config-row-label">门风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
                     key={w}
@@ -237,7 +237,7 @@ const CalculatorPage: React.FC = () => {
             {/* Super Compact Configurations Row */}
             <div className="configs-row">
               <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-muted)' }}>和牌:</span>
+                <span className="config-row-label">和牌:</span>
                 <button
                   className={`compact-toggle-btn ${!riichiIsSelfDraw ? 'active' : ''}`}
                   onClick={() => setRiichiIsSelfDraw(false)}
@@ -252,7 +252,7 @@ const CalculatorPage: React.FC = () => {
                 </button>
               </div>
               <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-muted)' }}>场风:</span>
+                <span className="config-row-label">场风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
                     key={w}
@@ -264,7 +264,7 @@ const CalculatorPage: React.FC = () => {
                 ))}
               </div>
               <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-muted)' }}>自风:</span>
+                <span className="config-row-label">自风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
                     key={w}

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -20,8 +20,19 @@ const CalculatorPage: React.FC = () => {
   const [riichiZifeng, setRiichiZifeng] = useState(1)
   const [riichiResetTrigger, setRiichiResetTrigger] = useState(0)
 
-  const handleGbReset = useCallback(() => setGbResetTrigger((p) => p + 1), [])
-  const handleRiichiReset = useCallback(() => setRiichiResetTrigger((p) => p + 1), [])
+  const handleGbReset = useCallback(() => {
+    setGbIsSelfDraw(false)
+    setGbQuanfeng(1)
+    setGbMenfeng(1)
+    setGbResetTrigger((p) => p + 1)
+  }, [])
+
+  const handleRiichiReset = useCallback(() => {
+    setRiichiIsSelfDraw(false)
+    setRiichiChangfeng(1)
+    setRiichiZifeng(1)
+    setRiichiResetTrigger((p) => p + 1)
+  }, [])
 
   // Dummy callback since direct output is rendered internally by the components
   const handleSelectScore = () => {}

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -47,131 +47,27 @@ const CalculatorPage: React.FC = () => {
   const handleSelectScore = () => {}
 
   return (
-    <div className="container calc-page-wrapper" style={{ maxWidth: '800px', margin: '0 auto', padding: '12px' }}>
-      {/* Premium Compact Styles */}
-      <style>{`
-        .compact-toggle-btn {
-          padding: 4px 10px;
-          font-size: 0.82rem;
-          font-weight: 700;
-          border: 1px solid var(--border);
-          background: #fff;
-          border-radius: 6px;
-          cursor: pointer;
-          transition: all 0.15s ease;
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-        }
-        .compact-toggle-btn.active {
-          background: var(--primary);
-          color: #fff;
-          border-color: var(--primary);
-        }
-        .configs-row {
-          display: flex;
-          gap: 12px;
-          flex-wrap: wrap;
-          margin-bottom: 12px;
-          align-items: center;
-          background: var(--bg-muted);
-          padding: 8px 12px;
-          border-radius: 8px;
-          border: 1px solid var(--border);
-        }
-
-        @media (max-width: 768px) {
-          .calc-page-wrapper {
-            padding: 4px !important;
-          }
-          .tab-btn {
-            font-size: 0.95rem !important;
-            padding: 8px 14px !important;
-            margin: 0 2px !important;
-          }
-          .configs-row {
-            gap: 8px !important;
-            padding: 6px 10px !important;
-            margin-bottom: 8px !important;
-          }
-          .compact-toggle-btn {
-            padding: 3px 6px !important;
-            font-size: 0.78rem !important;
-            border-radius: 4px !important;
-          }
-          .configs-row-section {
-            gap: 4px !important;
-          }
-          .card {
-            padding: 10px !important;
-          }
-        }
-      `}</style>
-
-      {/* Mode Tabs */}
-      <div
-        className="tabs"
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          marginBottom: 12,
-          borderBottom: '2px solid var(--border)',
-          paddingBottom: 2,
-        }}
-      >
+    <div className="container calc-page-wrapper">
+      <div className="tabs">
         <button
-          className={`tab-btn ${activeTab === 'GUOBIAO' ? 'active' : ''}`}
+          className={`calc-mode-tab-btn ${activeTab === 'GUOBIAO' ? 'active' : ''}`}
           onClick={() => setActiveTab('GUOBIAO')}
-          style={{
-            fontSize: '1.1rem',
-            fontWeight: 700,
-            padding: '10px 24px',
-            border: 'none',
-            background: 'none',
-            cursor: 'pointer',
-            borderBottom: activeTab === 'GUOBIAO' ? '4px solid var(--primary)' : '4px solid transparent',
-            color: activeTab === 'GUOBIAO' ? 'var(--primary)' : 'var(--text-muted)',
-            transition: 'all 0.2s ease',
-            margin: '0 4px',
-          }}
         >
           国标算番器
         </button>
         <button
-          className={`tab-btn ${activeTab === 'RIICHI' ? 'active' : ''}`}
+          className={`calc-mode-tab-btn ${activeTab === 'RIICHI' ? 'active' : ''}`}
           onClick={() => setActiveTab('RIICHI')}
-          style={{
-            fontSize: '1.1rem',
-            fontWeight: 700,
-            padding: '10px 24px',
-            border: 'none',
-            background: 'none',
-            cursor: 'pointer',
-            borderBottom: activeTab === 'RIICHI' ? '4px solid var(--primary)' : '4px solid transparent',
-            color: activeTab === 'RIICHI' ? 'var(--primary)' : 'var(--text-muted)',
-            transition: 'all 0.2s ease',
-            margin: '0 4px',
-          }}
         >
           立直算番器
         </button>
       </div>
 
-      {/* Main Container Card */}
-      <div
-        className="card"
-        style={{
-          padding: '16px',
-          boxShadow: '0 4px 20px rgba(0,0,0,0.04)',
-          borderRadius: '12px',
-          border: '1px solid var(--border)',
-        }}
-      >
+      <div className="card calc-card">
         {activeTab === 'GUOBIAO' ? (
           <div>
-            {/* Super Compact Configurations Row */}
             <div className="configs-row">
-              <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+              <div className="configs-row-section" style={{ gap: 6 }}>
                 <span className="config-row-label">和牌:</span>
                 <button
                   className={`compact-toggle-btn ${!gbIsSelfDraw ? 'active' : ''}`}
@@ -186,7 +82,7 @@ const CalculatorPage: React.FC = () => {
                   自摸
                 </button>
               </div>
-              <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <div className="configs-row-section" style={{ gap: 4 }}>
                 <span className="config-row-label">圈风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
@@ -198,7 +94,7 @@ const CalculatorPage: React.FC = () => {
                   </button>
                 ))}
               </div>
-              <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <div className="configs-row-section" style={{ gap: 4 }}>
                 <span className="config-row-label">门风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
@@ -210,16 +106,11 @@ const CalculatorPage: React.FC = () => {
                   </button>
                 ))}
               </div>
-              <button
-                className="compact-toggle-btn"
-                style={{ marginLeft: 'auto', background: 'var(--bg-muted)', color: 'var(--text-muted)', borderColor: 'var(--border-muted)' }}
-                onClick={handleGbReset}
-              >
+              <button className="compact-toggle-btn compact-toggle-btn-reset" onClick={handleGbReset}>
                 清空
               </button>
             </div>
 
-            {/* In-game Core Calculator Component */}
             <GuobiaoCalculator
               key={`gb-calc-${gbResetTrigger}`}
               onSelectScore={handleSelectScore}
@@ -234,9 +125,8 @@ const CalculatorPage: React.FC = () => {
           </div>
         ) : (
           <div>
-            {/* Super Compact Configurations Row */}
             <div className="configs-row">
-              <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+              <div className="configs-row-section" style={{ gap: 6 }}>
                 <span className="config-row-label">和牌:</span>
                 <button
                   className={`compact-toggle-btn ${!riichiIsSelfDraw ? 'active' : ''}`}
@@ -251,7 +141,7 @@ const CalculatorPage: React.FC = () => {
                   自摸
                 </button>
               </div>
-              <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <div className="configs-row-section" style={{ gap: 4 }}>
                 <span className="config-row-label">场风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
@@ -263,7 +153,7 @@ const CalculatorPage: React.FC = () => {
                   </button>
                 ))}
               </div>
-              <div className="configs-row-section" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <div className="configs-row-section" style={{ gap: 4 }}>
                 <span className="config-row-label">自风:</span>
                 {[1, 2, 3, 4].map((w) => (
                   <button
@@ -275,16 +165,11 @@ const CalculatorPage: React.FC = () => {
                   </button>
                 ))}
               </div>
-              <button
-                className="compact-toggle-btn"
-                style={{ marginLeft: 'auto', background: 'var(--bg-muted)', color: 'var(--text-muted)', borderColor: 'var(--border-muted)' }}
-                onClick={handleRiichiReset}
-              >
+              <button className="compact-toggle-btn compact-toggle-btn-reset" onClick={handleRiichiReset}>
                 清空
               </button>
             </div>
 
-            {/* In-game Core Calculator Component */}
             <RiichiCalculator
               key={`riichi-calc-${riichiResetTrigger}`}
               onSelectScore={handleSelectScore}

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -12,7 +12,7 @@ const CalculatorPage: React.FC = () => {
   const [gbIsSelfDraw, setGbIsSelfDraw] = useState(false)
   const [gbQuanfeng, setGbQuanfeng] = useState(1)
   const [gbMenfeng, setGbMenfeng] = useState(1)
-  const [gbResetTrigger,  setGbResetTrigger] = useState(0)
+  const [gbResetTrigger, setGbResetTrigger] = useState(0)
 
   // Standalone state for Riichi
   const [riichiIsSelfDraw, setRiichiIsSelfDraw] = useState(false)

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { GameSession, Season, getCurrentSeason, getSeasonLabel } from '../types'
-import { fetchSessions, fetchActiveSeasons } from '../api'
+import { GameSession } from '../types'
+import { fetchSessions } from '../api'
 import { GameCard } from '../components/GameCard'
 import { MSG } from '../constants'
+import { parseError } from '../utils/format'
+import { useActiveSeasons } from '../hooks/useActiveSeasons'
 
 export default function DashboardPage() {
   const [sessions, setSessions] = useState<GameSession[]>([])
-  const [seasons, setSeasons] = useState<Season[]>([])
+  const { seasons } = useActiveSeasons()
   const [seasonKey, setSeasonKey] = useState<string>('all')
   const [currentPage, setCurrentPage] = useState(1)
   const pageSize = 10
@@ -23,22 +25,10 @@ export default function DashboardPage() {
       .then((sData) => {
         if (!mounted) return
         setSessions(sData)
-        // If sessions load successfully, we can already stop the main loading spinner
-        // once we also try to get the seasons.
-        return fetchActiveSeasons()
-      })
-      .then((seasonsData) => {
-        if (!mounted || !seasonsData) return
-        const list = seasonsData.map((s) => ({
-          year: s.year,
-          month: s.month,
-          label: getSeasonLabel(s.year, s.month),
-        }))
-        setSeasons(list)
       })
       .catch((e: unknown) => {
         if (!mounted) return
-        setError(e instanceof Error ? e.message : MSG.ERROR)
+        setError(parseError(e))
       })
       .finally(() => {
         if (mounted) setLoading(false)

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -88,11 +88,8 @@ export default function DashboardPage() {
     )
 
   return (
-    <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-      <div
-        className="flex-between dashboard-header"
-        style={{ padding: '16px 24px', borderBottom: '1px solid var(--border)' }}
-      >
+    <div className="card dashboard-card">
+      <div className="flex-between dashboard-header">
         <h2 style={{ margin: 0, whiteSpace: 'nowrap' }}>历史对局</h2>
         <div className="dashboard-header-actions">
           <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -163,21 +163,12 @@ const FanTablePage: React.FC = () => {
             ))}
           </div>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: 24,
-            flexWrap: 'wrap',
-            gap: '12px',
-          }}
-        >
+        <div className="flex-between" style={{ marginBottom: 24, flexWrap: 'wrap' }}>
           <p className="page-subtitle" style={{ marginBottom: 0 }}>
             {activeMode.fanTableSubtitle}
           </p>
           {activeTab === 'GUOBIAO' && (
-            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
               <a
                 href="/guobiao-rules-2014-cn.pdf"
                 target="_blank"

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -36,7 +36,9 @@ const FanTablePage: React.FC = () => {
   // Snap seasonKey to the first available season once seasons load.
   useEffect(() => {
     if (seasons.length === 0) return
-    setSeasonKey((prev) => (seasons.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${seasons[0].year}-${seasons[0].month}`))
+    setSeasonKey((prev) =>
+      seasons.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${seasons[0].year}-${seasons[0].month}`
+    )
   }, [seasons])
 
   // Load selected season discoveries

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -2,10 +2,11 @@ import React, { useState, useMemo, useEffect } from 'react'
 import { fanTableData, FanItem } from '../data/fanTableData'
 import { riichiFanTableData } from '../data/riichiFanTableData'
 import { shenyangFanTableData } from '../data/shenyangFanTableData'
-import { fetchFanDiscoveries, fetchActiveSeasons } from '../api'
-import { FanDiscovery, getCurrentSeason, getSeasonLabel, Season, GAME_MODES, GameModeKey } from '../types'
+import { fetchFanDiscoveries } from '../api'
+import { FanDiscovery, getCurrentSeason, GAME_MODES, GameModeKey } from '../types'
 import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
+import { useActiveSeasons } from '../hooks/useActiveSeasons'
 
 const TAB_DATA_MAP: Record<GameModeKey, { data: () => FanItem[] }> = {
   GUOBIAO: { data: () => fanTableData },
@@ -22,37 +23,14 @@ const FanTablePage: React.FC = () => {
   const [discoveries, setDiscoveries] = useState<FanDiscovery[]>([])
   // Previous season discoveries (fallback when current season has no record yet)
   const [prevDiscoveries, setPrevDiscoveries] = useState<FanDiscovery[]>([])
-  const [seasons, setSeasons] = useState<Season[]>([])
+  const { seasons } = useActiveSeasons()
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.month}`)
 
-  // Load active seasons from backend (same as StatsPage)
+  // Snap seasonKey to the first available season once seasons load.
   useEffect(() => {
-    let mounted = true
-    fetchActiveSeasons()
-      .then((data) => {
-        if (!mounted) return
-        const list = data
-          .map((s) => ({
-            year: s.year,
-            month: s.month,
-            label: getSeasonLabel(s.year, s.month),
-          }))
-          .sort((a, b) => b.year - a.year || b.month - a.month)
-        setSeasons(list)
-        if (list.length > 0) {
-          setSeasonKey((prev) =>
-            list.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${list[0].year}-${list[0].month}`
-          )
-        }
-      })
-      .catch((e: unknown) => {
-        if (!mounted) return
-        console.error(e)
-      })
-    return () => {
-      mounted = false
-    }
-  }, [])
+    if (seasons.length === 0) return
+    setSeasonKey((prev) => (seasons.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${seasons[0].year}-${seasons[0].month}`))
+  }, [seasons])
 
   // Load selected season discoveries
   useEffect(() => {
@@ -235,7 +213,7 @@ const FanTablePage: React.FC = () => {
           />
           {activeTab === 'GUOBIAO' && seasons.length > 0 && (
             <select value={seasonKey} onChange={(e) => setSeasonKey(e.target.value)} className="select-inline">
-              {seasons.map((s: Season) => (
+              {seasons.map((s) => (
                 <option key={`${s.year}-${s.month}`} value={`${s.year}-${s.month}`}>
                   {s.label}
                 </option>

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -16,11 +16,17 @@ const TAB_DATA_MAP: Record<GameModeKey, { data: () => FanItem[] }> = {
 
 const currentSeason = getCurrentSeason()
 
-function keyDiscoveriesByMostRecent(discoveries: FanDiscovery[]): Record<string, FanDiscovery> {
-  const sorted = [...discoveries].sort(
-    (a, b) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime()
-  )
-  return Object.fromEntries(sorted.map((d) => [d.fanName, d]))
+// Group discoveries by fanName, keeping the earliest record per fan
+// (= the first player to achieve that fan = the "首位达成者" / champion).
+function keyDiscoveriesByEarliest(discoveries: FanDiscovery[]): Record<string, FanDiscovery> {
+  const result: Record<string, FanDiscovery> = {}
+  for (const d of discoveries) {
+    const existing = result[d.fanName]
+    if (!existing || new Date(d.discoveredAt).getTime() < new Date(existing.discoveredAt).getTime()) {
+      result[d.fanName] = d
+    }
+  }
+  return result
 }
 
 const FanTablePage: React.FC = () => {
@@ -88,8 +94,8 @@ const FanTablePage: React.FC = () => {
     return () => controller.abort()
   }, [seasonKey, seasons])
 
-  const discoveriesMap = useMemo(() => keyDiscoveriesByMostRecent(discoveries), [discoveries])
-  const prevDiscoveriesMap = useMemo(() => keyDiscoveriesByMostRecent(prevDiscoveries), [prevDiscoveries])
+  const discoveriesMap = useMemo(() => keyDiscoveriesByEarliest(discoveries), [discoveries])
+  const prevDiscoveriesMap = useMemo(() => keyDiscoveriesByEarliest(prevDiscoveries), [prevDiscoveries])
 
   const filteredFanTable = useMemo(() => {
     const data = TAB_DATA_MAP[activeTab].data()

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -16,6 +16,13 @@ const TAB_DATA_MAP: Record<GameModeKey, { data: () => FanItem[] }> = {
 
 const currentSeason = getCurrentSeason()
 
+function keyDiscoveriesByMostRecent(discoveries: FanDiscovery[]): Record<string, FanDiscovery> {
+  const sorted = [...discoveries].sort(
+    (a, b) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime()
+  )
+  return Object.fromEntries(sorted.map((d) => [d.fanName, d]))
+}
+
 const FanTablePage: React.FC = () => {
   const [search, setSearch] = useState('')
   const [activeTab, setActiveTab] = useState<GameModeKey>('GUOBIAO')
@@ -79,18 +86,8 @@ const FanTablePage: React.FC = () => {
     return () => controller.abort()
   }, [seasonKey, seasons])
 
-  const discoveriesMap = useMemo(() => {
-    const sorted = [...discoveries].sort(
-      (a, b) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime()
-    )
-    return Object.fromEntries(sorted.map((d) => [d.fanName, d]))
-  }, [discoveries])
-  const prevDiscoveriesMap = useMemo(() => {
-    const sorted = [...prevDiscoveries].sort(
-      (a, b) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime()
-    )
-    return Object.fromEntries(sorted.map((d) => [d.fanName, d]))
-  }, [prevDiscoveries])
+  const discoveriesMap = useMemo(() => keyDiscoveriesByMostRecent(discoveries), [discoveries])
+  const prevDiscoveriesMap = useMemo(() => keyDiscoveriesByMostRecent(prevDiscoveries), [prevDiscoveries])
 
   const filteredFanTable = useMemo(() => {
     const data = TAB_DATA_MAP[activeTab].data()

--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -174,7 +174,7 @@ const FanTablePage: React.FC = () => {
   return (
     <div className="fan-table-page">
       <div className="card">
-        <div className="flex-between" style={{ marginBottom: '16px' }}>
+        <div className="flex-between" style={{ marginBottom: 16 }}>
           <h2>{activeMode.fanTableTitle}</h2>
           <div className="tab-bar">
             {GAME_MODES.map((m) => (
@@ -193,7 +193,7 @@ const FanTablePage: React.FC = () => {
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            marginBottom: '24px',
+            marginBottom: 24,
             flexWrap: 'wrap',
             gap: '12px',
           }}

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -91,7 +91,7 @@ export default function HomePage() {
       </div>
 
       <div className="card active-games-section">
-        <h2 style={{ marginBottom: '16px' }}>正在进行的对局</h2>
+        <h2 style={{ marginBottom: 16 }}>正在进行的对局</h2>
         {activeSessions.length === 0 ? (
           <div className="empty-state">
             <p>当前没有正在进行的对局</p>
@@ -133,7 +133,7 @@ export default function HomePage() {
       </div>
 
       <div className="card rankings-section">
-        <h2 style={{ marginBottom: '16px' }}>本月荣誉殿堂</h2>
+        <h2 style={{ marginBottom: 16 }}>本月荣誉殿堂</h2>
         <div className="hall-of-fame-grid">
           {GAME_MODES.map((mode) => {
             const data = rankings[mode.key]

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -162,18 +162,7 @@ export default function HomePage() {
                     <span className="best-hand-label">🏆 本月最高和牌</span>
                     <div className="best-hand-value">
                       {data.best.fanCount} 番 · {data.best.winnerName}
-                      <div
-                        style={{
-                          fontSize: '0.75rem',
-                          marginTop: '4px',
-                          color: 'var(--sol-base01)',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {data.best.fanDetails}
-                      </div>
+                      <div className="best-hand-summary-detail">{data.best.fanDetails}</div>
                     </div>
                   </div>
                 )}

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -4,7 +4,7 @@ import { fetchPlayers, createSession } from '../api'
 import { Player, GameModeKey, GAME_MODES } from '../types'
 import { cardFontSize } from '../utils/fontSize'
 import { MSG } from '../constants'
-import { abbrName } from '../utils/format'
+import { abbrName, parseError } from '../utils/format'
 
 const MIN_PLAYERS = 3
 const MAX_PLAYERS = 4
@@ -25,7 +25,7 @@ export default function NewSessionPage() {
         setPlayers(p)
         setLoaded(true)
       })
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : MSG.ERROR))
+      .catch((e: unknown) => setError(parseError(e)))
   }, [])
 
   const togglePlayer = (id: number) => {
@@ -69,7 +69,7 @@ export default function NewSessionPage() {
       const session = await createSession(defaultName, gameMode, selectedIds)
       navigate(`/session/${session.id}`)
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : MSG.ERROR)
+      setError(parseError(e))
       setCreating(false)
     }
   }

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -97,24 +97,13 @@ export default function NewSessionPage() {
       </div>
 
       <div className="form-group">
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            gap: 8,
-            marginBottom: 12,
-          }}
-        >
-          <label style={{ margin: 0 }}>
-            选择玩家{' '}
-            <span style={{ fontSize: '0.8rem', color: 'var(--accent)', fontWeight: 'normal' }}>
-              (请按照东南西北顺序点击玩家)
-            </span>{' '}
-            (已选 {selectedIds.length}/{MIN_PLAYERS}-{MAX_PLAYERS})
-          </label>
-        </div>
+        <label style={{ display: 'block', marginBottom: 12 }}>
+          选择玩家{' '}
+          <span style={{ fontSize: '0.8rem', color: 'var(--accent)', fontWeight: 'normal' }}>
+            (请按照东南西北顺序点击玩家)
+          </span>{' '}
+          (已选 {selectedIds.length}/{MIN_PLAYERS}-{MAX_PLAYERS})
+        </label>
 
         {players.length > 0 && (
           <div className="filter-bar">

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -97,13 +97,13 @@ export default function NewSessionPage() {
       </div>
 
       <div className="form-group">
-        <label style={{ display: 'block', marginBottom: 12 }}>
+        <div style={{ display: 'block', marginBottom: 12 }}>
           选择玩家{' '}
           <span style={{ fontSize: '0.8rem', color: 'var(--accent)', fontWeight: 'normal' }}>
             (请按照东南西北顺序点击玩家)
           </span>{' '}
           (已选 {selectedIds.length}/{MIN_PLAYERS}-{MAX_PLAYERS})
-        </label>
+        </div>
 
         {players.length > 0 && (
           <div className="filter-bar">

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -62,7 +62,7 @@ export default function PlayerDetailPage() {
                   <th>模式</th>
                   <th>日期</th>
                   <th>状态</th>
-                  <th style={{ textAlign: 'right' }}>分数</th>
+                  <th className="text-right">分数</th>
                 </tr>
               </thead>
               <tbody>
@@ -80,13 +80,7 @@ export default function PlayerDetailPage() {
                         {g.status === 'IN_PROGRESS' ? '进行中' : '已结束'}
                       </span>
                     </td>
-                    <td
-                      className={`${scoreClass(g.totalScore)}`}
-                      style={{
-                        textAlign: 'right',
-                        fontVariantNumeric: 'tabular-nums',
-                      }}
-                    >
+                    <td className={`${scoreClass(g.totalScore)} num-cell`}>
                       {g.totalScore > 0 ? `+${g.totalScore}` : g.totalScore}
                     </td>
                   </tr>

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { fetchPlayerDetail } from '../api'
 import { PlayerDetail } from '../types'
-import { abbrName, scoreClass } from '../utils/format'
+import { abbrName, scoreClass, parseError } from '../utils/format'
 import { MSG } from '../constants'
 
 export default function PlayerDetailPage() {
@@ -22,7 +22,7 @@ export default function PlayerDetailPage() {
         setLoading(false)
       })
       .catch((e: unknown) => {
-        setError(e instanceof Error ? e.message : MSG.ERROR)
+        setError(parseError(e))
         setLoading(false)
       })
   }, [id])

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -55,7 +55,7 @@ export default function PlayerDetailPage() {
           </div>
         ) : (
           <div className="score-table">
-            <table style={{ minWidth: 340 }}>
+            <table>
               <thead>
                 <tr>
                   <th>游戏</th>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -757,7 +757,7 @@ export default function SessionPage() {
       <div className="card">
         <div className="flex-between" style={{ marginBottom: 16 }}>
           <h2 style={{ marginBottom: 0 }}>计分板</h2>
-          <div style={{ textAlign: 'right', display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
             <span className="session-meta" style={{ margin: 0, fontSize: '0.85rem' }}>
               {session.gameModeDisplayName} &middot;{' '}
               {new Date(session.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
@@ -909,8 +909,8 @@ export default function SessionPage() {
                 <tr>
                   <th>名次</th>
                   <th>玩家</th>
-                  <th style={{ textAlign: 'right' }}>分数</th>
-                  <th style={{ textAlign: 'right' }}>积分(RP)</th>
+                  <th className="text-right">分数</th>
+                  <th className="text-right">积分(RP)</th>
                 </tr>
               </thead>
               <tbody>
@@ -925,23 +925,10 @@ export default function SessionPage() {
                         <span className={`rank-tag rank-tag-${rank}`}>#{rank}</span>
                       </td>
                       <td>{p.userName}</td>
-                      <td
-                        className={scoreClass(val)}
-                        style={{
-                          textAlign: 'right',
-                          fontVariantNumeric: 'tabular-nums',
-                        }}
-                      >
+                      <td className={`${scoreClass(val)} num-cell`}>
                         {val > 0 ? `+${val}` : val}
                       </td>
-                      <td
-                        style={{
-                          textAlign: 'right',
-                          fontVariantNumeric: 'tabular-nums',
-                          fontWeight: 'bold',
-                          color: 'var(--primary)',
-                        }}
-                      >
+                      <td className="num-cell-rp">
                         {baseRp > 0 ? `+${baseRp.toFixed(1)}` : baseRp.toFixed(1)}
                         {bonus > 0 && <span className="rp-bonus">(+{bonus.toFixed(bonus % 1 === 0 ? 0 : 1)})</span>}
                       </td>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -8,7 +8,7 @@ import { RiichiCalculator } from '../components/RiichiCalculator'
 import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
 import { deriveGameState, deriveRoundState, getWindName } from '../utils/gameState'
-import { scoreClass } from '../utils/format'
+import { scoreClass, parseError } from '../utils/format'
 import { MSG } from '../constants'
 
 export default function SessionPage() {
@@ -80,7 +80,7 @@ export default function SessionPage() {
   }
 
   useEffect(() => {
-    load().catch((e: unknown) => setError(e instanceof Error ? e.message : MSG.ERROR))
+    load().catch((e: unknown) => setError(parseError(e)))
   }, [id])
 
   if (!session)
@@ -220,7 +220,7 @@ export default function SessionPage() {
       resetForm()
       await load()
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : MSG.ERROR)
+      setError(parseError(e))
     } finally {
       setSubmitting(false)
     }
@@ -234,7 +234,7 @@ export default function SessionPage() {
       await deleteRound(session.id, roundNumber)
       await load()
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : MSG.ERROR)
+      setError(parseError(e))
     } finally {
       setSubmitting(false)
     }
@@ -248,7 +248,7 @@ export default function SessionPage() {
       await completeSession(session.id)
       await load()
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : MSG.ERROR)
+      setError(parseError(e))
     } finally {
       setSubmitting(false)
     }

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -925,9 +925,7 @@ export default function SessionPage() {
                         <span className={`rank-tag rank-tag-${rank}`}>#{rank}</span>
                       </td>
                       <td>{p.userName}</td>
-                      <td className={`${scoreClass(val)} num-cell`}>
-                        {val > 0 ? `+${val}` : val}
-                      </td>
+                      <td className={`${scoreClass(val)} num-cell`}>{val > 0 ? `+${val}` : val}</td>
                       <td className="num-cell-rp">
                         {baseRp > 0 ? `+${baseRp.toFixed(1)}` : baseRp.toFixed(1)}
                         {bonus > 0 && <span className="rp-bonus">(+{bonus.toFixed(bonus % 1 === 0 ? 0 : 1)})</span>}

--- a/ui/src/pages/SignUpPage.tsx
+++ b/ui/src/pages/SignUpPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { createPlayer, checkUserName } from '../api'
-import { MSG } from '../constants'
+import { parseError } from '../utils/format'
 
 export default function SignUpPage() {
   const navigate = useNavigate()
@@ -56,7 +56,7 @@ export default function SignUpPage() {
       await createPlayer(userName.trim(), firstName.trim(), lastName.trim())
       navigate('/')
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : MSG.ERROR)
+      setError(parseError(err))
       setSubmitting(false)
     }
   }

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -254,9 +254,9 @@ export default function StatsPage() {
                     <tr>
                       <th>名次</th>
                       <th>玩家</th>
-                      <th style={{ textAlign: 'right' }}>场次</th>
-                      <th style={{ textAlign: 'right' }}>胜场</th>
-                      <th style={{ textAlign: 'right' }}>积分(RP)</th>
+                      <th className="text-right">场次</th>
+                      <th className="text-right">胜场</th>
+                      <th className="text-right">积分(RP)</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -271,16 +271,9 @@ export default function StatsPage() {
                           {s.userName}
                           <span className="table-username">{abbr(s)}</span>
                         </td>
-                        <td style={{ textAlign: 'right' }}>{s.gamesPlayed}</td>
-                        <td style={{ textAlign: 'right' }}>{s.wins}</td>
-                        <td
-                          style={{
-                            textAlign: 'right',
-                            fontVariantNumeric: 'tabular-nums',
-                            fontWeight: 'bold',
-                            color: 'var(--primary)',
-                          }}
-                        >
+                        <td className="text-right">{s.gamesPlayed}</td>
+                        <td className="text-right">{s.wins}</td>
+                        <td className="num-cell-rp">
                           {s.totalRP > 0 ? `+${s.totalRP.toFixed(1)}` : s.totalRP.toFixed(1)}
                         </td>
                       </tr>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -76,10 +76,6 @@ export default function StatsPage() {
   }, [seasons])
 
   useEffect(() => {
-    if (seasonsError) setError(seasonsError)
-  }, [seasonsError])
-
-  useEffect(() => {
     if (tab === 'games') {
       loadStats(gameMode, seasonKey)
     } else {
@@ -136,10 +132,10 @@ export default function StatsPage() {
         <p>{MSG.LOADING}</p>
       </div>
     )
-  if (error)
+  if (error || seasonsError)
     return (
       <div className="empty-state">
-        <p>{error}</p>
+        <p>{error || seasonsError}</p>
       </div>
     )
 

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -70,7 +70,9 @@ export default function StatsPage() {
   // unless the current selection is still valid.
   useEffect(() => {
     if (seasons.length === 0) return
-    setSeasonKey((prev) => (seasons.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${seasons[0].year}-${seasons[0].month}`))
+    setSeasonKey((prev) =>
+      seasons.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${seasons[0].year}-${seasons[0].month}`
+    )
   }, [seasons])
 
   useEffect(() => {

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -1,16 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams, Link } from 'react-router-dom'
-import {
-  PlayerStats,
-  Player,
-  GameModeKey,
-  GAME_MODES,
-  Season,
-  getCurrentSeason,
-  getSeasonLabel,
-  BestRound,
-} from '../types'
-import { fetchStats, fetchPlayers, fetchBestRounds, fetchActiveSeasons } from '../api'
+import { PlayerStats, Player, GameModeKey, GAME_MODES, getCurrentSeason, BestRound } from '../types'
+import { fetchStats, fetchPlayers, fetchBestRounds } from '../api'
 import { MahjongHand } from '../components/MahjongHand'
 
 type Tab = 'games' | 'players'
@@ -18,8 +9,9 @@ type Tab = 'games' | 'players'
 const currentSeason = getCurrentSeason()
 
 import { statFontSize } from '../utils/fontSize'
-import { abbrName } from '../utils/format'
+import { abbrName, parseError } from '../utils/format'
 import { MSG } from '../constants'
+import { useActiveSeasons } from '../hooks/useActiveSeasons'
 
 export default function StatsPage() {
   const navigate = useNavigate()
@@ -34,7 +26,7 @@ export default function StatsPage() {
   const [bestRoundsError, setBestRoundsError] = useState('')
   const [monthlyBestRounds, setMonthlyBestRounds] = useState<BestRound[]>([])
   const [monthlyBestRoundsError, setMonthlyBestRoundsError] = useState('')
-  const [seasons, setSeasons] = useState<Season[]>([])
+  const { seasons, error: seasonsError } = useActiveSeasons()
 
   const [gameMode, setGameMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [seasonKey, setSeasonKey] = useState<string>(`${currentSeason.year}-${currentSeason.month}`)
@@ -55,7 +47,7 @@ export default function StatsPage() {
         setLoading(false)
       })
       .catch((e: unknown) => {
-        setError(e instanceof Error ? e.message : MSG.ERROR)
+        setError(parseError(e))
         setLoading(false)
       })
   }
@@ -69,32 +61,21 @@ export default function StatsPage() {
         setLoading(false)
       })
       .catch((e: unknown) => {
-        setError(e instanceof Error ? e.message : MSG.ERROR)
+        setError(parseError(e))
         setLoading(false)
       })
   }
 
+  // Snap seasonKey to the first available season once seasons load,
+  // unless the current selection is still valid.
   useEffect(() => {
-    let mounted = true
-    fetchActiveSeasons()
-      .then((data) => {
-        if (!mounted) return
-        const list = data.map((s) => ({ year: s.year, month: s.month, label: getSeasonLabel(s.year, s.month) }))
-        setSeasons(list)
-        if (list.length > 0) {
-          setSeasonKey((prev) =>
-            list.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${list[0].year}-${list[0].month}`
-          )
-        }
-      })
-      .catch((e: unknown) => {
-        if (!mounted) return
-        setError(e instanceof Error ? e.message : MSG.ERROR)
-      })
-    return () => {
-      mounted = false
-    }
-  }, [])
+    if (seasons.length === 0) return
+    setSeasonKey((prev) => (seasons.some((s) => `${s.year}-${s.month}` === prev) ? prev : `${seasons[0].year}-${seasons[0].month}`))
+  }, [seasons])
+
+  useEffect(() => {
+    if (seasonsError) setError(seasonsError)
+  }, [seasonsError])
 
   useEffect(() => {
     if (tab === 'games') {
@@ -113,7 +94,7 @@ export default function StatsPage() {
           if (!controller.signal.aborted) setBestRounds(data)
         })
         .catch((e: unknown) => {
-          if (!controller.signal.aborted) setBestRoundsError(e instanceof Error ? e.message : MSG.ERROR)
+          if (!controller.signal.aborted) setBestRoundsError(parseError(e))
         })
     }
     return () => controller.abort()
@@ -131,7 +112,7 @@ export default function StatsPage() {
         })
         .catch((e: unknown) => {
           if (!controller.signal.aborted) {
-            setMonthlyBestRoundsError(e instanceof Error ? e.message : MSG.ERROR)
+            setMonthlyBestRoundsError(parseError(e))
             setMonthlyBestRounds([])
           }
         })

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -1,3 +1,5 @@
+import { MSG } from '../constants'
+
 /**
  * Abbreviates a name to initials.
  * e.g. "John Doe" -> "J.D."
@@ -35,4 +37,8 @@ export function scoreClass(score: number): string {
   if (score > 0) return 'score-positive'
   if (score < 0) return 'score-negative'
   return ''
+}
+
+export function parseError(e: unknown): string {
+  return e instanceof Error ? e.message : MSG.ERROR
 }


### PR DESCRIPTION
## Summary

A 15-commit cleanup pass on the codebase based on the `/audit` checklist. No new features, no behavior changes (one regression caught and fixed mid-stream — see Test plan).

**Frontend cleanup:**
- Drop dead CSS (`.use-score-btn`, `.th-subtitle`).
- Add missing CSS vars (`--bg-muted`, `--text-muted`, `--border-muted`, `--rank-silver`, `--rank-bronze`) — the first two were already referenced in CalculatorPage but never defined, so the browser was falling back to inherit/transparent.
- Extract utility classes: `.text-right`, `.num-cell`, `.num-cell-rp`, `.config-row-label`. Replace 14+ inline-style sites.
- Move CalculatorPage's embedded `<style>{...}</style>` block into `index.css`. Add `.calc-mode-tab-btn`, `.calc-card`, `.compact-toggle-btn-reset`. Keep the calculator's responsive breakpoint at 768px (the dense toggle row needs to compress earlier than the rest of the app).
- Mobile responsive: `.dashboard-header` shrinks padding under 640px; drop fragile `minWidth:340` on player-detail table.
- Extract `useActiveSeasons()` hook (replaces ~80 lines of fetch-and-map across 3 pages) + `parseError(e)` util (replaces 14 inline copies of `e instanceof Error ? e.message : MSG.ERROR`).
- Extract `<WindSelectorRow>` component (4 identical wind-button rows in CalculatorPage) and `keyDiscoveriesByMostRecent()` helper (2 identical builders in FanTablePage).
- Use `.flex-between` for FanTablePage's subtitle+actions row; drop a dead flex wrapper around a single-child label in NewSessionPage.

**Backend cleanup:**
- Add private `loadActivePlayer(Long)` helper in `GameService` to fold 3× near-identical `findById.orElse(null) + null/bot` patterns.
- Add private generic `queryByModeAndDate(...)` helper to collapse two parallel 4-branch if/else ladders in `getBestRounds`.
- Replace 4 fully-qualified `java.<pkg>.<Type>` references with proper imports.

**Audit skill:**
- Add a fully-qualified-name check under Part 4 of `.claude/commands/audit.md` so future audits flag the same pattern.

## Test plan

- [x] `./gradlew spotlessApply` clean
- [x] `(cd ui && npx tsc --noEmit)` clean
- [x] `./gradlew compileJava -q` clean
- [x] No orphan `isOnline` references; no FQN matches in `server/src`
- [x] Caught and fixed a `flex:1` regression on the calculator mode tabs (`.tab-btn` → `.calc-mode-tab-btn` lost the inherited `flex:1`, shrinking the tabs and their underline indicator). Now restored.
- [ ] Smoke test `/calculator` in the browser: tabs split the row width, the active tab's blue underline spans its full half, configs-row has the gray background
- [ ] Smoke test `/stats`, `/game`, `/fan-table`: season dropdown is newest-first
- [ ] Smoke test `/game` on a narrow viewport: dashboard header padding feels tight (12px 16px under 640px)
- [ ] Backend smoke: `/api/stats/best-rounds?gameMode=GUOBIAO&year=2026&month=6` (and other combinations) return identical results to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wind direction selector component for Calculator
  * Hook exposing active seasons for shared season filtering

* **Bug Fixes**
  * Ensured bots are excluded from winner calculations
  * Unified error messages across UI flows via a new parser

* **Style**
  * New theme variables, responsive calculator and dashboard styling updates

* **Documentation**
  * Added audit checklist for Java FQN usage remediation

* **Chores**
  * Cleaned/standardized Java type declarations and service refactoring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->