### PR TITLE
feat(profile): 个人战绩按模式拆分 + 平均排名 + 番种成就限国标

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -7,6 +7,7 @@ public class PlayerStatsResponse {
   private int gamesPlayed;
   private int totalScore;
   private double avgScore;
+  private double avgRank;
   private int wins;
   private double totalRP;
   private double baseRP;
@@ -60,6 +61,14 @@ public class PlayerStatsResponse {
 
   public void setAvgScore(double avgScore) {
     this.avgScore = avgScore;
+  }
+
+  public double getAvgRank() {
+    return avgRank;
+  }
+
+  public void setAvgRank(double avgRank) {
+    this.avgRank = avgRank;
   }
 
   public int getWins() {

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -709,6 +709,7 @@ public class GameService {
     Map<Long, Integer> totalScores = new HashMap<>();
     Map<Long, Integer> gamesPlayed = new HashMap<>();
     Map<Long, Integer> wins = new HashMap<>();
+    Map<Long, Integer> totalRanks = new HashMap<>();
     Map<Long, Double> totalRP = new HashMap<>();
     Map<Long, Double> tieredBonusPerPlayer = new HashMap<>();
     Map<Long, Double> adminBonusPerPlayer = new HashMap<>();
@@ -802,6 +803,7 @@ public class GameService {
 
         for (var entry : ranked) {
           totalRP.merge(entry.playerId(), entry.rp(), (a, b) -> a + b);
+          totalRanks.merge(entry.playerId(), entry.rank(), Integer::sum);
         }
 
         int topScore = ((Number) sorted.get(0)[1]).intValue();
@@ -835,6 +837,8 @@ public class GameService {
               stat.setTotalRP(total);
               int games = gamesPlayed.getOrDefault(p.getId(), 0);
               stat.setAvgScore(games > 0 ? total / games : 0);
+              stat.setAvgRank(
+                  games > 0 ? (double) totalRanks.getOrDefault(p.getId(), 0) / games : 0);
               return stat;
             })
         .collect(Collectors.toList());

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1311,6 +1311,7 @@ tr:hover td {
     gap: 8px;
     flex-wrap: wrap;
     justify-content: center;
+    order: 3;
   }
 
   .app-header nav a {
@@ -1438,6 +1439,7 @@ tr:hover td {
   .auth-actions {
     margin-left: 0;
     gap: 6px;
+    order: 2;
   }
 
   .btn-signup {

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { fetchStats, fetchFanDiscoveries, setupProfile, lookupClaimablePlayer } from '../api'
+import { GAME_MODES, GameModeKey, PlayerStats } from '../types'
 
 export default function ProfilePage() {
   const navigate = useNavigate()
@@ -9,7 +10,7 @@ export default function ProfilePage() {
     return rawMe ? JSON.parse(rawMe) : null
   })
 
-  const [stats, setStats] = useState<any | null>(null)
+  const [statsByMode, setStatsByMode] = useState<Partial<Record<GameModeKey, PlayerStats>>>({})
   const [discoveries, setDiscoveries] = useState<any[]>([])
 
   // 账号设置(关联老账号 / 注册新账号)
@@ -22,15 +23,17 @@ export default function ProfilePage() {
   useEffect(() => {
     if (!me) return
 
-    // 1. 获取玩家个人战绩
-    fetchStats()
-      .then((data) => {
-        const myStat = data.find((s: any) => s.playerId === me.id)
-        if (myStat) setStats(myStat)
-      })
-      .catch(console.error)
+    // 1. 各模式战绩并行拉取
+    GAME_MODES.forEach((mode) => {
+      fetchStats(mode.key)
+        .then((data) => {
+          const myStat = data.find((s: any) => s.playerId === me.id)
+          if (myStat) setStatsByMode((prev) => ({ ...prev, [mode.key]: myStat }))
+        })
+        .catch(console.error)
+    })
 
-    // 2. 获取玩家个人番型成就
+    // 2. 稀有番种成就(仅国标产生)
     fetchFanDiscoveries()
       .then((data) => {
         const myDiscoveries = data.filter((fd: any) => fd.playerId === me.id)
@@ -141,100 +144,116 @@ export default function ProfilePage() {
         </div>
       </div>
 
-      {/* 2. 个人战绩展示 */}
-      <div className="profile-card">
-        <h3
-          style={{
-            margin: '0 0 20px 0',
-            fontSize: '18px',
-            color: 'var(--primary)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-          }}
-        >
-          📊 个人战绩
-        </h3>
-        {stats && stats.gamesPlayed > 0 ? (
-          <div className="profile-stats-grid">
-            <div className="profile-stat-card">
-              <div className="profile-stat-value profile-stat-value-teal">{stats.gamesPlayed}</div>
-              <div className="profile-stat-label">总局数</div>
-            </div>
-            <div className="profile-stat-card">
-              <div className="profile-stat-value profile-stat-value-teal">
-                {stats.wins}{' '}
-                <span className="profile-stat-suffix">({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)</span>
-              </div>
-              <div className="profile-stat-label">胜场 (胜率)</div>
-            </div>
-            <div className="profile-stat-card">
-              <div className="profile-stat-value profile-stat-value-gold">
-                {stats.totalRP > 0 ? `+${stats.totalRP.toFixed(1)}` : stats.totalRP.toFixed(1)}
-              </div>
-              <div className="profile-stat-label">总积分 (RP)</div>
-            </div>
-            <div className="profile-stat-card">
-              <div className="profile-stat-value profile-stat-value-gold">
-                {stats.avgScore > 0 ? `+${stats.avgScore.toFixed(0)}` : stats.avgScore.toFixed(0)}
-              </div>
-              <div className="profile-stat-label">场均表现</div>
-            </div>
-          </div>
-        ) : (
-          <div className="empty-state empty-state-compact">
-            <p>新晋雀士，暂无本赛季对局统计数据。</p>
-          </div>
-        )}
-      </div>
-
-      {/* 3. 个人番型成就展示 */}
-      <div className="profile-card">
-        <h3
-          style={{
-            margin: '0 0 20px 0',
-            fontSize: '18px',
-            color: 'var(--primary)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-          }}
-        >
-          🏆 稀有番种成就
-        </h3>
-        {discoveries.length > 0 ? (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            {discoveries.map((fd, i) => (
-              <div
-                key={i}
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  background: 'linear-gradient(135deg, rgba(33, 140, 116, 0.02), rgba(181, 137, 0, 0.02))',
-                  border: '1px solid #eef7f4',
-                  borderRadius: '10px',
-                  padding: '12px 16px',
-                }}
-              >
-                <div>
-                  <div style={{ fontWeight: 700, color: 'var(--mj-teal)', fontSize: '15px' }}>🏅 {fd.fanName}</div>
-                  <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
-                    发现日期: {new Date(fd.discoveredAt).toLocaleDateString()}
-                  </div>
+      {/* 2. 各模式个人战绩(国标 / 东北 / 立直) */}
+      {GAME_MODES.map((mode) => {
+        const stats = statsByMode[mode.key]
+        const hasStats = stats && stats.gamesPlayed > 0
+        return (
+          <div key={mode.key} className="profile-card">
+            <h3
+              style={{
+                margin: '0 0 20px 0',
+                fontSize: '18px',
+                color: 'var(--primary)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+              }}
+            >
+              📊 {mode.label} 战绩
+            </h3>
+            {hasStats ? (
+              <div className="profile-stats-grid">
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-teal">{stats.gamesPlayed}</div>
+                  <div className="profile-stat-label">总局数</div>
                 </div>
-                <span className="profile-status-pill profile-status-pill-warning">+{fd.bonusRp || 0} RP</span>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-teal">
+                    {stats.wins}{' '}
+                    <span className="profile-stat-suffix">
+                      ({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)
+                    </span>
+                  </div>
+                  <div className="profile-stat-label">胜场 (胜率)</div>
+                </div>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-gold">
+                    {stats.totalRP > 0 ? `+${stats.totalRP.toFixed(1)}` : stats.totalRP.toFixed(1)}
+                  </div>
+                  <div className="profile-stat-label">总积分 (RP)</div>
+                </div>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-gold">
+                    {stats.avgScore > 0 ? `+${stats.avgScore.toFixed(0)}` : stats.avgScore.toFixed(0)}
+                  </div>
+                  <div className="profile-stat-label">场均表现</div>
+                </div>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-teal">{stats.avgRank.toFixed(2)}</div>
+                  <div className="profile-stat-label">平均排名</div>
+                </div>
               </div>
-            ))}
-          </div>
-        ) : (
-          <div className="empty-state empty-state-compact">
-            <p>暂未发现首和稀有番种成就。</p>
-          </div>
-        )}
-      </div>
+            ) : (
+              <div className="empty-state empty-state-compact">
+                <p>本模式暂无对局统计。</p>
+              </div>
+            )}
 
-      {/* 4. 完善账号:关联老账号 / 注册新账号 — 二选一,完成后此区永久消失 */}
+            {/* 稀有番种成就只在国标模式下显示(其他模式没有番种系统) */}
+            {mode.key === 'GUOBIAO' && (
+              <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
+                <h4
+                  style={{
+                    margin: '0 0 16px 0',
+                    fontSize: '15px',
+                    color: 'var(--primary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  🏆 稀有番种成就
+                </h4>
+                {discoveries.length > 0 ? (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                    {discoveries.map((fd, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          background: 'linear-gradient(135deg, rgba(33, 140, 116, 0.02), rgba(181, 137, 0, 0.02))',
+                          border: '1px solid #eef7f4',
+                          borderRadius: '10px',
+                          padding: '12px 16px',
+                        }}
+                      >
+                        <div>
+                          <div style={{ fontWeight: 700, color: 'var(--mj-teal)', fontSize: '15px' }}>
+                            🏅 {fd.fanName}
+                          </div>
+                          <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
+                            发现日期: {new Date(fd.discoveredAt).toLocaleDateString()}
+                          </div>
+                        </div>
+                        <span className="profile-status-pill profile-status-pill-warning">+{fd.bonusRp || 0} RP</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="empty-state empty-state-compact">
+                    <p>暂未发现首和稀有番种成就。</p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
+
+      {/* 4. 完善账号:关联老账号 / 注册新账号 */}
       {!me.merged && (
         <div className="profile-card profile-card-warning">
           <h3

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -124,6 +124,7 @@ export interface PlayerStats {
   adminBonus: number
   fanDiscoveryBonus: number
   avgScore: number
+  avgRank: number
   wins: number
 }
 


### PR DESCRIPTION
## 概要

ProfilePage 的 "个人战绩" 区域改造:

1. **战绩按模式拆分**:从单张混合所有模式的卡片,改成 3 张独立卡片(国标 / 东北 / 立直),让玩家直观看到自己在每个规则下的表现差异。
2. **新增 "平均排名" 指标**:每张模式卡的统计扩展为 5 项 — 总局数、胜场(胜率)、总积分 (RP)、场均表现、**平均排名**(新)。
3. **稀有番种成就限国标模式**:从顶层独立卡片移到国标卡片内嵌(border-top 分隔)。其他模式没有番种系统,放在外层会引起误解。

## 一、后端

- \`PlayerStatsResponse\` 新增 \`avgRank\` 字段(double)
- \`GameService.getPlayerStats\` 在已有 \`RpCalculator.rankPlayers\` 排序基础上,新增 \`Map<Long, Integer> totalRanks\` 累加每场名次,聚合时按 \`games\` 计算平均

## 二、前端

- \`ui/src/types/index.ts\`: \`PlayerStats\` 接口同步加 \`avgRank: number\`
- \`ui/src/pages/ProfilePage.tsx\`:
  - state \`stats\` → \`statsByMode: Partial<Record<GameModeKey, PlayerStats>>\`
  - useEffect 并行 fetch 3 次(每模式一次)
  - 战绩区从 1 张卡 → \`GAME_MODES.map\` 渲染 3 张卡
  - 稀有番种成就从独立卡片改为国标卡片内嵌(\`mode.key === 'GUOBIAO' &&\` 条件)

## 测试要点

- [ ] 登录后 Profile 页看到 3 张模式卡(国标 → 东北 → 立直 顺序)
- [ ] 每张卡 5 个 stat:总局数、胜场(胜率)、总积分、场均表现、平均排名
- [ ] 平均排名 4 人模式范围 1.00-4.00,3 人模式 1.00-3.00
- [ ] 仅国标卡内嵌 "🏆 稀有番种成就" 子区块,东北/立直 不显示
- [ ] 玩家只玩过国标 → 东北/立直 卡显示 "本模式暂无对局统计。"
- [ ] mobile 视窗下 5 个 stat 卡片单列堆叠不溢出
- [ ] 桌面端 2 列网格,第 5 个 stat 单独占一行(已有 .profile-stats-grid 行为)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added average rank metric to player statistics display.
  * Reorganized battle statistics view to display per-game-mode breakdown, with each mode showing wins, win rate, RP, average score, and average rank when applicable.
  * Updated rare achievements display to show conditionally based on game mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->