### PR TITLE
fix(ui): mobile 顶栏 nav 单独成行 + 荣誉殿堂卡片不溢出

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1296,8 +1296,9 @@ tr:hover td {
   }
 
   .logo-link {
-    flex-basis: 100%;
-    justify-content: center;
+    flex: 1 1 auto;
+    justify-content: flex-start;
+    min-width: 0;
   }
 
   .logo {
@@ -1306,7 +1307,7 @@ tr:hover td {
   }
 
   .app-header nav {
-    flex: 1;
+    flex: 1 1 100%;
     gap: 8px;
     flex-wrap: wrap;
     justify-content: center;
@@ -2557,6 +2558,7 @@ tr:hover td {
   border-radius: var(--radius);
   padding: 24px;
   box-shadow: var(--shadow);
+  min-width: 0;
 }
 
 .mode-rank-title {

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -249,9 +249,12 @@ export default function ProfilePage() {
           >
             🎯 完善账号
           </h3>
-          <p style={{ margin: '0 0 16px 0', fontSize: '13px', color: 'var(--text-muted)', lineHeight: 1.5 }}>
-            填写下方信息完成账号绑定。如果系统已存在匹配的历史账号,将自动关联并继承战绩,否则会注册一个全新雀士档案。
-          </p>
+          <div style={{ margin: '0 0 16px 0', fontSize: '13px', color: 'var(--text-muted)', lineHeight: 1.5 }}>
+            <p style={{ margin: 0 }}>填写下方信息完成账号绑定。</p>
+            <p style={{ margin: 0 }}>
+              如果系统已存在匹配的历史账号, 将自动关联并继承战绩, 否则会注册一个全新雀士档案。
+            </p>
+          </div>
 
           <form onSubmit={handleSetupSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
             <div>


### PR DESCRIPTION
## 概要

两处 mobile 视觉问题修复:

1. **顶栏 5 个 tab 在 mobile 上挤成两行**:即使把右上角改成 "我的(退出)" 后,5 个导航(首页/游戏/统计/算番器/番表)仍然被迫 wrap 成两小行,因为它们跟 \`auth-actions\` 共享第二行,空间不够。
2. **首页 "本月荣誉殿堂" 各类麻将下面的白色卡片在 mobile 上横向溢出**:\`.mode-rank-column\` 是 grid item,默认 \`min-width: auto\` (= 内容固有最小宽度),长玩家名/番种描述把列撑得比 viewport 还宽,白卡边界跑出屏幕。

## 一、顶栏布局改成 2 行

\`ui/src/index.css\` (\`@media (max-width: 640px)\`)

- \`.logo-link\`: \`flex-basis: 100%; justify-content: center\` → \`flex: 1 1 auto; justify-content: flex-start; min-width: 0\`
- \`.app-header nav\`: \`flex: 1\` → \`flex: 1 1 100%\`

新布局:

| 行 | 内容 |
|---|---|
| 1 | logo + 标题(左)…… 我的 / 退出(右) |
| 2 | 首页 / 游戏 / 统计 / 算番器 / 番表(全宽居中) |

## 二、荣誉殿堂卡片溢出

\`ui/src/index.css\` (\`.mode-rank-column\`)

- 加 \`min-width: 0\`,允许 grid item 收缩到小于内容固有宽度;\`.player-name\` 已有 \`overflow: hidden + text-overflow: ellipsis\`,自动截断长名字。

## 测试要点

- [ ] mobile 视窗 ≤640px:顶栏正好两行,5 个 nav 在第二行单行排列
- [ ] mobile 视窗 ≤640px:首页 "本月荣誉殿堂" 三个卡片横向不溢出
- [ ] 长玩家名(>10 字符)在荣誉殿堂里被 ellipsis 截断,不再撑爆卡片
- [ ] 桌面端(≥640px)布局未受影响
- [ ] 长番种描述(\`.best-hand-summary-detail\`)继续 ellipsis(本来就有,不应该回归)

🤖 Generated with [Claude Code](https://claude.com/claude-code)