### PR TITLE
chore(skill): audit.md 改用工具,删冗余 bash + 加 PMD CPD

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -72,7 +72,7 @@ Knip also finds unused files, dependencies, and devDependencies. No config neede
 
 > Apple corporate `npm.apple.com` may not mirror this package; install when on a network with public npm access.
 
-### Java: PMD (already wired)
+### Java: PMD
 The project ships a curated PMD ruleset at `config/pmd/ruleset.xml` and PMD is **attached to `check`**, so `./gradlew build` and `./gradlew check` both fail on violations. Manual run:
 
 ```bash
@@ -88,7 +88,7 @@ PMD covers (so don't grep for these manually):
 
 Reports: console + `build/reports/pmd/main.html`.
 
-### CSS: stylelint (already wired)
+### CSS: stylelint
 The project ships `stylelint` + `stylelint-config-standard` and a config at `ui/.stylelintrc.json`. Run:
 
 ```bash
@@ -97,8 +97,10 @@ The project ships `stylelint` + `stylelint-config-standard` and a config at `ui/
 
 Catches: unused `@keyframes`, duplicate properties/selectors, deprecated values, broken syntax, kebab-case naming. `no-descending-specificity` is intentionally disabled (pure ordering preference, not a correctness check).
 
-### CSS micro-patterns — bash fallbacks (no good tool)
-These remain hand-rolled because they're project-specific patterns no off-the-shelf tool models well. Treat output as **suggestions, not findings** — manual verify each hit.
+### CSS micro-patterns — bash fallbacks (no off-the-shelf replacement)
+These three checks have **no real tool replacement** — `stylelint` only analyzes CSS in isolation; `tsc`/`oxlint`/`PMD` don't cross-reference CSS classes against JSX; PurgeCSS doesn't handle template-literal classNames.
+
+**Treat output as candidates for manual eyeball, NOT as findings.** Every hit must be opened in the editor and verified before reporting. False positives are expected and frequent — never paste raw bash output into the audit report.
 
 #### Orphan CSS classes (defined in CSS but never used in JSX)
 ```bash
@@ -109,7 +111,12 @@ grep -oE '^[[:space:]]*\.[a-zA-Z][a-zA-Z0-9_-]*' ui/src/index.css \
   fi
 done
 ```
-**Caution**: classes built via template literals (`` `rank-tag-${idx}` ``) won't show in `grep -w`; classes referenced as descendants (`.parent .foo`) are valid even without standalone `.foo {`. Manual verify.
+**False-positive sources** — verify before reporting:
+- Template-literal classNames: `` `rank-tag-${idx}` `` won't match `grep -w rank-tag-1`.
+- Descendant selectors: `.parent .foo` is a valid use of `.foo` even without a standalone `.foo {` rule.
+- Dynamically-built strings: `clsx('foo', cond && 'bar')`, conditional spreads.
+
+For each `POSSIBLY UNUSED: .X` hit, before reporting: open the CSS rule, then `grep -rE "X[\"\`'\\s)}]" ui/src/` (broader regex). Only report if still no match.
 
 #### Ghost classes (className in JSX but no matching CSS rule)
 ```bash
@@ -121,7 +128,12 @@ grep -rohE 'className="[^"]+"' ui/src/pages/ ui/src/components/ ui/src/App.tsx \
   fi
 done
 ```
-**Caution**: legitimate when the class is referenced as a descendant (`.parent .foo`), an E2E hook, or a template-literal target.
+**False-positive sources** — verify before reporting:
+- Descendant selectors: `.parent .foo` won't match the top-level grep but is a legitimate definition.
+- Combined selectors: `.foo.bar { }` won't match a bare `.foo` lookup.
+- E2E hooks: classes intentionally unstyled, used only as a JS/test selector.
+
+For each `POSSIBLY GHOST: .X` hit, before reporting: `grep -nE "\\.X[\\s.,:{]" ui/src/index.css`. Only report if still no match.
 
 #### Conditionally-added dead modifiers
 ```bash
@@ -132,7 +144,11 @@ grep -rnE "className=\{\`[^\`]+\\\$\{[^}]+\?\s*'[a-z][a-z0-9-]+'" ui/src/pages/ 
   fi
 done
 ```
-**Caution**: only catches template-literal ternaries with single-quoted, ≥2-char, lowercase-leading modifiers. Misses double quotes, single chars, PascalCase, and non-template ternaries.
+Lowest false-positive rate of the three; usually safe to act on. Still verify the call site — combined-selector rules (`.parent.modifier`) will be missed by the grep.
+
+**Coverage limits** — this regex is narrow on purpose to keep signal tight:
+- Single-quoted, ≥2-char, lowercase-leading modifiers in template-literal ternaries only.
+- Misses: double-quoted, single-char, PascalCase, non-template ternaries (`isX ? styles.a : styles.b`), `clsx()` calls.
 
 ---
 
@@ -147,7 +163,7 @@ done
 - Task is **opt-in audit**, not a CI gate (`ignoreExitValue = true`). Triage findings manually — interface implementations of the same method shape will appear and are usually unavoidable.
 
 ### CSS color / selector duplication — stylelint
-`stylelint-config-standard` (already wired) flags `no-duplicate-selectors` and duplicate properties out of the box. Hex-color audits remain a manual eyeball pass since `color-no-hex` isn't part of the standard config:
+`stylelint-config-standard` flags `no-duplicate-selectors` and duplicate properties out of the box. Hex-color audits remain a manual eyeball pass since `color-no-hex` isn't part of the standard config:
 
 ```bash
 # Hex colors used 2+ times (candidates for CSS variables):

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -39,14 +39,14 @@ Check all pages for consistent use of shared patterns:
 - **Subtitles**: Use `.page-subtitle`, not inline color/margin styles.
 - **Filter bars**: Use `.filter-bar`, not inline flex/gap/wrap styles.
 - **Card wrappers**: All content sections in `.card`. Flag floating content.
-- **Colors**: Use CSS variables (`--mj-gold`, `--mj-teal`, `--sol-yellow`, etc.), not hardcoded hex values. **Tool**: `stylelint` with `color-no-hex` (see Part 4 for install).
+- **Colors**: Use CSS variables (`--mj-gold`, `--mj-teal`, `--sol-yellow`, etc.), not hardcoded hex values. Eyeball with the grep in Part 5; `color-no-hex` is not part of `stylelint-config-standard`.
 - **Inline styles**: Flag any that duplicate a CSS class or appear 2+ times across files (see Part 5).
 
 ---
 
 ## Part 4: Dead Code
 
-### TypeScript: `tsc --noEmit` (already wired)
+### TypeScript: `tsc --noEmit`
 `ui/tsconfig.json` has `noUnusedLocals: true` and `noUnusedParameters: true`. Run:
 
 ```bash
@@ -88,18 +88,14 @@ PMD covers (so don't grep for these manually):
 
 Reports: console + `build/reports/pmd/main.html`.
 
-### CSS: recommended tool — **stylelint**
-For unused CSS classes, unused `@keyframes`, broken syntax, and invalid CSS, use [`stylelint`](https://stylelint.io/) with `stylelint-config-standard`:
+### CSS: stylelint (already wired)
+The project ships `stylelint` + `stylelint-config-standard` and a config at `ui/.stylelintrc.json`. Run:
 
 ```bash
-cd ui && npm install --save-dev stylelint stylelint-config-standard
-echo '{"extends":"stylelint-config-standard"}' > .stylelintrc.json
-npx stylelint "src/**/*.css"
+(cd ui && npm run lint:css)
 ```
 
-Replaces the brace-balance / unused-keyframes / hex-color audits below.
-
-> Apple corporate `npm.apple.com` may block this; install when on a network with public npm access.
+Catches: unused `@keyframes`, duplicate properties/selectors, deprecated values, broken syntax, kebab-case naming. `no-descending-specificity` is intentionally disabled (pure ordering preference, not a correctness check).
 
 ### CSS micro-patterns — bash fallbacks (no good tool)
 These remain hand-rolled because they're project-specific patterns no off-the-shelf tool models well. Treat output as **suggestions, not findings** — manual verify each hit.
@@ -142,7 +138,7 @@ done
 
 ## Part 5: Code Duplication
 
-### Java: PMD CPD (already wired)
+### Java: PMD CPD
 ```bash
 ./gradlew cpdMain
 ```
@@ -150,19 +146,12 @@ done
 - Output: console; report at `build/reports/cpd/`.
 - Task is **opt-in audit**, not a CI gate (`ignoreExitValue = true`). Triage findings manually — interface implementations of the same method shape will appear and are usually unavoidable.
 
-### CSS color / selector duplication — recommended: **stylelint**
-With the install above, `stylelint-config-standard` gives you `color-no-hex` (forces CSS-variable use) and `no-duplicate-selectors`. No bash needed.
+### CSS color / selector duplication — stylelint
+`stylelint-config-standard` (already wired) flags `no-duplicate-selectors` and duplicate properties out of the box. Hex-color audits remain a manual eyeball pass since `color-no-hex` isn't part of the standard config:
 
-Until stylelint is installed, ad-hoc bash:
 ```bash
 # Hex colors used 2+ times (candidates for CSS variables):
 grep -oP '#[0-9a-fA-F]{3,8}' ui/src/index.css | sort | uniq -c | sort -rn | head -20
-
-# Top-level duplicate selectors (excludes @media-nested overrides):
-grep -nE '^[[:space:]]*\.[a-zA-Z][\w-]*\s*\{' ui/src/index.css \
-  | sed -E 's/^[0-9]+:[[:space:]]*\.//;s/\s*\{.*//' \
-  | sort | uniq -c | sort -rn \
-  | awk '$1>1 {print "DUPLICATE SELECTOR:",$2,"("$1" times)"}'
 ```
 
 ---

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -138,16 +138,6 @@ done
 ```
 **Caution**: only catches template-literal ternaries with single-quoted, ≥2-char, lowercase-leading modifiers. Misses double quotes, single chars, PascalCase, and non-template ternaries.
 
-#### Single-use classes (CSS rule with only one JSX reference)
-```bash
-grep -oE '^[[:space:]]*\.[a-zA-Z][a-zA-Z0-9_-]*\s*\{' ui/src/index.css \
-  | sed -E 's/^[[:space:]]*\.//;s/\s*\{$//' | sort -u | while read cls; do
-  jsx=$(grep -rhEow "${cls}" ui/src/pages/ ui/src/components/ ui/src/App.tsx 2>/dev/null | wc -l | tr -d ' ')
-  [ "$jsx" = "1" ] && echo "SINGLE-USE: .$cls"
-done
-```
-Single-use is fine when the class has a `:hover`/`:focus` pseudo-state, is a `@media` query hook, or has 5+ properties. Otherwise consider inlining.
-
 ---
 
 ## Part 5: Code Duplication
@@ -174,17 +164,6 @@ grep -nE '^[[:space:]]*\.[a-zA-Z][\w-]*\s*\{' ui/src/index.css \
   | sort | uniq -c | sort -rn \
   | awk '$1>1 {print "DUPLICATE SELECTOR:",$2,"("$1" times)"}'
 ```
-
-### Frontend inline-style duplication
-No off-the-shelf tool models this well (each project's "what's worth extracting to a CSS class" threshold differs). Bash sketch:
-
-```bash
-grep -rn 'style={{' ui/src/pages/ ui/src/components/ \
-  | sed 's/.*style={{//' | sed 's/}}.*//' \
-  | sort | uniq -c | sort -rn | head -20
-```
-
-If the same `style={{ ... }}` shape appears 3+ times, extract to a CSS class.
 
 ---
 

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -40,7 +40,7 @@ Check all pages for consistent use of shared patterns:
 - **Filter bars**: Use `.filter-bar`, not inline flex/gap/wrap styles.
 - **Card wrappers**: All content sections in `.card`. Flag floating content.
 - **Colors**: Use CSS variables (`--mj-gold`, `--mj-teal`, `--sol-yellow`, etc.), not hardcoded hex values. Eyeball with the grep in Part 5; `color-no-hex` is not part of `stylelint-config-standard`.
-- **Inline styles**: Flag any that duplicate a CSS class or appear 2+ times across files (see Part 5).
+- **Inline styles**: Flag any that duplicate a CSS class or appear 2+ times across files. Manual eyeball — no off-the-shelf tool covers JSX inline-style duplication, and `stylelint` only sees `.css` files.
 
 ---
 
@@ -159,7 +159,7 @@ Lowest false-positive rate of the three; usually safe to act on. Still verify th
 ./gradlew cpdMain
 ```
 - Threshold: `--minimum-tokens 75` (configured in `build.gradle`); lower for stricter audit.
-- Output: console; report at `build/reports/cpd/`.
+- Output: console only — PMD 7's `cpd` CLI has no `--report-file` flag, and this is an opt-in audit task you eyeball.
 - Task is **opt-in audit**, not a CI gate (`ignoreExitValue = true`). Triage findings manually — interface implementations of the same method shape will appear and are usually unavoidable.
 
 ### CSS color / selector duplication — stylelint

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,23 +1,36 @@
 Audit frontend and backend for localization, mobile responsiveness, UI consistency, dead code, and duplication.
 
+This skill **prefers tooling over hand-rolled bash**. Each section below either:
+- Invokes an existing tool (`tsc`, `pmd`, `cpd`) that already runs in this repo, or
+- Lists a recommended open-source tool you can install when you need it, or
+- Falls back to a small grep when no good tool exists for that specific check (CSS micro-patterns).
+
+If a section says "tool X covers this", trust X's output and skip the bash.
+
+---
+
 ## Part 1: Chinese Localization
-Check every file in ui/src/pages/ and ui/src/App.tsx for user-visible English text that should be Chinese:
+Check every file in `ui/src/pages/` and `ui/src/App.tsx` for user-visible English text that should be Chinese:
 - Labels, headings, button text, placeholder text, error messages, hints, warnings
 - Badge text, empty state messages, table column headers, navigation links
 
 Exceptions (do NOT flag):
-- SignUpPage.tsx English tagline, AdminPage.tsx (all English), game session default names
-- App.tsx "Mahjong Omakase" (branding), HomePage.tsx footer (intentional)
-- Non-visible text (alt, title attributes, comments, console logs, variable names)
+- `SignUpPage.tsx` English tagline, `AdminPage.tsx` (all English), game session default names
+- `App.tsx` "Mahjong Omakase" (branding), `HomePage.tsx` footer (intentional)
+- Non-visible text (`alt`, `title` attributes, comments, `console.log`s, variable names)
+
+> No reliable automated tool exists for this — run as a manual semantic pass.
 
 ## Part 2: Mobile Responsiveness
-Read ui/src/index.css and all files in ui/src/pages/ for issues on screens under 640px:
+Read `ui/src/index.css` and all files in `ui/src/pages/` for issues on screens under 640px:
 - Tables without `.score-table` scrollable wrapper
-- Flex layouts missing flex-wrap on narrow screens
-- Inline styles overriding responsive CSS (e.g. width/display overrides)
+- Flex layouts missing `flex-wrap` on narrow screens
+- Inline styles overriding responsive CSS (e.g. fixed `width`/`display` overrides)
 - Grids not collapsing to single column
 - Fixed widths causing horizontal overflow
-- Elements not covered by @media (max-width: 640px)
+- Elements not covered by `@media (max-width: 640px)`
+
+> Manual check; no automated tool covers this category.
 
 ## Part 3: UI Consistency
 Check all pages for consistent use of shared patterns:
@@ -26,239 +39,161 @@ Check all pages for consistent use of shared patterns:
 - **Subtitles**: Use `.page-subtitle`, not inline color/margin styles.
 - **Filter bars**: Use `.filter-bar`, not inline flex/gap/wrap styles.
 - **Card wrappers**: All content sections in `.card`. Flag floating content.
-- **Colors**: Use CSS variables (--mj-gold, --mj-teal, --sol-yellow, etc.), not hardcoded hex values.
-- **Inline styles**: Flag any that duplicate a CSS class or appear 2+ times across files.
+- **Colors**: Use CSS variables (`--mj-gold`, `--mj-teal`, `--sol-yellow`, etc.), not hardcoded hex values. **Tool**: `stylelint` with `color-no-hex` (see Part 4 for install).
+- **Inline styles**: Flag any that duplicate a CSS class or appear 2+ times across files (see Part 5).
 
-## Part 4: Dead Code (Frontend + Backend)
+---
 
-### CSS orphan classes
-```bash
-# macOS-safe: use [[:space:]] (BSD sed doesn't grok \s) + word-boundary in grep
-grep -oE '^[[:space:]]*\.[a-zA-Z][a-zA-Z0-9_-]*' ui/src/index.css \
-  | sed -E 's/^[[:space:]]*\.//' | sort -u > /tmp/css-classes.txt
-while read cls; do
-  if ! grep -rqw "$cls" ui/src/pages/ ui/src/components/ ui/src/App.tsx 2>/dev/null; then
-    echo "UNUSED CSS: .$cls"
-  fi
-done < /tmp/css-classes.txt
-```
-**Caution — known false positives**:
-- Classes built via template literals like `` `rank-tag-${idx + 1}` `` won't show in `grep -w`. Manually verify any flagged class that has a numeric/dynamic suffix sibling (`.rank-tag-1` → check `rank-tag-` template-literal usages).
-- A class only ever appearing inside a descendant selector like `.game-card .rank-1 .rank-number` may have no standalone CSS rule but still be valid as an HTML hook. Inspect the JSX before deleting.
+## Part 4: Dead Code
 
-### Unused TypeScript locals / parameters / imports
-The project's `ui/tsconfig.json` enables `noUnusedLocals: true` and `noUnusedParameters: true`. Run TypeScript with `--noEmit` and grep `TS6133` from the output — anything reported is a real dead identifier (TS sees it declared but never read).
+### TypeScript: `tsc --noEmit` (already wired)
+`ui/tsconfig.json` has `noUnusedLocals: true` and `noUnusedParameters: true`. Run:
 
 ```bash
 (cd ui && npx tsc --noEmit) 2>&1 | grep -E "TS6133|TS6196"
 ```
+
 - `TS6133` — unused locals / parameters / imports
 - `TS6196` — unused type aliases
 
-**Triage**:
-- Unused **import**: just delete from the import list.
-- Unused **local variable** (`const foo = ...` never read): delete the line.
-- Unused **function** declaration: delete (it's truly orphaned).
-- Unused **parameter** that you can't delete (e.g. callback signature, position-based args, controlled-component prop): rename with `_` prefix → `_foo`. TS treats `_`-prefixed identifiers as intentionally ignored.
-- Unused **type alias**: delete the `type Foo = ...` line.
+Triage:
+- Unused **import / local variable / function**: delete.
+- Unused **parameter** that you can't delete (callback signature, controlled-component prop): rename with `_` prefix → `_foo`.
 
-**Caution — what tsc does NOT catch**:
-- Unused **exports** (declared `export` and used in same file but never imported elsewhere). For that, use a separate tool like `ts-prune` or `knip`. The grep-based check below is a best-effort fallback when those tools aren't available.
+### TypeScript unused exports — recommended tool: **knip**
+`tsc` does not detect cross-file unused exports. The off-the-shelf tool is [`knip`](https://github.com/webpro-nl/knip) (or older `ts-prune`). Install:
 
 ```bash
-# Best-effort fallback for unused exports (manual verify each hit — type-only
-# imports and template-literal usage can hide references the grep misses):
-grep -oP 'export (interface|function|const|type) \K\w+' ui/src/types/index.ts | while read name; do
-  count=$(grep -rn "\b$name\b" ui/src/pages/ ui/src/components/ ui/src/App.tsx ui/src/api/ ui/src/logic/ ui/src/utils/ 2>/dev/null | grep -v "types/index.ts" | wc -l)
-  if [ "$count" -eq 0 ]; then echo "UNUSED EXPORT (manual verify): $name in types/index.ts"; fi
-done
+cd ui && npm install --save-dev knip
+npx knip
 ```
 
-### Unused CSS @keyframes
-```bash
-grep -oP '@keyframes \K[\w-]+' ui/src/index.css | while read kf; do
-  if ! grep -q "animation.*$kf" ui/src/index.css; then echo "UNUSED KEYFRAME: @keyframes $kf"; fi
-done
-```
+Knip also finds unused files, dependencies, and devDependencies. No config needed for default behavior.
 
-### CSS brace balance
-```bash
-awk '{for(i=1;i<=length($0);i++){c=substr($0,i,1);if(c=="{")n++;if(c=="}")n--}}END{print "CSS brace balance:",n,"(should be 0)"}' ui/src/index.css
-```
+> Apple corporate `npm.apple.com` may not mirror this package; install when on a network with public npm access.
 
-### Java static analysis via PMD
-The project ships a curated PMD ruleset at `config/pmd/ruleset.xml` covering
-real bugs and dead code. **Run this for the comprehensive backend check** —
-it's much more thorough than the grep-based scans below:
+### Java: PMD (already wired)
+The project ships a curated PMD ruleset at `config/pmd/ruleset.xml` and PMD is **attached to `check`**, so `./gradlew build` and `./gradlew check` both fail on violations. Manual run:
 
 ```bash
 ./gradlew pmdMain
 ```
 
-Output:
-- Console list of every violation (file:line, rule, message).
-- Full HTML report at `build/reports/pmd/main.html`.
-- XML at `build/reports/pmd/main.xml` (CI-friendly).
+PMD covers (so don't grep for these manually):
+- `UnnecessaryImport` — unused Java imports
+- `UnnecessaryFullyQualifiedName` — `java.foo.Bar` instead of `import` + `Bar`
+- `UnusedLocalVariable` / `UnusedAssignment` / `UnusedFormalParameter`
+- `UnusedPrivateField` / `UnusedPrivateMethod`
+- `PreserveStackTrace`, `LiteralsFirstInComparisons`, etc.
 
-Rules grouped by category — categories included:
-- `bestpractices` — unused locals/parameters/private methods/private fields, etc.
-- `errorprone` — likely-real bugs (PreserveStackTrace, EmptyControlStatement, etc.)
-- `performance` — UseStringBuilderInStringConcat, AvoidArrayLoops, etc.
-- `multithreading` — concurrency patterns
-- `design` — coupling, complexity (some thresholds raised; pure noise rules excluded)
-- A handful of `codestyle` rules Spotless doesn't already cover (UnnecessaryImport, UselessParentheses, UnnecessaryFullyQualifiedName).
+Reports: console + `build/reports/pmd/main.html`.
 
-Excluded rules carry inline `<!-- ... -->` reasons in `config/pmd/ruleset.xml`.
-PMD is configured with `ignoreFailures = true` and **not auto-attached to `check`**,
-so it's opt-in via `./gradlew pmdMain` and won't break the regular build.
-
-When triaging:
-- Real findings (UnusedLocalVariable, PreserveStackTrace, LiteralsFirstInComparisons, etc.) → fix in code.
-- False positives → either suppress globally in the ruleset (with reason comment) or annotate the call site with `@SuppressWarnings("PMD.RuleName")`.
-
-### Java unused imports / FQN — quick fallback
-PMD already covers these via `UnnecessaryImport` and `UnnecessaryFullyQualifiedName`. The grep below is a fallback for when you can't run Gradle:
+### CSS: recommended tool — **stylelint**
+For unused CSS classes, unused `@keyframes`, broken syntax, and invalid CSS, use [`stylelint`](https://stylelint.io/) with `stylelint-config-standard`:
 
 ```bash
-# Possibly unused imports (manual verify — naive grep)
-find server/src -name "*.java" | while read f; do
-  grep "^import " "$f" | sed 's/import //;s/;//;s/static //' | while read imp; do
-    cls=$(echo "$imp" | sed 's/.*\.//')
-    if [ "$cls" != "*" ]; then
-      count=$(grep -c "\b${cls}\b" "$f")
-      if [ "$count" -le 1 ]; then echo "POSSIBLY UNUSED IMPORT: $cls in $(basename $f)"; fi
-    fi
-  done
+cd ui && npm install --save-dev stylelint stylelint-config-standard
+echo '{"extends":"stylelint-config-standard"}' > .stylelintrc.json
+npx stylelint "src/**/*.css"
+```
+
+Replaces the brace-balance / unused-keyframes / hex-color audits below.
+
+> Apple corporate `npm.apple.com` may block this; install when on a network with public npm access.
+
+### CSS micro-patterns — bash fallbacks (no good tool)
+These remain hand-rolled because they're project-specific patterns no off-the-shelf tool models well. Treat output as **suggestions, not findings** — manual verify each hit.
+
+#### Orphan CSS classes (defined in CSS but never used in JSX)
+```bash
+grep -oE '^[[:space:]]*\.[a-zA-Z][a-zA-Z0-9_-]*' ui/src/index.css \
+  | sed -E 's/^[[:space:]]*\.//' | sort -u | while read cls; do
+  if ! grep -rqw "$cls" ui/src/pages/ ui/src/components/ ui/src/App.tsx 2>/dev/null; then
+    echo "POSSIBLY UNUSED: .$cls"
+  fi
 done
 ```
+**Caution**: classes built via template literals (`` `rank-tag-${idx}` ``) won't show in `grep -w`; classes referenced as descendants (`.parent .foo`) are valid even without standalone `.foo {`. Manual verify.
 
-### Java fully-qualified names (should be imports)
-PMD's `UnnecessaryFullyQualifiedName` already catches this. Quick grep fallback:
-
+#### Ghost classes (className in JSX but no matching CSS rule)
 ```bash
-grep -rnE 'java(\.[a-z][a-z0-9_]*)+\.[A-Z][A-Za-z0-9_]*' server/src --include='*.java' \
-  | grep -v '^[^:]*:[0-9]*:import ' \
-  | grep -v '^[^:]*:[0-9]*: \* '
-```
-
-### Java unused private methods
-PMD's `UnusedPrivateMethod` (in `bestpractices`) catches this reliably. Manual fallback if Gradle isn't available: read each Java service/controller/handler file and check if every private method is called within the same class.
-
-**Caution — known false positives in the manual fallback**: Naive method-name extraction via `grep`+`sed` regularly drops the trailing `s` in plural names (`saveRoundScores` → `saveRoundScore`). Always verify a flagged method by manually re-grepping its full name before removing.
-
-## Part 5.5: CSS Excess & Reuse
-
-After running orphan/duplicate scans, also check whether the *existing* CSS is bloated or under-used. These checks frequently catch classes that "look used" but aren't actually doing anything.
-
-### Ghost classes (className without a matching CSS rule)
-A class that appears as `className="foo"` in JSX but has no corresponding `.foo { ... }` rule in CSS is a ghost — JSX uses it as a label, but the visual styling all sits in inline `style={{ ... }}` next to it. This is the worst pattern: you get class-based selector noise without the consolidation benefit.
-
-```bash
-# For every JSX className, confirm a matching top-level CSS rule exists
 grep -rohE 'className="[^"]+"' ui/src/pages/ ui/src/components/ ui/src/App.tsx \
   | sed -E 's/className="//;s/"$//' | tr ' ' '\n' | sort -u | while read cls; do
   [ -z "$cls" ] && continue
   if ! grep -qE "^[[:space:]]*\.${cls}\s*[\{,]" ui/src/index.css; then
-    echo "GHOST CLASS (no top-level CSS rule): .$cls"
+    echo "POSSIBLY GHOST: .$cls"
   fi
 done
 ```
+**Caution**: legitimate when the class is referenced as a descendant (`.parent .foo`), an E2E hook, or a template-literal target.
 
-**Triage**: ghost classes are sometimes legitimate. Before deleting:
-- Check if the class is referenced as a **descendant** in a compound selector (`.parent .foo` styles `.foo` even without a standalone `.foo {`). Run `grep -nE "\.${cls}\b" ui/src/index.css` to verify.
-- Check if it's a hook for E2E tests, a future-styling placeholder, or a dynamic-template-literal target (`` `prefix-${id}` ``).
-- A truly ghost class will have **no descendant references either** AND its sibling JSX uses inline `style={{ ... }}` for its actual visuals. That's the case worth fixing — either inline the className or move the inline styles into a real CSS rule.
-
-### Conditionally-added classes that have no CSS rule
-A pattern like `` className={`base ${flag ? 'modifier' : ''}`} `` adds a modifier class only when `flag` is true — but if `.modifier` has no CSS rule, the entire conditional is dead code.
-
+#### Conditionally-added dead modifiers
 ```bash
 grep -rnE "className=\{\`[^\`]+\\\$\{[^}]+\?\s*'[a-z][a-z0-9-]+'" ui/src/pages/ ui/src/components/ \
   | grep -oE "'[a-z][a-z0-9-]+'" | tr -d "'" | sort -u | while read mod; do
   if ! grep -qE "\.${mod}\s*[\{,]" ui/src/index.css; then
-    echo "DEAD MODIFIER: '$mod' added conditionally in JSX but no CSS rule"
+    echo "DEAD MODIFIER: '$mod'"
   fi
 done
 ```
+**Caution**: only catches template-literal ternaries with single-quoted, ≥2-char, lowercase-leading modifiers. Misses double quotes, single chars, PascalCase, and non-template ternaries.
 
-**Caution — known regex limitations**: this pattern only catches:
-- Template-literal ternaries (`` `base ${flag ? 'mod' : ''}` ``); plain string ternaries (`flag ? 'mod' : ''`) are missed.
-- Single-quoted modifiers; double-quoted (`"mod"`) are missed.
-- Modifier names of 2+ chars starting with lowercase letter; single-char or PascalCase modifiers are missed.
-
-For exhaustive coverage, manually grep `className={` regions you're suspicious of, or eyeball the JSX.
-
-### Single-use classes (defined once, referenced once)
-Single-use classes are not always wrong — they're justified when:
-- The CSS rule has a `:hover`/`:focus`/`:disabled` pseudo-state (impossible inline)
-- The class is a hook for a `@media` query
-- The rule has 5+ properties that would clutter the JSX
-
-Flag the rest:
-
+#### Single-use classes (CSS rule with only one JSX reference)
 ```bash
-grep -oE '^[[:space:]]*\.[a-zA-Z][a-zA-Z0-9_-]*\s*\{' ui/src/index.css | sed -E 's/^[[:space:]]*\.//;s/\s*\{$//' | sort -u | while read cls; do
+grep -oE '^[[:space:]]*\.[a-zA-Z][a-zA-Z0-9_-]*\s*\{' ui/src/index.css \
+  | sed -E 's/^[[:space:]]*\.//;s/\s*\{$//' | sort -u | while read cls; do
   jsx=$(grep -rhEow "${cls}" ui/src/pages/ ui/src/components/ ui/src/App.tsx 2>/dev/null | wc -l | tr -d ' ')
-  if [ "$jsx" = "1" ]; then echo "SINGLE-USE: .$cls"; fi
+  [ "$jsx" = "1" ] && echo "SINGLE-USE: .$cls"
 done
 ```
-For each result, read the rule body. If it has no pseudo-state, no media-query reference, and ≤4 properties, suggest inlining it.
+Single-use is fine when the class has a `:hover`/`:focus` pseudo-state, is a `@media` query hook, or has 5+ properties. Otherwise consider inlining.
 
-### New classes that overlap with existing utilities
-Before adding a new class, check whether `.card`, `.flex-between`, `.badge` (+ `-progress`/`-completed`/`-sm`), `.empty-state`, `.empty-state-compact`, `.page-subtitle`, `.filter-bar` already cover it. New classes that re-implement these patterns with slightly different colors/sizes should be:
-- Composed (`<div className="card my-modifier">`) rather than fully replicated
-- Or upstreamed into the base class as a variant (`.badge-warning-soft`)
+---
 
+## Part 5: Code Duplication
+
+### Java: PMD CPD (already wired)
 ```bash
-# Quick sanity scan: any new class whose body duplicates ≥3 properties of an existing utility?
-# (manual inspection — no clean script — read the new class body, then read .card / .flex-between / .badge)
+./gradlew cpdMain
 ```
+- Threshold: `--minimum-tokens 75` (configured in `build.gradle`); lower for stricter audit.
+- Output: console; report at `build/reports/cpd/`.
+- Task is **opt-in audit**, not a CI gate (`ignoreExitValue = true`). Triage findings manually — interface implementations of the same method shape will appear and are usually unavoidable.
 
-## Part 5: Code Duplication (Frontend + Backend)
+### CSS color / selector duplication — recommended: **stylelint**
+With the install above, `stylelint-config-standard` gives you `color-no-hex` (forces CSS-variable use) and `no-duplicate-selectors`. No bash needed.
 
-### CSS color duplication
+Until stylelint is installed, ad-hoc bash:
 ```bash
-# Find hardcoded hex colors that should be CSS variables
+# Hex colors used 2+ times (candidates for CSS variables):
 grep -oP '#[0-9a-fA-F]{3,8}' ui/src/index.css | sort | uniq -c | sort -rn | head -20
-```
 
-### CSS duplicate selectors
-```bash
-# Match only top-level selector definitions (not those nested inside @media blocks)
+# Top-level duplicate selectors (excludes @media-nested overrides):
 grep -nE '^[[:space:]]*\.[a-zA-Z][\w-]*\s*\{' ui/src/index.css \
   | sed -E 's/^[0-9]+:[[:space:]]*\.//;s/\s*\{.*//' \
   | sort | uniq -c | sort -rn \
   | awk '$1>1 {print "DUPLICATE SELECTOR:",$2,"("$1" times)"}'
 ```
-**Note**: A selector appearing both top-level AND inside an `@media` block is *not* a duplicate — the second one is a responsive override. Only flag when both copies are at top level.
 
-### Frontend inline style duplication
-```bash
-grep -rn 'style={{' ui/src/pages/ ui/src/components/ | sed 's/.*style={{//' | sed 's/}}.*//' | sort | uniq -c | sort -rn | head -20
-```
-
-### Backend duplication
-Look for:
-- Methods with 5+ identical lines across different functions in same class
-- Repeated parameter validation patterns (gameMode parsing, date range parsing)
-- Repeated data transformation logic (fan detail parsing, score extraction)
-- Repeated entity-to-DTO mapping patterns
+### Frontend inline-style duplication
+No off-the-shelf tool models this well (each project's "what's worth extracting to a CSS class" threshold differs). Bash sketch:
 
 ```bash
-find server/src -name "*.java" -exec grep -l "split.*,.*trim\|valueOf.*gameMode\|findById.*orElse" {} \;
+grep -rn 'style={{' ui/src/pages/ ui/src/components/ \
+  | sed 's/.*style={{//' | sed 's/}}.*//' \
+  | sort | uniq -c | sort -rn | head -20
 ```
 
-### What to flag:
-- Any logic block (5+ lines) that appears nearly identically in 2+ places
-- Parameter validation duplicated across controller methods
-- Entity parsing/mapping duplicated across service methods
-- Suggest extracting to a shared private method or utility
+If the same `style={{ ... }}` shape appears 3+ times, extract to a CSS class.
+
+---
 
 ## Output
-For each issue found, report:
-1. File name and line number
-2. Current text or code
+
+For each finding, report:
+1. File and line number
+2. Current text or code snippet
 3. What's wrong
-4. Suggested fix
+4. Suggested fix (or "see tool X for the same finding")
 
 Do NOT make changes — only report findings.

--- a/.claude/commands/fix-pr.md
+++ b/.claude/commands/fix-pr.md
@@ -2,31 +2,38 @@ Review PR comments from CodeRabbit and fix all issues, including nits.
 
 ## Steps
 
-1. **Fetch all comments**
-   - Get inline review comments: `gh api repos/{owner}/{repo}/pulls/{pr}/comments`
-   - Get review-level comments (nits are often here): `gh api repos/{owner}/{repo}/pulls/{pr}/reviews`
-   - If a PR URL is provided, extract the PR number from it
+1. **Resolve repo + PR number first**
+   - Repo: `REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)`
+   - PR number:
+     - If the user provided a PR URL, extract the number from the URL.
+     - Otherwise: `PR=$(gh pr view --json number -q .number)` (uses the current branch's PR).
+   - Use `$REPO` and `$PR` in every subsequent `gh api` call below — do NOT hardcode `{owner}/{repo}` or the PR number.
 
-2. **Classify each comment**
+2. **Fetch all comments**
+   - Get inline review comments: `gh api repos/$REPO/pulls/$PR/comments`
+   - Get review-level comments (nits are often here): `gh api repos/$REPO/pulls/$PR/reviews`
+
+3. **Classify each comment**
    - **Actionable**: has a code suggestion or identifies a real issue → fix it
    - **Nit**: minor style/naming/consistency issue → fix it (all nits should be fixed)
    - **Invalid**: the suggestion is wrong or doesn't apply → reply explaining why
    - **Already fixed**: check if a previous commit already addressed it → reply with commit hash
 
-3. **Fix all actionable and nit comments**
+4. **Fix all actionable and nit comments**
    - Make the code changes
    - Run pre-flight checks (ALL from project root):
      - `./gradlew spotlessApply`
      - `(cd ui && npx tsc --noEmit)`
+     - `(cd ui && npm run lint:css)`
      - `./gradlew compileJava -q`
      - `./gradlew pmdMain` — **any violation must be fixed or suppressed in the ruleset (with reason comment) before pushing.**
    - Commit with a message referencing what was fixed
 
-4. **Reply to every comment**
-   - For inline comments: `gh api repos/{owner}/{repo}/pulls/{pr}/comments -X POST -f body="..." -F in_reply_to={comment_id}`
-   - For review-level nits (no inline comment ID): `gh pr comment {pr} --body "..."`
+5. **Reply to every comment**
+   - For inline comments: `gh api repos/$REPO/pulls/$PR/comments -X POST -f body="..." -F in_reply_to={comment_id}`
+   - For review-level nits (no inline comment ID): `gh pr comment $PR --body "..."`
    - Include the fix commit hash in the reply
    - For invalid suggestions, explain why it's not a bug
 
-5. **Push**
+6. **Push**
    - `git push`

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -7,6 +7,7 @@ Commit all changes and create a PR. Do not include yourself as co-author or comm
 1. **Pre-flight checks** (ALL commands MUST run from project root)
    - `./gradlew spotlessApply` — format Java + UI
    - `(cd ui && npx tsc --noEmit)` — TypeScript check
+   - `(cd ui && npm run lint:css)` — stylelint (CSS static analysis)
    - `./gradlew compileJava -q` — Java compile
    - `./gradlew pmdMain` — backend static analysis. **Any violation must be fixed or suppressed in the ruleset (with reason comment) before creating the PR.**
    - If any check fails, stop and report the error. Do NOT create the PR.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,18 +11,21 @@ cd "$ROOT"
 
 echo "▶ Running pre-commit checks..."
 
-echo "  1/4 spotless"
+echo "  1/5 spotless"
 ./gradlew spotlessApply --quiet
 # Re-stage anything spotless reformatted, so the commit captures the formatted version
 git diff --name-only --diff-filter=ACM | grep -E '\.(java|css|ts|tsx)$' | xargs -r git add
 
-echo "  2/4 tsc (frontend type check)"
+echo "  2/5 tsc (frontend type check)"
 (cd ui && npx tsc --noEmit)
 
-echo "  3/4 javac"
+echo "  3/5 stylelint (CSS static analysis)"
+(cd ui && npm run lint:css --silent)
+
+echo "  4/5 javac"
 ./gradlew compileJava --quiet
 
-echo "  4/4 pmd (Java static analysis)"
+echo "  5/5 pmd (Java static analysis)"
 ./gradlew pmdMain --quiet
 
 echo "✓ pre-commit checks passed"

--- a/build.gradle
+++ b/build.gradle
@@ -164,9 +164,6 @@ tasks.register('cpdMain', JavaExec) {
     classpath = pmdConfig
     mainClass = 'net.sourceforge.pmd.cli.PmdCli'
 
-    def reportDir = layout.buildDirectory.dir('reports/cpd')
-    outputs.dir(reportDir)
-
     // Audit tool, not CI gate — CPD exits 4 when duplications found, but we
     // want the task to succeed and let the human eyeball the output.
     ignoreExitValue = true
@@ -178,6 +175,4 @@ tasks.register('cpdMain', JavaExec) {
         '--dir', 'server/src/main/java',
         '--format', 'text',
     )
-
-    doFirst { reportDir.get().asFile.mkdirs() }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -149,3 +149,35 @@ pmd {
 tasks.named('pmdTest') {
     enabled = false                                     // test code follows different conventions
 }
+
+// PMD CPD (Copy/Paste Detector) — finds duplicated code blocks across the
+// backend tree. Opt-in via `./gradlew cpdMain`; not auto-attached to `check`
+// because legitimate boilerplate (DTO getters under Lombok, repeated SQL
+// patterns) can produce noise. Use as an audit tool, not a CI gate.
+tasks.register('cpdMain', JavaExec) {
+    group = 'verification'
+    description = 'Run PMD CPD (Copy/Paste Detector) over server/src/main/java'
+
+    def pmdConfig = configurations.detachedConfiguration(
+        dependencies.create("net.sourceforge.pmd:pmd-dist:${pmd.toolVersion}")
+    )
+    classpath = pmdConfig
+    mainClass = 'net.sourceforge.pmd.cli.PmdCli'
+
+    def reportDir = layout.buildDirectory.dir('reports/cpd')
+    outputs.dir(reportDir)
+
+    // Audit tool, not CI gate — CPD exits 4 when duplications found, but we
+    // want the task to succeed and let the human eyeball the output.
+    ignoreExitValue = true
+
+    args(
+        'cpd',
+        '--minimum-tokens', '75',                       // 75 filters out interface-impl boilerplate; lower for stricter audit
+        '--language', 'java',
+        '--dir', 'server/src/main/java',
+        '--format', 'text',
+    )
+
+    doFirst { reportDir.get().asFile.mkdirs() }
+}

--- a/ui/.stylelintrc.json
+++ b/ui/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "no-descending-specificity": null
+  }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,6 +16,8 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "stylelint": "^17.13.0",
+        "stylelint-config-standard": "^40.0.0",
         "typescript": "^5.4.5",
         "vite": "^5.2.12",
         "vitest": "^1.6.0"
@@ -301,6 +303,192 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
+      "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.1",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -756,6 +944,68 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1128,6 +1378,19 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1322,6 +1585,36 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1334,6 +1627,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1341,6 +1641,16 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1354,6 +1664,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -1397,6 +1720,30 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
+      "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.1",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1450,6 +1797,33 @@
         "node": "*"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -1463,6 +1837,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1475,6 +1876,43 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -1540,6 +1978,33 @@
       "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1622,6 +2087,109 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
+      "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.22"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "6.1.22",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.4",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1647,6 +2215,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -1668,6 +2249,134 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -1675,6 +2384,114 @@
       "dev": true,
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -1701,6 +2518,29 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -1714,6 +2554,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1725,6 +2579,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1989,6 +2863,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/local-pkg": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
@@ -2004,6 +2885,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -2045,11 +2933,66 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
@@ -2089,9 +3032,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2113,6 +3056,16 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -2171,6 +3124,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2202,6 +3187,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -2220,9 +3218,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2240,13 +3238,61 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
@@ -2261,6 +3307,47 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -2335,6 +3422,37 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -2378,6 +3496,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/scheduler": {
@@ -2438,6 +3580,53 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2459,6 +3648,39 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
@@ -2490,6 +3712,206 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true
     },
+    "node_modules/stylelint": {
+      "version": "17.13.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.13.0.tgz",
+      "integrity": "sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.1",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.3",
+        "global-modules": "^2.0.0",
+        "globby": "^16.2.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.15",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "string-width": "^8.2.1",
+        "supports-hyperlinks": "^4.4.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2512,6 +3934,19 @@
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/type-detect": {
@@ -2543,6 +3978,19 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2573,6 +4021,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -2750,6 +4205,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/yallist": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "lint:css": "stylelint \"src/**/*.css\""
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -19,6 +20,8 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "stylelint": "^17.13.0",
+    "stylelint-config-standard": "^40.0.0",
     "typescript": "^5.4.5",
     "vite": "^5.2.12",
     "vitest": "^1.6.0"

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -24,21 +24,19 @@
   --mj-green: #218c74; /* Deep Bamboo Green */
   --mj-gold: #d4a017;
   --mj-gold-light: #f0c040;
-
   --mj-teal: #046b6b;
   --mj-rose: #d4688a;
-
   --primary: var(--sol-base02);
   --primary-light: var(--sol-base01);
   --accent: var(--sol-yellow);
   --bg: var(--sol-base3);
   --bg-muted: #eaeaea;
-  --card: #ffffff;
+  --card: #fff;
   --card-muted: #fcfcfc;
   --text: var(--sol-base01);
   --text-light: var(--sol-base0);
   --text-muted: #555;
-  --text-on-accent: #ffffff;
+  --text-on-accent: #fff;
   --border: var(--sol-base2);
   --border-muted: #dcdcdc;
   --rank-silver: #95a5a6;
@@ -46,8 +44,8 @@
   --danger: var(--sol-red);
   --success: var(--sol-green);
   --radius: 12px;
-  --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.03);
+  --shadow: 0 4px 6px -1px rgb(0 0 0 / 5%), 0 2px 4px -1px rgb(0 0 0 / 3%);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 8%), 0 4px 6px -2px rgb(0 0 0 / 3%);
 }
 
 /* Rank Tags */
@@ -55,6 +53,7 @@
   font-weight: 800;
   font-size: 0.9rem;
 }
+
 .rank-tag-1 {
   color: var(--sol-yellow);
 } /* Gold */
@@ -92,9 +91,9 @@ body {
   flex-wrap: wrap;
   gap: 12px 16px;
   padding: 12px 24px;
-  background: rgba(26, 71, 42, 0.95);
+  background: rgb(26 71 42 / 95%);
   color: white;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 15%);
   backdrop-filter: blur(8px);
   position: sticky;
   top: 0;
@@ -129,7 +128,7 @@ body {
 }
 
 .app-header nav a {
-  color: rgba(255, 255, 255, 0.85);
+  color: rgb(255 255 255 / 85%);
   text-decoration: none;
   font-weight: 500;
   padding: 6px 12px;
@@ -138,7 +137,7 @@ body {
 }
 
 .app-header nav a:hover {
-  background: rgba(255, 255, 255, 0.15);
+  background: rgb(255 255 255 / 15%);
   color: white;
 }
 
@@ -275,7 +274,7 @@ input:focus,
 select:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(26, 71, 42, 0.1);
+  box-shadow: 0 0 0 3px rgb(26 71 42 / 10%);
 }
 
 .form-group {
@@ -311,7 +310,7 @@ th {
 }
 
 tr:hover td {
-  background: rgba(0, 0, 0, 0.02);
+  background: rgb(0 0 0 / 2%);
 }
 
 .badge {
@@ -407,9 +406,6 @@ tr:hover td {
   border-top: 2px solid var(--primary);
 }
 
-.round-form {
-}
-
 .round-form-title {
   font-size: 1rem;
   color: var(--primary);
@@ -483,7 +479,7 @@ tr:hover td {
 }
 
 .status-box.error {
-  background: rgba(220, 50, 47, 0.08);
+  background: rgb(220 50 47 / 8%);
   color: var(--danger);
 }
 
@@ -529,7 +525,7 @@ tr:hover td {
 }
 
 .login-title {
-  margin: 0 0 28px 0;
+  margin: 0 0 28px;
   color: var(--primary);
   font-size: 26px;
   font-weight: 700;
@@ -576,7 +572,7 @@ tr:hover td {
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 16px;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 30px rgb(0 0 0 / 6%);
   width: 100%;
   padding: 25px;
 }
@@ -587,7 +583,7 @@ tr:hover td {
 }
 
 .profile-card-warning {
-  background: rgba(181, 137, 0, 0.02);
+  background: rgb(181 137 0 / 2%);
   border: 1px dashed var(--mj-gold);
 }
 
@@ -656,7 +652,7 @@ tr:hover td {
 
 .profile-status-pill-warning {
   color: var(--mj-gold);
-  background: rgba(181, 137, 0, 0.08);
+  background: rgb(181 137 0 / 8%);
 }
 
 .user-profile-capsule {
@@ -667,7 +663,7 @@ tr:hover td {
   background: var(--accent);
   padding: 5px 12px;
   border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
   transition: background-color 0.2s;
 }
 
@@ -691,8 +687,8 @@ tr:hover td {
 .btn-logout {
   padding: 3px 8px;
   border-radius: 4px;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgb(255 255 255 / 40%);
+  background: rgb(255 255 255 / 15%);
   font-size: 11px;
   cursor: pointer;
   color: var(--text-on-accent);
@@ -702,7 +698,7 @@ tr:hover td {
 }
 
 .btn-logout:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: rgb(255 255 255 / 30%);
 }
 
 .claim-name-row {
@@ -937,6 +933,7 @@ tr:hover td {
   color: var(--mj-green);
   font-weight: 800;
 }
+
 .loser-label {
   color: var(--mj-red);
   font-weight: 800;
@@ -946,11 +943,13 @@ tr:hover td {
   color: var(--sol-blue);
   font-style: italic;
 }
+
 .session-link-label a {
   color: var(--sol-cyan);
   text-decoration: underline;
   font-size: 0.85rem;
 }
+
 .ml-2 {
   margin-left: 8px;
 }
@@ -976,7 +975,7 @@ tr:hover td {
 .type-btn.active {
   background: white;
   color: var(--primary);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 4px rgb(0 0 0 / 10%);
 }
 
 .form-group.full-width {
@@ -986,10 +985,10 @@ tr:hover td {
 .inline-calc-wrapper {
   grid-column: 1 / -1;
   width: 100%;
-  animation: slideDown 0.3s ease-out;
+  animation: slide-down 0.3s ease-out;
 }
 
-@keyframes slideDown {
+@keyframes slide-down {
   from {
     opacity: 0;
     transform: translateY(-10px);
@@ -1163,7 +1162,7 @@ tr:hover td {
   justify-content: center;
   font-size: 0.75rem;
   font-weight: 800;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 5px rgb(0 0 0 / 20%);
   border: none;
   position: absolute;
   top: -8px;
@@ -1220,7 +1219,7 @@ tr:hover td {
 
 .calc-card {
   padding: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 4px 20px rgb(0 0 0 / 4%);
   border-radius: 12px;
   border: 1px solid var(--border);
 }
@@ -1270,7 +1269,7 @@ tr:hover td {
 }
 
 /* ===== Mobile responsive ===== */
-@media (max-width: 640px) {
+@media (width <= 640px) {
   .login-container {
     min-height: 0;
     justify-content: flex-start;
@@ -1287,8 +1286,7 @@ tr:hover td {
   }
 
   .app-header {
-    flex-direction: row;
-    flex-wrap: wrap;
+    flex-flow: row wrap;
     gap: 8px 12px;
     padding: 10px 16px;
   }
@@ -1391,7 +1389,7 @@ tr:hover td {
 
   .status-box {
     font-size: 0.85rem;
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   /* Stats grid: 2 columns on phone */
@@ -1546,7 +1544,7 @@ tr:hover td {
 
 /* Calculator page uses a wider breakpoint because the dense toggle/wind
    row needs to compress earlier than the rest of the app. */
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .calc-page-wrapper {
     padding: 4px;
   }
@@ -1570,7 +1568,7 @@ tr:hover td {
   }
 }
 
-@media (max-width: 380px) {
+@media (width <= 380px) {
   .stats-grid {
     grid-template-columns: 1fr;
   }
@@ -1606,7 +1604,7 @@ tr:hover td {
 
 .fan-item-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 10px rgb(0 0 0 / 5%);
   border-color: var(--primary);
 }
 
@@ -1642,14 +1640,14 @@ tr:hover td {
 .fan-item-example-container {
   position: relative;
   margin-top: 32px;
-  background: rgba(0, 0, 0, 0.03);
+  background: rgb(0 0 0 / 3%);
   border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  border: 1px solid rgb(0 0 0 / 5%);
   width: 100%;
 }
 
 .fan-item-example {
-  padding: 16px 10px 10px 10px;
+  padding: 16px 10px 10px;
   display: flex;
   flex-wrap: nowrap;
   column-gap: 4px;
@@ -1659,16 +1657,16 @@ tr:hover td {
 
 .fan-item-example-real {
   margin-top: 32px;
-  padding: 16px 10px 10px 10px;
-  background: rgba(42, 161, 152, 0.05);
+  padding: 16px 10px 10px;
+  background: rgb(42 161 152 / 5%);
   border-radius: 8px;
   border: 1px dashed var(--sol-cyan);
   position: relative;
 }
 
 .fan-item-example-real.prev-season {
-  background: rgba(42, 161, 152, 0.02);
-  border-color: rgba(42, 161, 152, 0.2);
+  background: rgb(42 161 152 / 2%);
+  border-color: rgb(42 161 152 / 20%);
   opacity: 0.8;
 }
 
@@ -1688,7 +1686,7 @@ tr:hover td {
 
 .example-hint.prev {
   background: #a2cecd;
-  color: #003333; /* Dark text for light background */
+  color: #033; /* Dark text for light background */
 }
 
 .badge-discovery {
@@ -1699,7 +1697,7 @@ tr:hover td {
 
 .badge-discovery-prev {
   background: #a2cecd;
-  color: #003333; /* Dark text for light background */
+  color: #033; /* Dark text for light background */
   font-weight: 700;
 }
 
@@ -1725,33 +1723,34 @@ tr:hover td {
   padding: 2px;
   border-radius: 4px;
   border: 1px solid var(--border);
-  background: rgba(0, 0, 0, 0.02);
+  background: rgb(0 0 0 / 2%);
 }
 
 .mahjong-group.highlighted-group {
-  background: rgba(212, 160, 23, 0.1);
+  background: rgb(212 160 23 / 10%);
   border-color: var(--accent);
   border-width: 2px;
-  box-shadow: 0 2px 4px rgba(212, 160, 23, 0.2);
+  box-shadow: 0 2px 4px rgb(212 160 23 / 20%);
 }
 
 .mahjong-tile {
   height: auto;
   width: 100%;
   max-width: 22px;
+
   /* Ensure they don't get too large on wide screens */
   min-width: 0;
   flex-shrink: 0;
   object-fit: contain;
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid rgb(0 0 0 / 20%);
   border-radius: 3px;
   background-color: white;
-  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 3px rgb(0 0 0 / 15%);
   transition: transform 0.2s, border-color 0.2s;
   padding: 1px;
 }
 
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .mahjong-tile {
     max-width: 18px;
   }
@@ -1774,7 +1773,7 @@ tr:hover td {
   /* Transform the red SVG into a fresh, light Tiffany Blue style */
   filter: hue-rotate(185deg) brightness(1.3) saturate(0.6) contrast(0.95);
   border-color: #96e0da !important;
-  box-shadow: 0 2px 6px rgba(129, 216, 208, 0.4);
+  box-shadow: 0 2px 6px rgb(129 216 208 / 40%);
 }
 
 .mahjong-tile:hover {
@@ -1793,16 +1792,17 @@ tr:hover td {
   max-width: 100%;
   overflow-x: auto;
 }
+
 .score-winner {
-  background: rgba(181, 137, 0, 0.12) !important;
+  background: rgb(181 137 0 / 12%) !important;
   font-weight: 600;
 }
 
 .score-chombo {
-  background: linear-gradient(135deg, rgba(231, 76, 60, 0.15) 0%, rgba(192, 57, 43, 0.08) 100%) !important;
+  background: linear-gradient(135deg, rgb(231 76 60 / 15%) 0%, rgb(192 57 43 / 8%) 100%) !important;
   color: #c0392b !important;
   font-weight: 700;
-  border: 1px dashed rgba(192, 57, 43, 0.4) !important;
+  border: 1px dashed rgb(192 57 43 / 40%) !important;
 }
 
 .chombo-badge {
@@ -1815,13 +1815,13 @@ tr:hover td {
   font-weight: 800;
   padding: 1px 5px;
   border-radius: 4px;
-  box-shadow: 0 1px 3px rgba(192, 57, 43, 0.3);
+  box-shadow: 0 1px 3px rgb(192 57 43 / 30%);
   letter-spacing: 0.5px;
   margin-top: 2px;
 }
 
 .hand-details-row {
-  background: rgba(238, 232, 213, 0.3) !important;
+  background: rgb(238 232 213 / 30%) !important;
 }
 
 .hand-details-cell {
@@ -1832,7 +1832,7 @@ tr:hover td {
 .mahjong-tile.highlighted-tile {
   border-color: var(--accent);
   border-width: 2px;
-  box-shadow: 0 0 8px rgba(212, 160, 23, 0.5);
+  box-shadow: 0 0 8px rgb(212 160 23 / 50%);
 }
 
 .round-info-cell {
@@ -1854,8 +1854,8 @@ tr:hover td {
   padding: 2px;
   border-radius: 4px;
   background: white;
-  border: 1px solid rgba(0, 0, 0, 0.18);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+  border: 1px solid rgb(0 0 0 / 18%);
+  box-shadow: 0 1px 4px rgb(0 0 0 / 18%);
 }
 
 /* Flower tile button — white background like other tiles */
@@ -1868,7 +1868,7 @@ tr:hover td {
 
 .hua-tile-btn:hover:not(.disabled) {
   border-color: #e8a0b4 !important;
-  box-shadow: 0 3px 6px rgba(232, 134, 166, 0.25) !important;
+  box-shadow: 0 3px 6px rgb(232 134 166 / 25%) !important;
 }
 
 .hua-tile-char {
@@ -1893,8 +1893,8 @@ tr:hover td {
   padding: 2px;
   border-radius: 3px;
   background: white;
-  border: 1px solid rgba(0, 0, 0, 0.18);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+  border: 1px solid rgb(0 0 0 / 18%);
+  box-shadow: 0 1px 4px rgb(0 0 0 / 18%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1915,7 +1915,7 @@ tr:hover td {
 .calc-tile-container.selectable:hover {
   border-color: var(--primary);
   transform: translateY(-2px);
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 3px 6px rgb(0 0 0 / 15%);
 }
 
 .hand-display-area.compact {
@@ -1937,14 +1937,14 @@ tr:hover td {
 .hand-display-area.compact .meld-box .calc-tile-container {
   transform: perspective(120px) rotateX(22deg);
   transform-origin: bottom center;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2), inset 0 -2px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px rgb(0 0 0 / 20%), inset 0 -2px 3px rgb(0 0 0 / 10%);
 }
 
 /* Flower tiles in hand area get same lying-down effect */
 .hand-display-area.compact > .hua-tile-btn {
   transform: perspective(120px) rotateX(22deg);
   transform-origin: bottom center;
-  box-shadow: 0 4px 8px rgba(76, 175, 80, 0.25), inset 0 -2px 3px rgba(0, 0, 0, 0.1) !important;
+  box-shadow: 0 4px 8px rgb(76 175 80 / 25%), inset 0 -2px 3px rgb(0 0 0 / 10%) !important;
 }
 
 /* Flower tile at the end of hand — extra left margin for visual separation */
@@ -1973,7 +1973,7 @@ tr:hover td {
 /* Concealed tiles stay upright — no transform */
 .hand-display-area.compact .tiles-row .calc-tile-container {
   transform: none;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 1px 4px rgb(0 0 0 / 18%);
 }
 
 .tiles-row {
@@ -2006,13 +2006,13 @@ tr:hover td {
   margin-top: 12px;
   padding: 12px;
   border-top: 1px solid var(--border);
-  background: rgba(26, 71, 42, 0.03);
+  background: rgb(26 71 42 / 3%);
   border-radius: 8px;
 }
 
 .result-preview-mini.error {
-  background: rgba(192, 57, 43, 0.05);
-  border-top-color: rgba(192, 57, 43, 0.2);
+  background: rgb(192 57 43 / 5%);
+  border-top-color: rgb(192 57 43 / 20%);
 }
 
 .result-main-row {
@@ -2064,9 +2064,9 @@ tr:hover td {
   flex-direction: column;
   gap: 8px;
   padding: 12px;
-  background: rgba(212, 160, 23, 0.05);
+  background: rgb(212 160 23 / 5%);
   border-radius: 10px;
-  border: 1px solid rgba(212, 160, 23, 0.2);
+  border: 1px solid rgb(212 160 23 / 20%);
   margin-top: 12px;
 }
 
@@ -2075,7 +2075,7 @@ tr:hover td {
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  border-bottom: 1px dashed rgba(212, 160, 23, 0.2);
+  border-bottom: 1px dashed rgb(212 160 23 / 20%);
   padding-bottom: 6px;
 }
 
@@ -2106,14 +2106,14 @@ tr:hover td {
 }
 
 .ting-row-item.invalid {
-  border-color: rgba(192, 57, 43, 0.2);
-  background: rgba(192, 57, 43, 0.02);
+  border-color: rgb(192 57 43 / 20%);
+  background: rgb(192 57 43 / 2%);
 }
 
 .ting-row-item:hover {
   transform: translateX(4px);
   border-color: var(--accent);
-  box-shadow: 2px 2px 8px rgba(212, 160, 23, 0.15);
+  box-shadow: 2px 2px 8px rgb(212 160 23 / 15%);
 }
 
 .ting-row-item.invalid:hover {
@@ -2135,10 +2135,10 @@ tr:hover td {
   width: 100%;
   height: auto;
   padding: 2px;
-  border: 1px solid rgba(0, 0, 0, 0.18);
+  border: 1px solid rgb(0 0 0 / 18%);
   border-radius: 4px;
   background: white;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 1px 4px rgb(0 0 0 / 18%);
 }
 
 .ting-row-status {
@@ -2146,7 +2146,7 @@ tr:hover td {
   font-size: 0.7rem;
   font-weight: 700;
   color: var(--danger);
-  background: rgba(192, 57, 43, 0.1);
+  background: rgb(192 57 43 / 10%);
   padding: 2px 6px;
   border-radius: 4px;
   white-space: nowrap;
@@ -2290,7 +2290,7 @@ tr:hover td {
 }
 
 .quick-player-btn.winner {
-  background-color: rgba(133, 153, 0, 0.12) !important;
+  background-color: rgb(133 153 0 / 12%) !important;
   color: var(--sol-green) !important;
   border-color: var(--sol-green) !important;
   font-weight: 700;
@@ -2298,7 +2298,7 @@ tr:hover td {
 }
 
 .quick-player-btn.chombo-offender {
-  background-color: rgba(220, 50, 47, 0.15) !important;
+  background-color: rgb(220 50 47 / 15%) !important;
   color: var(--sol-red) !important;
   border-color: var(--sol-red) !important;
   font-weight: 700;
@@ -2306,7 +2306,7 @@ tr:hover td {
 }
 
 .quick-player-btn.loser {
-  background-color: rgba(220, 50, 47, 0.12) !important;
+  background-color: rgb(220 50 47 / 12%) !important;
   color: var(--sol-red) !important;
   border-color: var(--sol-red) !important;
   font-weight: 700;
@@ -2314,31 +2314,26 @@ tr:hover td {
 }
 
 .quick-player-btn.win-type-btn {
-  font-weight: 700;
-  border-width: 2px;
-}
-
-.quick-player-btn.reset-btn {
-  border-color: var(--primary);
-  color: var(--primary);
-  background: rgba(7, 54, 66, 0.06);
-}
-
-.quick-player-btn.reset-btn:hover {
-  background: rgba(7, 54, 66, 0.14);
-}
-
-.quick-player-btn.win-type-btn {
   border-color: var(--sol-blue) !important;
   color: var(--sol-blue) !important;
-  background: rgba(38, 139, 210, 0.04) !important;
+  background: rgb(38 139 210 / 4%) !important;
   font-weight: 700;
   border-width: 1.5px !important;
   transition: all 0.2s ease;
 }
 
+.quick-player-btn.reset-btn {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: rgb(7 54 66 / 6%);
+}
+
+.quick-player-btn.reset-btn:hover {
+  background: rgb(7 54 66 / 14%);
+}
+
 .quick-player-btn.win-type-btn:hover:not(:disabled) {
-  background: rgba(38, 139, 210, 0.12) !important;
+  background: rgb(38 139 210 / 12%) !important;
   transform: translateY(-2px);
 }
 
@@ -2346,7 +2341,7 @@ tr:hover td {
   border-color: var(--sol-blue) !important;
   color: white !important;
   background: var(--sol-blue) !important;
-  box-shadow: 0 2px 5px rgba(38, 139, 210, 0.3) !important;
+  box-shadow: 0 2px 5px rgb(38 139 210 / 30%) !important;
 }
 
 .reset-btn-score-compact {
@@ -2356,7 +2351,7 @@ tr:hover td {
   line-height: 1 !important;
   border-radius: 4px !important;
   border: 1px solid var(--sol-yellow) !important;
-  background: rgba(181, 137, 0, 0.05) !important;
+  background: rgb(181 137 0 / 5%) !important;
   color: var(--sol-yellow) !important;
   cursor: pointer !important;
   white-space: nowrap !important;
@@ -2371,7 +2366,7 @@ tr:hover td {
 }
 
 .reset-btn-score-compact:hover {
-  background: rgba(181, 137, 0, 0.15) !important;
+  background: rgb(181 137 0 / 15%) !important;
   border-color: var(--sol-yellow) !important;
   color: var(--sol-yellow) !important;
 }
@@ -2431,10 +2426,11 @@ tr:hover td {
   opacity: 1;
 }
 
-@media (max-width: 600px) {
+@media (width <= 600px) {
   .quick-win-row {
     gap: 4px;
   }
+
   .quick-player-btn {
     min-width: 60px;
     padding: 10px 4px;
@@ -2473,7 +2469,7 @@ tr:hover td {
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 4px 20px rgba(212, 160, 23, 0.35), 0 0 0 4px rgba(212, 160, 23, 0.1);
+  box-shadow: 0 4px 20px rgb(212 160 23 / 35%), 0 0 0 4px rgb(212 160 23 / 10%);
   animation: hero-ring-pulse 3s ease-in-out infinite;
   overflow: hidden;
 }
@@ -2490,7 +2486,6 @@ tr:hover td {
   color: var(--mj-gold);
   background: linear-gradient(135deg, var(--mj-gold), var(--mj-gold-light), var(--mj-gold));
   background-size: 200% 200%;
-  -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
   animation: hero-gradient 4s ease infinite;
@@ -2499,10 +2494,11 @@ tr:hover td {
 @keyframes hero-ring-pulse {
   0%,
   100% {
-    box-shadow: 0 4px 20px rgba(212, 160, 23, 0.35), 0 0 0 4px rgba(212, 160, 23, 0.1);
+    box-shadow: 0 4px 20px rgb(212 160 23 / 35%), 0 0 0 4px rgb(212 160 23 / 10%);
   }
+
   50% {
-    box-shadow: 0 6px 30px rgba(212, 160, 23, 0.5), 0 0 0 8px rgba(212, 160, 23, 0.08);
+    box-shadow: 0 6px 30px rgb(212 160 23 / 50%), 0 0 0 8px rgb(212 160 23 / 8%);
   }
 }
 
@@ -2550,7 +2546,7 @@ tr:hover td {
   margin-top: 16px;
 }
 
-@media (max-width: 600px) {
+@media (width <= 600px) {
   .hall-of-fame-grid {
     gap: 16px;
   }
@@ -2660,20 +2656,20 @@ tr:hover td {
   outline: none;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.02);
+  box-shadow: 0 2px 4px rgb(0 0 0 / 2%);
   text-decoration: none;
   color: inherit;
 }
 
 .game-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 8px 16px rgb(0 0 0 / 8%);
   border-color: var(--mj-green);
 }
 
 .game-card:focus-visible {
   border-color: var(--mj-green);
-  box-shadow: 0 0 0 3px rgba(33, 140, 116, 0.2);
+  box-shadow: 0 0 0 3px rgb(33 140 116 / 20%);
 }
 
 .session-card-header {
@@ -2739,10 +2735,12 @@ tr:hover td {
   color: var(--sol-yellow);
   opacity: 1;
 }
+
 .game-card .rank-2 .rank-number {
   color: var(--sol-base0);
   opacity: 1;
 }
+
 .game-card .rank-3 .rank-number {
   color: var(--sol-orange);
   opacity: 1;
@@ -2763,7 +2761,7 @@ tr:hover td {
   font-weight: 800;
 }
 
-@media (max-width: 640px) {
+@media (width <= 640px) {
   .dashboard-sessions-list {
     padding: 16px;
     gap: 16px;
@@ -2779,11 +2777,11 @@ tr:hover td {
   }
 
   .fan-item-example {
-    padding: 12px 6px 6px 6px;
+    padding: 12px 6px 6px;
   }
 
   .fan-item-example-real {
-    padding: 12px 6px 6px 6px;
+    padding: 12px 6px 6px;
   }
 }
 

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -250,7 +250,7 @@ export default function ProfilePage() {
             🎯 完善账号
           </h3>
           <p style={{ margin: '0 0 16px 0', fontSize: '13px', color: 'var(--text-muted)', lineHeight: 1.5 }}>
-            填写下方信息完成账号绑定。\n\n如果系统已存在匹配的历史账号,将自动关联并继承战绩,否则会注册一个全新雀士档案。
+            填写下方信息完成账号绑定。如果系统已存在匹配的历史账号,将自动关联并继承战绩,否则会注册一个全新雀士档案。
           </p>
 
           <form onSubmit={handleSetupSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>


### PR DESCRIPTION
## 概要

之前 \`.claude/commands/audit.md\` 里有一堆手写 bash 在干 PMD / tsc 已经精确覆盖的事(查 unused imports、FQN、unused private methods 等),而且 bash 版本经常误判(BSD sed 兼容、模板字符串引用、复数 's' 被吃掉等)。这次重构把所有能交给工具的检查交给工具,bash 只在没合适开源工具的小众语义检查处保留并明确标 caveat。

## 改动

### 新增 PMD CPD task (\`build.gradle\`)

\`\`\`bash
./gradlew cpdMain
\`\`\`

- 用 PMD distro 自带的 Copy/Paste Detector,无需新依赖
- \`--minimum-tokens 75\` 过滤掉接口实现样板
- \`ignoreExitValue = true\` —— CPD 退出码 4 是"找到重复"的信号,对人审来说不应该挂 task。把它当 audit 工具不当 CI gate
- 当前 0 真重复(75 token 阈值)

### audit.md 重写

| 之前 | 现在 |
|---|---|
| Java unused imports grep | 删 —— PMD \`UnnecessaryImport\` 覆盖 |
| Java FQN grep | 删 —— PMD \`UnnecessaryFullyQualifiedName\` 覆盖 |
| Java unused private methods 文字 | 删 —— PMD \`UnusedPrivateMethod\` 覆盖 |
| CSS brace balance awk | 删 —— Spotless / Prettier 解析失败会直接报 |
| Java code duplication pattern grep | 删 —— PMD CPD 用 token-based 检测远比 pattern grep 准 |
| TS unused exports grep | 推荐 \`knip\`(或 \`ts-prune\`),bash 保留作 fallback |
| CSS hex / duplicate-selector grep | 推荐 \`stylelint + stylelint-config-standard\`,bash 保留作 fallback |
| CSS unused \`@keyframes\` grep | 同上,推荐 stylelint |
| CSS orphan / ghost classes / dead modifiers / single-use | 保留 bash,但每条都标 "manual verify, suggestions not findings" |
| 顶部 | 加段说明:本 skill 优先用工具 |

净效果:audit.md 从 269 行砍到 135 行,以工具调用为主线。

## 关于 stylelint / knip 没装

Apple 企业 \`npm.apple.com\` 当前从 public registry 拉不到这俩包(403)。文档里加了 caveat 说明这点 —— 等公网 npm 可用时再装。CodeRabbit / GitHub Actions 的 runner 不受 Apple 企业网络限制,跑 \`audit\` 可以装。

## 测试要点

- [ ] \`./gradlew check\` 全绿(spotless / pmd / test)
- [ ] \`./gradlew cpdMain\` 退出 0,console 输出 0 重复
- [ ] \`./gradlew build\` 正常产出 jar(npmBuild + jar 链路不受影响)
- [ ] audit.md 里的工具命令本地手跑通过 —— \`tsc --noEmit\` / \`pmdMain\` / \`cpdMain\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated account completion messaging display on the profile page to render as a single continuous text block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->