### PR TITLE
perf(tier): /game 页面按月 cache, 砍 SQL 数量级

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionRepository.java
@@ -48,4 +48,22 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
       @Param("mode") GameMode mode,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
+
+  /**
+   * Completed sessions in a season+mode window up to and including {@code asOf}, in chronological
+   * order. Used by {@code computeSessionPlayerBonuses} — replaces the per-call full-table {@code
+   * findAll} + in-memory filter that was scanning every session per round write.
+   */
+  @Query(
+      "SELECT s FROM GameSession s "
+          + "WHERE s.status = com.mahjong.omakase.model.SessionStatus.COMPLETED "
+          + "AND s.gameMode = :mode "
+          + "AND s.createdAt >= :start AND s.createdAt < :end "
+          + "AND s.createdAt <= :asOf "
+          + "ORDER BY s.createdAt ASC")
+  List<GameSession> findCompletedInSeasonUpTo(
+      @Param("mode") GameMode mode,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end,
+      @Param("asOf") LocalDateTime asOf);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -12,21 +12,32 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
           + "WHERE rs.round.gameSession.id = :sessionId GROUP BY rs.player.id")
   List<Object[]> getTotalScoresBySession(Long sessionId);
 
+  /**
+   * Bulk version: one row per (sessionId, playerId, totalScore) across the given session ids.
+   * Replaces N separate {@link #getTotalScoresBySession} calls in stats / player-detail loops.
+   */
+  @Query(
+      "SELECT rs.round.gameSession.id, rs.player.id, SUM(rs.score) FROM RoundScore rs "
+          + "WHERE rs.round.gameSession.id IN :sessionIds "
+          + "GROUP BY rs.round.gameSession.id, rs.player.id")
+  List<Object[]> getTotalScoresBySessions(List<Long> sessionIds);
+
   @Query(
       "SELECT rs.player.id, COUNT(DISTINCT rs.round.gameSession.id) FROM RoundScore rs "
           + "WHERE rs.round.gameSession.id IN :sessionIds GROUP BY rs.player.id")
   List<Object[]> getGamesPlayedPerPlayerInSessions(List<Long> sessionIds);
 
   /**
-   * Returns one row per (round × scoring player) in the given session: [roundId, winnerId,
-   * dealInPlayerId, scoringPlayerId, score]. Used to compute Riichi round-level metrics
+   * Returns one row per (round × scoring player) across the given sessions: [sessionId, roundId,
+   * winnerId, dealInPlayerId, scoringPlayerId, score]. Used to compute Riichi round-level metrics
    * (和牌率/放铳率/平均打点/平均铳点) without N+1 lazy loads. Excludes rows whose player has been nulled out by
    * account deletion.
    */
   @Query(
-      "SELECT r.id, r.winnerId, r.dealInPlayerId, rs.player.id, rs.score FROM RoundScore rs "
-          + "JOIN rs.round r WHERE r.gameSession.id = :sessionId AND rs.player IS NOT NULL")
-  List<Object[]> getRoundDetailsBySession(Long sessionId);
+      "SELECT r.gameSession.id, r.id, r.winnerId, r.dealInPlayerId, rs.player.id, rs.score "
+          + "FROM RoundScore rs JOIN rs.round r "
+          + "WHERE r.gameSession.id IN :sessionIds AND rs.player IS NOT NULL")
+  List<Object[]> getRoundDetailsBySessions(List<Long> sessionIds);
 
   @Modifying
   @Query("UPDATE RoundScore rs SET rs.player = null WHERE rs.player.id = :playerId")

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -243,30 +243,55 @@ public class GameService {
 
   @Transactional(readOnly = true)
   public List<SessionSummaryResponse> getAllSessionSummaries() {
-    return sessionRepo.findAllByOrderByCreatedAtDesc().stream().map(this::toSummary).toList();
+    List<GameSession> sessions = sessionRepo.findAllByOrderByCreatedAtDesc();
+    Map<String, Map<Long, Tier>> tiersCache = new HashMap<>();
+    Map<String, Map<Long, Integer>> monthlyGamesCache = new HashMap<>();
+    return sessions.stream().map(s -> toSummary(s, tiersCache, monthlyGamesCache)).toList();
   }
 
-  private SessionSummaryResponse toSummary(GameSession s) {
+  private String monthCacheKey(GameMode mode, LocalDateTime sessionUtc) {
+    java.time.LocalDate pt =
+        sessionUtc.atZone(ZONE_UTC).withZoneSameInstant(ZONE_PACIFIC).toLocalDate();
+    return mode.name() + ":" + pt.getYear() + "-" + pt.getMonthValue();
+  }
+
+  private SessionSummaryResponse toSummary(
+      GameSession s,
+      Map<String, Map<Long, Tier>> tiersCache,
+      Map<String, Map<Long, Integer>> monthlyGamesCache) {
     SessionSummaryResponse r = SessionSummaryResponse.from(s);
     GameMode mode = s.getGameMode();
     if (mode != GameMode.GUOBIAO && mode != GameMode.RIICHI) return r;
     List<Player> players =
         s.getPlayers().stream().map(GameSessionPlayer::getPlayer).filter(Objects::nonNull).toList();
+
+    String key = monthCacheKey(mode, s.getCreatedAt());
+    Map<Long, Tier> tiers =
+        tiersCache.computeIfAbsent(
+            key, k -> tierService.resolveTiersForDate(mode, s.getCreatedAt()));
+    Map<Long, Integer> monthly =
+        monthlyGamesCache.computeIfAbsent(
+            key, k -> tierService.monthlyGamesByPlayerForReferenceDate(mode, s.getCreatedAt()));
+
     r.setTableStrength(
-        tableStrengthService.compute(players, mode, s.getCreatedAt()).getDisplayName());
-    annotateRankingsTier(r.getRankings(), players, mode);
+        tableStrengthService.compute(players, mode, tiers, monthly).getDisplayName());
+    annotateRankingsTier(r.getRankings(), players, tiers, mode);
     return r;
   }
 
   private void annotateRankingsTier(
-      List<PlayerPerformanceDTO> rankings, List<Player> players, GameMode mode) {
+      List<PlayerPerformanceDTO> rankings,
+      List<Player> players,
+      Map<Long, Tier> tiers,
+      GameMode mode) {
     if (rankings == null) return;
     Map<Long, Player> byId = new HashMap<>();
     for (Player p : players) byId.put(p.getId(), p);
     for (PlayerPerformanceDTO row : rankings) {
       Player p = byId.get(row.getPlayerId());
       if (p == null) continue;
-      row.setTier(tierService.computeTier(p, mode).name());
+      Tier t = tiers.get(p.getId());
+      row.setTier((t != null ? t : tierService.computeTier(p, mode)).name());
     }
   }
 

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -348,6 +348,12 @@ public class GameService {
     resp.setStatus(session.getStatus().name());
     resp.setCreatedAt(session.getCreatedAt());
 
+    GameMode sessionMode = session.getGameMode();
+    final Long sessionThroneId =
+        (sessionMode == GameMode.GUOBIAO || sessionMode == GameMode.RIICHI)
+            ? tierService.findThroneId(sessionMode)
+            : null;
+
     resp.setPlayers(
         session.getPlayers().stream()
             .filter(gsp -> gsp.getPlayer() != null)
@@ -361,15 +367,13 @@ public class GameService {
                           p.getFirstName(),
                           p.getLastName(),
                           gsp.getSeat());
-                  GameMode mode = session.getGameMode();
-                  if (mode == GameMode.GUOBIAO || mode == GameMode.RIICHI) {
-                    info.setTier(tierService.computeTier(p, mode).name());
+                  if (sessionMode == GameMode.GUOBIAO || sessionMode == GameMode.RIICHI) {
+                    info.setTier(tierService.computeTier(p, sessionMode, sessionThroneId).name());
                   }
                   return info;
                 })
             .collect(Collectors.toList()));
 
-    GameMode sessionMode = session.getGameMode();
     if (sessionMode == GameMode.GUOBIAO || sessionMode == GameMode.RIICHI) {
       List<Player> players =
           session.getPlayers().stream()
@@ -461,16 +465,13 @@ public class GameService {
       return bonuses;
     }
 
-    String season = getSeasonStringFromUtc(session.getCreatedAt());
+    YearMonth seasonYm = YearMonth.from(toPacificTime(session.getCreatedAt()));
+    LocalDateTime seasonStartUtc = toUtcTime(seasonYm.atDay(1).atStartOfDay());
+    LocalDateTime seasonEndUtc = toUtcTime(seasonYm.plusMonths(1).atDay(1).atStartOfDay());
 
     List<GameSession> seasonSessions =
-        sessionRepo.findAll().stream()
-            .filter(s -> s.getStatus() == SessionStatus.COMPLETED)
-            .filter(s -> s.getGameMode() == session.getGameMode())
-            .filter(s -> getSeasonStringFromUtc(s.getCreatedAt()).equals(season))
-            .filter(s -> !s.getCreatedAt().isAfter(session.getCreatedAt()))
-            .sorted(Comparator.comparing(GameSession::getCreatedAt))
-            .toList();
+        sessionRepo.findCompletedInSeasonUpTo(
+            session.getGameMode(), seasonStartUtc, seasonEndUtc, session.getCreatedAt());
 
     Map<Long, Integer> gameIndexUpToHere = new HashMap<>();
     if (!seasonSessions.isEmpty()) {
@@ -867,8 +868,38 @@ public class GameService {
       }
     }
 
+    // Bulk-load total scores per session — replaces N+1 calls to getTotalScoresBySession.
+    Map<Long, List<Object[]>> scoresBySessionId = new HashMap<>();
+    if (!completedSessions.isEmpty()) {
+      List<Long> sessionIds = completedSessions.stream().map(GameSession::getId).toList();
+      for (Object[] row : roundScoreRepo.getTotalScoresBySessions(sessionIds)) {
+        Long sid = (Long) row[0];
+        // Reshape into [playerId, score] tuples to keep the existing inner-loop format.
+        scoresBySessionId
+            .computeIfAbsent(sid, k -> new ArrayList<>())
+            .add(new Object[] {row[1], row[2]});
+      }
+    }
+
+    // Bulk-load Riichi round details — one SQL for all Riichi sessions in scope.
+    Map<Long, List<Object[]>> riichiRoundsBySessionId = new HashMap<>();
+    List<Long> riichiSessionIds =
+        completedSessions.stream()
+            .filter(s -> s.getGameMode() == GameMode.RIICHI)
+            .map(GameSession::getId)
+            .toList();
+    if (!riichiSessionIds.isEmpty()) {
+      for (Object[] row : roundScoreRepo.getRoundDetailsBySessions(riichiSessionIds)) {
+        Long sid = (Long) row[0];
+        // Drop the leading sessionId so the per-session shape matches getRoundDetailsBySession.
+        riichiRoundsBySessionId
+            .computeIfAbsent(sid, k -> new ArrayList<>())
+            .add(new Object[] {row[1], row[2], row[3], row[4], row[5]});
+      }
+    }
+
     for (GameSession session : completedSessions) {
-      List<Object[]> sessionScores = roundScoreRepo.getTotalScoresBySession(session.getId());
+      List<Object[]> sessionScores = scoresBySessionId.getOrDefault(session.getId(), List.of());
       if (!sessionScores.isEmpty()) {
         String season = getSeasonStringFromUtc(session.getCreatedAt());
         String seasonModeKey = season + ":" + session.getGameMode().name();
@@ -930,8 +961,9 @@ public class GameService {
         // Round-level metrics only collected for Riichi (和牌率/放铳率/平均打点/平均铳点).
         // Other modes have different scoring semantics where these don't translate cleanly.
         if (session.getGameMode() == GameMode.RIICHI) {
+          List<Object[]> rows = riichiRoundsBySessionId.getOrDefault(session.getId(), List.of());
           accumulateRiichiRoundStats(
-              session.getId(), roundsPlayed, handWins, dealIns, winPointsSum, dealInPointsSum);
+              rows, roundsPlayed, handWins, dealIns, winPointsSum, dealInPointsSum);
         }
       }
     }
@@ -1015,13 +1047,12 @@ public class GameService {
    * dealInPlayerId == null, so no deal-in is recorded for those rounds).
    */
   private void accumulateRiichiRoundStats(
-      Long sessionId,
+      List<Object[]> rows,
       Map<Long, Integer> roundsPlayed,
       Map<Long, Integer> handWins,
       Map<Long, Integer> dealIns,
       Map<Long, Integer> winPointsSum,
       Map<Long, Integer> dealInPointsSum) {
-    List<Object[]> rows = roundScoreRepo.getRoundDetailsBySession(sessionId);
     Set<Long> seenRounds = new HashSet<>();
     for (Object[] row : rows) {
       Long roundId = (Long) row[0];
@@ -1058,18 +1089,21 @@ public class GameService {
 
     List<GameSession> sessions = sessionRepo.findByPlayersPlayerIdOrderByCreatedAtDesc(playerId);
 
+    // Bulk-load this player's score per session — replaces N+1 calls to getTotalScoresBySession.
+    Map<Long, Integer> scoreBySession = new HashMap<>();
+    if (!sessions.isEmpty()) {
+      List<Long> sessionIds = sessions.stream().map(GameSession::getId).toList();
+      for (Object[] row : roundScoreRepo.getTotalScoresBySessions(sessionIds)) {
+        if (row[1] != null && ((Long) row[1]).equals(playerId)) {
+          scoreBySession.put((Long) row[0], ((Number) row[2]).intValue());
+        }
+      }
+    }
+
     List<PlayerDetailResponse.GameEntry> games =
         sessions.stream()
             .map(
                 session -> {
-                  List<Object[]> scores = roundScoreRepo.getTotalScoresBySession(session.getId());
-                  int totalScore =
-                      scores.stream()
-                          .filter(r -> r[0] != null && ((Long) r[0]).equals(playerId))
-                          .map(r -> ((Number) r[1]).intValue())
-                          .findFirst()
-                          .orElse(0);
-
                   PlayerDetailResponse.GameEntry entry = new PlayerDetailResponse.GameEntry();
                   entry.setSessionId(session.getId());
                   entry.setSessionName(session.getName());
@@ -1077,7 +1111,7 @@ public class GameService {
                   entry.setGameModeDisplayName(session.getGameMode().getDisplayName());
                   entry.setStatus(session.getStatus().name());
                   entry.setCreatedAt(session.getCreatedAt());
-                  entry.setTotalScore(totalScore);
+                  entry.setTotalScore(scoreBySession.getOrDefault(session.getId(), 0));
                   return entry;
                 })
             .collect(Collectors.toList());

--- a/server/src/main/java/com/mahjong/omakase/service/TableStrengthService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TableStrengthService.java
@@ -60,14 +60,31 @@ public class TableStrengthService {
    */
   public TableStrength compute(List<Player> players, GameMode mode, LocalDateTime sessionDate) {
     if (mode != GameMode.GUOBIAO && mode != GameMode.RIICHI) return null;
+    Map<Long, Tier> tierByPlayer =
+        sessionDate != null ? tierService.resolveTiersForDate(mode, sessionDate) : Map.of();
+    Map<Long, Integer> monthlyByPlayer =
+        sessionDate != null
+            ? tierService.monthlyGamesByPlayerForReferenceDate(mode, sessionDate)
+            : Map.of();
+    return compute(players, mode, tierByPlayer, monthlyByPlayer);
+  }
+
+  /**
+   * Precomputed-map overload — caller provides the per-(mode, month) tier and monthly-games maps so
+   * a request that summarizes 150 sessions doesn't redo {@code resolveTiersForDate} + {@code
+   * monthlyGamesByPlayer} 150 times. {@link GameService#getAllSessionSummaries} groups sessions by
+   * (mode, PT year-month) and reuses one map per group.
+   */
+  public TableStrength compute(
+      List<Player> players,
+      GameMode mode,
+      Map<Long, Tier> tierByPlayer,
+      Map<Long, Integer> monthlyByPlayer) {
+    if (mode != GameMode.GUOBIAO && mode != GameMode.RIICHI) return null;
     if (players == null) return TableStrength.BAI_QUE_LIN;
 
     List<Player> humans = players.stream().filter(p -> p != null && !p.isBot()).toList();
     if (humans.size() < 2) return TableStrength.BAI_QUE_LIN;
-
-    // Tier per player AT THE TIME of the session — snapshot for past months, live for current.
-    Map<Long, Tier> tierByPlayer =
-        sessionDate != null ? tierService.resolveTiersForDate(mode, sessionDate) : Map.of();
 
     int stableTop = 0;
     int lv3Count = 0;
@@ -77,10 +94,7 @@ public class TableStrengthService {
       Tier t = tierByPlayer.getOrDefault(p.getId(), tierService.computeTier(p, mode));
       if (t == Tier.LV3 || t == Tier.LV4_THRONE) {
         lv3Count++;
-        int monthlyGames =
-            sessionDate != null
-                ? tierService.monthlyGamesForReferenceDate(p, mode, sessionDate)
-                : tierService.monthlyGames(p, mode);
+        int monthlyGames = monthlyByPlayer.getOrDefault(p.getId(), 0);
         if (monthlyGames >= STABLE_TOP_MONTHLY_GAMES) {
           stableTop++;
         }

--- a/server/src/main/java/com/mahjong/omakase/service/TableStrengthService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TableStrengthService.java
@@ -82,6 +82,8 @@ public class TableStrengthService {
       Map<Long, Integer> monthlyByPlayer) {
     if (mode != GameMode.GUOBIAO && mode != GameMode.RIICHI) return null;
     if (players == null) return TableStrength.BAI_QUE_LIN;
+    Map<Long, Tier> safeTiers = tierByPlayer != null ? tierByPlayer : Map.of();
+    Map<Long, Integer> safeMonthly = monthlyByPlayer != null ? monthlyByPlayer : Map.of();
 
     List<Player> humans = players.stream().filter(p -> p != null && !p.isBot()).toList();
     if (humans.size() < 2) return TableStrength.BAI_QUE_LIN;
@@ -91,10 +93,10 @@ public class TableStrengthService {
     int lv1Count = 0;
 
     for (Player p : humans) {
-      Tier t = tierByPlayer.getOrDefault(p.getId(), tierService.computeTier(p, mode));
+      Tier t = safeTiers.getOrDefault(p.getId(), tierService.computeTier(p, mode));
       if (t == Tier.LV3 || t == Tier.LV4_THRONE) {
         lv3Count++;
-        int monthlyGames = monthlyByPlayer.getOrDefault(p.getId(), 0);
+        int monthlyGames = safeMonthly.getOrDefault(p.getId(), 0);
         if (monthlyGames >= STABLE_TOP_MONTHLY_GAMES) {
           stableTop++;
         }

--- a/server/src/main/java/com/mahjong/omakase/service/TierService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TierService.java
@@ -343,13 +343,6 @@ public class TierService {
     return monthlyGames(p, mode, r[0], r[1]);
   }
 
-  public int monthlyGamesForReferenceDate(Player p, GameMode mode, LocalDateTime referenceUtc) {
-    java.time.LocalDate pacificDate =
-        referenceUtc.atZone(ZONE_UTC).withZoneSameInstant(ZONE_PACIFIC).toLocalDate();
-    LocalDateTime[] r = monthUtcRangeFor(pacificDate);
-    return monthlyGames(p, mode, r[0], r[1]);
-  }
-
   /**
    * Bulk: per-player count of completed sessions in [start, end) for a mode. One SQL — replaces
    * per-player {@code findAll}+filter scans that were causing N+1 lazy collection loads on the

--- a/server/src/main/java/com/mahjong/omakase/service/TierService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TierService.java
@@ -364,6 +364,15 @@ public class TierService {
     return out;
   }
 
+  /** Convenience: bulk monthly games for the PT month containing the given UTC reference date. */
+  public Map<Long, Integer> monthlyGamesByPlayerForReferenceDate(
+      GameMode mode, LocalDateTime referenceUtc) {
+    java.time.LocalDate pacificDate =
+        referenceUtc.atZone(ZONE_UTC).withZoneSameInstant(ZONE_PACIFIC).toLocalDate();
+    LocalDateTime[] r = monthUtcRangeFor(pacificDate);
+    return monthlyGamesByPlayer(mode, r[0], r[1]);
+  }
+
   private int monthlyGames(Player p, GameMode mode, LocalDateTime startUtc, LocalDateTime endUtc) {
     return monthlyGamesByPlayer(mode, startUtc, endUtc).getOrDefault(p.getId(), 0);
   }

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -31,16 +31,6 @@ export default function ProfilePage() {
     setDiscoveries([])
     setTier(null)
 
-    // 1. 各模式战绩并行拉取
-    GAME_MODES.forEach((mode) => {
-      fetchStats(mode.key)
-        .then((data) => {
-          const myStat = data.find((s: any) => s.playerId === me.id)
-          if (myStat) setStatsByMode((prev) => ({ ...prev, [mode.key]: myStat }))
-        })
-        .catch(console.error)
-    })
-
     // 2. 稀有番种成就(仅国标产生)
     fetchFanDiscoveries()
       .then((data) => {
@@ -57,6 +47,18 @@ export default function ProfilePage() {
         setTier(null)
       })
   }, [me])
+
+  // 个人战绩按需拉取: 只拉当前选中模式的, 切模式时再拉. 避免开页就触发 3 次重的 stats 请求.
+  useEffect(() => {
+    if (!me) return
+    if (statsByMode[selectedMode]) return
+    fetchStats(selectedMode)
+      .then((data) => {
+        const myStat = data.find((s: any) => s.playerId === me.id)
+        if (myStat) setStatsByMode((prev) => ({ ...prev, [selectedMode]: myStat }))
+      })
+      .catch(console.error)
+  }, [me, selectedMode, statsByMode])
 
   if (!me) {
     return (


### PR DESCRIPTION
## Summary

- /game 页面之前每个 session 都重做 `resolveTiersForDate` + `monthlyGamesByPlayer`，150 sessions × 多次 SQL = 几百次往返，页面打开 5+ 秒
- 改为请求级 cache，按 `(mode, PT 年-月)` key 共享，~6 个月 × 2 mode = 12 SQL 全搞定
- `annotateRankingsTier` 复用同一个 tier map，顺便切换到 session-month tier（之前用今日 tier，现在和 TableStrength 一致）

## Test plan

- [ ] 部署后打开 /game，应该秒开（之前 5+ 秒）
- [ ] 段位徽章正确显示（每行玩家旁边）
- [ ] 桌力 tag 正确显示（凤凰台 / 麒麟阁 / 困龙阙 / 太极殿 / 百雀林）
- [ ] 历史月份的 session 显示**当时的**段位 + 桌力，不是今日的
- [ ] /stats 和 /profile 等已优化的页面没有 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized session summary generation through caching of tier and monthly game data across multiple sessions, reducing redundant calculations and improving response times when retrieving session summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->