### PR TITLE
fix: 顶栏右上角不显示用户名 + 移除 Player.@Version 修绑定 NPE

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/model/Player.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Player.java
@@ -43,14 +43,6 @@ public class Player {
   @Column(nullable = false, columnDefinition = "boolean default false")
   private boolean merged = false;
 
-  /**
-   * Hibernate optimistic-lock version. Guards setupProfile / claim flows: if two concurrent
-   * transactions race to bind a Google account to the same legacy Player, only the first commit
-   * succeeds; the second one's UPDATE checks {@code version = ?} mismatches and Hibernate throws an
-   * {@link jakarta.persistence.OptimisticLockException}, which Spring surfaces as a 409/500.
-   */
-  @Version private Long version;
-
   public Player(String userName, String firstName, String lastName) {
     this.userName = userName;
     this.firstName = firstName;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -78,8 +78,6 @@ function App() {
     }
   }, [])
 
-  const userDisplayName = me ? [me.firstName, me.lastName].filter(Boolean).join(' ') || me.userName || '' : ''
-
   const handleLogout = () => {
     localStorage.removeItem('mahjong_token')
     sessionStorage.removeItem('mahjong_me')
@@ -105,7 +103,7 @@ function App() {
           {token && me ? (
             <div className="user-profile-capsule">
               <Link to="/profile">
-                <span className="user-display-name">{userDisplayName}</span>
+                <span className="user-display-name">我的</span>
               </Link>
               <button onClick={handleLogout} className="btn-logout">
                 退出


### PR DESCRIPTION
## 概要

两处修复打包到一个 PR:

1. **顶栏 mobile overflow**:登录后,如果用户的 firstName/lastName/userName 文本过长,顶栏右上角的 \`.user-profile-capsule\` 会撑大,把首页/游戏/统计/算番器/番表 这一排导航挤成两行。改成固定文案 "我的" 链接到个人页,退出按钮保持不变。
2. **绑定时 setup-profile 500 NPE**:历史 \`players\` 行 \`version\` 列是 NULL(\`@Version\` 后加,JPA auto-DDL 没回填),走 claim 路径调 \`saveAndFlush\` 时 Hibernate \`Versioning.increment\` 对 null 调 \`longValue()\` 抛 NPE,用户绑定失败。本项目 20 个用户,乐观锁带来的复杂度大于价值,直接删 \`@Version\` 字段。

## 一、顶栏 mobile overflow

\`ui/src/App.tsx\`
- \`<span class="user-display-name">\` 内容由 \`{userDisplayName}\` 改成字面量 "我的"
- 删掉因此 orphan 掉的 \`userDisplayName\` 计算行

## 二、Player.@Version 移除

\`server/src/main/java/com/mahjong/omakase/model/Player.java\`
- 删 \`@Version private Long version\` + 对应 javadoc
- AuthController 不动:\`saveAndFlush\` 在没有 \`@Version\` 时走普通 update,无 NPE 隐患
- DB 里残留的 \`version\` 列无害,不需要 migration

## 测试要点

- [ ] mobile 视窗(<640px)登录后顶栏导航保持单行
- [ ] 桌面端右上角显示 "我的(退出)" 两个元素
- [ ] 点击 "我的" 跳到 /profile,点击 "退出" 清登录态并跳到 /login
- [ ] 未登录时仍显示 "登录" 按钮
- [ ] 用 Google 登录新账号→在 setup-profile 表单填一个匹配历史 Player(version=NULL)的 userName/firstName/lastName→提交 应该 200 而不是 500
- [ ] 用 Google 登录新账号→填一个全新的 userName→提交注册新账号 应该 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Concurrent update protection support has been removed from player data, potentially affecting how simultaneous updates are handled in certain scenarios.

* **UI Changes**
  * The authenticated user display name in the header now displays a fixed label instead of dynamically computing the name from user profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->