### PR TITLE
perf(cache): Caffeine 后端缓存 + 启动预热, 删 UI 30s cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'com.google.api-client:google-api-client:2.2.0'
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'

--- a/server/src/main/java/com/mahjong/omakase/MahjongOmakaseApplication.java
+++ b/server/src/main/java/com/mahjong/omakase/MahjongOmakaseApplication.java
@@ -2,10 +2,12 @@ package com.mahjong.omakase;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableCaching
 public class MahjongOmakaseApplication {
   public static void main(String[] args) {
     SpringApplication.run(MahjongOmakaseApplication.class, args);

--- a/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -147,6 +147,7 @@ public class AdminController {
   public Map<String, Object> backfillTier(@RequestHeader("X-Admin-Password") String password) {
     checkPassword(password);
     TierService.BackfillResult r = tierService.backfillAllHistory();
+    gameService.evictAllCaches();
     log.info("Admin triggered tier backfill: processed={} skipped={}", r.processed(), r.skipped());
     return Map.of("processed", r.processed(), "skipped", r.skipped());
   }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -14,6 +14,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.event.EventListener;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -40,6 +42,7 @@ public class GameService {
   private final TierService tierService;
   private final TableStrengthService tableStrengthService;
   private final PlayerMonthlySkillRepository monthlySkillRepo;
+  private final CacheManager cacheManager;
   private final Map<GameMode, GameModeHandler> handlers;
   private volatile double participationBonus;
 
@@ -54,6 +57,7 @@ public class GameService {
       TierService tierService,
       TableStrengthService tableStrengthService,
       PlayerMonthlySkillRepository monthlySkillRepo,
+      CacheManager cacheManager,
       List<GameModeHandler> handlerList) {
     this.playerRepo = playerRepo;
     this.sessionRepo = sessionRepo;
@@ -65,15 +69,53 @@ public class GameService {
     this.tierService = tierService;
     this.tableStrengthService = tableStrengthService;
     this.monthlySkillRepo = monthlySkillRepo;
+    this.cacheManager = cacheManager;
     this.handlers =
         handlerList.stream()
             .collect(Collectors.toMap(GameModeHandler::getGameMode, Function.identity()));
     this.participationBonus = loadParticipationBonus();
   }
 
+  /**
+   * Wipes every derived-state cache. Called from every write path that could change session list,
+   * player stats, home summary, or active seasons. Cheaper than fine-grained per-cache eviction —
+   * caches refill on the next read.
+   */
+  public void evictAllCaches() {
+    for (String name : cacheManager.getCacheNames()) {
+      var cache = cacheManager.getCache(name);
+      if (cache != null) cache.clear();
+    }
+  }
+
   @EventListener(ApplicationReadyEvent.class)
   public void init() {
     initializeDiscoveries();
+    warmupCaches();
+  }
+
+  /**
+   * Pre-populate the read caches so the first user request after deploy doesn't pay the cold cost.
+   * Without this, deploy + idle hours = the next user gets a slow page even though the Caffeine
+   * cache exists — it would just be empty.
+   */
+  private void warmupCaches() {
+    log.info("Warming up read caches...");
+    try {
+      getAllSessionSummaries();
+      getActiveSeasons();
+      java.time.LocalDate today = java.time.LocalDate.now(ZONE_PACIFIC);
+      LocalDateTime ptStart = YearMonth.from(today).atDay(1).atStartOfDay();
+      LocalDateTime ptEnd = YearMonth.from(today).plusMonths(1).atDay(1).atStartOfDay();
+      getHomeSummary(ptStart, ptEnd);
+      for (GameMode mode : GameMode.values()) {
+        getPlayerStats(mode, ptStart, ptEnd);
+      }
+      log.info("Cache warmup done");
+    } catch (RuntimeException e) {
+      // Don't fail boot if warmup hits an issue — caches will fill on first real request anyway.
+      log.warn("Cache warmup hit an error (caches will fill lazily): {}", e.getMessage());
+    }
   }
 
   public void initializeDiscoveries() {
@@ -159,6 +201,7 @@ public class GameService {
 
   public void reloadSettings() {
     this.participationBonus = loadParticipationBonus();
+    evictAllCaches();
   }
 
   private double loadParticipationBonus() {
@@ -219,7 +262,9 @@ public class GameService {
       player.setLastName(lastName.trim());
     }
     log.info("Updated player id={}, name='{} {}'", id, player.getFirstName(), player.getLastName());
-    return playerRepo.save(player);
+    Player saved = playerRepo.save(player);
+    evictAllCaches();
+    return saved;
   }
 
   public void deletePlayer(Long id) {
@@ -239,9 +284,11 @@ public class GameService {
     gameSessionPlayerRepo.deleteByPlayerId(id);
     monthlySkillRepo.deleteByPlayerId(id);
     playerRepo.deleteById(Objects.requireNonNull(id));
+    evictAllCaches();
   }
 
   @Transactional(readOnly = true)
+  @Cacheable("sessionSummaries")
   public List<SessionSummaryResponse> getAllSessionSummaries() {
     List<GameSession> sessions = sessionRepo.findAllByOrderByCreatedAtDesc();
     Map<String, Map<Long, Tier>> tiersCache = new HashMap<>();
@@ -330,6 +377,7 @@ public class GameService {
         session.getId(),
         session.getName(),
         session.getPlayerCount());
+    evictAllCaches();
     return session;
   }
 
@@ -564,6 +612,7 @@ public class GameService {
         request.getPrevalentWind(),
         request.getRiichiPlayerIds(),
         request.getBackfill());
+    evictAllCaches();
   }
 
   public void deleteRound(Long sessionId, int roundNumber) {
@@ -587,6 +636,7 @@ public class GameService {
       r.setRoundNumber(num++);
     }
     sessionRepo.save(session);
+    evictAllCaches();
   }
 
   public void completeSession(Long sessionId) {
@@ -610,6 +660,7 @@ public class GameService {
     tierService.onSessionCompleted(session, totals);
 
     log.info("Completed session id={}", sessionId);
+    evictAllCaches();
   }
 
   public void deleteSession(Long sessionId) {
@@ -622,6 +673,7 @@ public class GameService {
     sessionRepo.delete(session);
     log.info("Deleted session id={}", sessionId);
     rederiveDiscoveriesForSeason(mode, sessionTime);
+    evictAllCaches();
   }
 
   private void rederiveDiscoveriesForSeason(GameMode mode, LocalDateTime sessionTime) {
@@ -736,6 +788,7 @@ public class GameService {
         .collect(Collectors.toList());
   }
 
+  @Cacheable("activeSeasons")
   public List<Map<String, Integer>> getActiveSeasons() {
     List<LocalDateTime> creationTimes = sessionRepo.findSessionCreationTimesWithRounds();
     Set<YearMonth> seasons = new TreeSet<>(Comparator.reverseOrder());
@@ -759,6 +812,7 @@ public class GameService {
    * and per-mode rankings (top 3 by RP + best round). Replaces 1 + N + 2M frontend round-trips with
    * one response.
    */
+  @Cacheable("homeSummary")
   public HomeSummaryResponse getHomeSummary(LocalDateTime start, LocalDateTime end) {
     List<SessionDetailResponse> activeSessions =
         sessionRepo.findByStatusOrderByCreatedAtDesc(SessionStatus.IN_PROGRESS).stream()
@@ -791,6 +845,7 @@ public class GameService {
    *     back to returning all-time statistics. The season string is derived consistently using
    *     getSeasonStringFromUtc.
    */
+  @Cacheable("playerStats")
   public List<PlayerStatsResponse> getPlayerStats(
       GameMode gameMode, LocalDateTime start, LocalDateTime end) {
     List<Player> players = playerRepo.findAll();

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -13,6 +13,15 @@ spring:
   h2:
     console:
       enabled: false
+  cache:
+    type: caffeine
+    cache-names:
+      - sessionSummaries
+      - playerStats
+      - homeSummary
+      - activeSeasons
+    caffeine:
+      spec: maximumSize=200,recordStats
 
 server:
   port: ${PORT:8080}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -14,36 +14,6 @@ import { MSG } from '../constants'
 
 const API = '/api'
 
-const cache = new Map<string, { data: unknown; expiry: number }>()
-const CACHE_TTL = 30_000
-
-if (typeof document !== 'undefined') {
-  document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible') cache.clear()
-  })
-}
-
-function getCached<T>(key: string): T | null {
-  const entry = cache.get(key)
-  if (entry && Date.now() < entry.expiry) return structuredClone(entry.data) as T
-  cache.delete(key)
-  return null
-}
-
-function setCache(key: string, data: unknown) {
-  cache.set(key, { data, expiry: Date.now() + CACHE_TTL })
-}
-
-export function invalidateCache(prefix?: string) {
-  if (!prefix) {
-    cache.clear()
-    return
-  }
-  for (const key of cache.keys()) {
-    if (key.startsWith(prefix)) cache.delete(key)
-  }
-}
-
 function getAuthHeaders(headers: Record<string, string> = {}): Record<string, string> {
   const token = localStorage.getItem('mahjong_token')
   if (token) {
@@ -62,16 +32,9 @@ async function handleResponse<T = void>(res: Response): Promise<T> {
   return JSON.parse(text)
 }
 
-async function cachedFetch<T>(url: string, signal?: AbortSignal): Promise<T> {
-  const cached = getCached<T>(url)
-  if (cached) return cached
-  const res = await fetch(url, {
-    signal,
-    headers: getAuthHeaders(),
-  })
-  const data = await handleResponse<T>(res)
-  setCache(url, data)
-  return data
+async function authFetch<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(url, { signal, headers: getAuthHeaders() })
+  return handleResponse<T>(res)
 }
 
 export async function loginWithGoogle(credential: string): Promise<{ token: string; player: Player }> {
@@ -91,7 +54,7 @@ export async function fetchCurrentUser(): Promise<Player> {
 }
 
 export async function fetchPlayers(): Promise<Player[]> {
-  return cachedFetch(`${API}/players`)
+  return authFetch(`${API}/players`)
 }
 
 export async function createPlayer(userName: string, firstName: string, lastName: string): Promise<Player> {
@@ -100,9 +63,7 @@ export async function createPlayer(userName: string, firstName: string, lastName
     headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ userName, firstName, lastName }),
   })
-  const data = await handleResponse<Player>(res)
-  invalidateCache()
-  return data
+  return handleResponse<Player>(res)
 }
 
 export async function checkUserName(userName: string): Promise<boolean> {
@@ -114,7 +75,7 @@ export async function checkUserName(userName: string): Promise<boolean> {
 }
 
 export async function fetchSessions(signal?: AbortSignal): Promise<GameSession[]> {
-  return cachedFetch(`${API}/sessions`, signal)
+  return authFetch(`${API}/sessions`, signal)
 }
 
 export async function createSession(name: string, gameMode: string, playerIds: number[]): Promise<GameSession> {
@@ -123,13 +84,11 @@ export async function createSession(name: string, gameMode: string, playerIds: n
     headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ name, gameMode, playerIds }),
   })
-  const data = await handleResponse<GameSession>(res)
-  invalidateCache()
-  return data
+  return handleResponse<GameSession>(res)
 }
 
 export async function fetchSessionDetail(id: number, signal?: AbortSignal): Promise<SessionDetail> {
-  return cachedFetch(`${API}/sessions/${id}`, signal)
+  return authFetch(`${API}/sessions/${id}`, signal)
 }
 
 export async function addRound(sessionId: number, data: AddRoundData): Promise<void> {
@@ -139,7 +98,6 @@ export async function addRound(sessionId: number, data: AddRoundData): Promise<v
     body: JSON.stringify(data),
   })
   await handleResponse(res)
-  invalidateCache()
 }
 
 export async function deleteRound(sessionId: number, roundNumber: number): Promise<void> {
@@ -148,7 +106,6 @@ export async function deleteRound(sessionId: number, roundNumber: number): Promi
     headers: getAuthHeaders(),
   })
   await handleResponse(res)
-  invalidateCache()
 }
 
 export async function completeSession(id: number): Promise<void> {
@@ -157,11 +114,10 @@ export async function completeSession(id: number): Promise<void> {
     headers: getAuthHeaders(),
   })
   await handleResponse(res)
-  invalidateCache()
 }
 
 export async function fetchActiveSeasons(): Promise<{ year: number; month: number }[]> {
-  return cachedFetch(`${API}/stats/seasons`)
+  return authFetch(`${API}/stats/seasons`)
 }
 
 export async function fetchStats(
@@ -177,15 +133,15 @@ export async function fetchStats(
     params.set('month', String(month))
   }
   const qs = params.toString()
-  return cachedFetch(`${API}/stats${qs ? `?${qs}` : ''}`, signal)
+  return authFetch(`${API}/stats${qs ? `?${qs}` : ''}`, signal)
 }
 
 export async function fetchPlayerDetail(id: number): Promise<PlayerDetail> {
-  return cachedFetch(`${API}/players/${id}/detail`)
+  return authFetch(`${API}/players/${id}/detail`)
 }
 
 export async function fetchPlayerTier(id: number): Promise<PlayerTierResponse> {
-  return cachedFetch(`${API}/players/${id}/tier`)
+  return authFetch(`${API}/players/${id}/tier`)
 }
 
 export async function fetchBestRounds(
@@ -201,7 +157,7 @@ export async function fetchBestRounds(
     params.set('month', String(month))
   }
   const qs = params.toString()
-  return cachedFetch(`${API}/stats/best-rounds${qs ? `?${qs}` : ''}`, signal)
+  return authFetch(`${API}/stats/best-rounds${qs ? `?${qs}` : ''}`, signal)
 }
 
 export async function fetchHomeSummary(year?: number, month?: number, signal?: AbortSignal): Promise<HomeSummary> {
@@ -211,7 +167,7 @@ export async function fetchHomeSummary(year?: number, month?: number, signal?: A
     params.set('month', String(month))
   }
   const qs = params.toString()
-  return cachedFetch(`${API}/home-summary${qs ? `?${qs}` : ''}`, signal)
+  return authFetch(`${API}/home-summary${qs ? `?${qs}` : ''}`, signal)
 }
 
 export async function fetchFanDiscoveries(
@@ -228,7 +184,7 @@ export async function fetchFanDiscoveries(
     params.set('month', String(month))
   }
   const qs = params.toString()
-  return cachedFetch(`${API}/stats/fan-discoveries${qs ? `?${qs}` : ''}`, signal)
+  return authFetch(`${API}/stats/fan-discoveries${qs ? `?${qs}` : ''}`, signal)
 }
 
 export async function setupProfile(userName: string, firstName: string, lastName: string): Promise<Player> {
@@ -237,9 +193,7 @@ export async function setupProfile(userName: string, firstName: string, lastName
     headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ userName, firstName, lastName }),
   })
-  const data = await handleResponse<Player>(res)
-  invalidateCache()
-  return data
+  return handleResponse<Player>(res)
 }
 
 export async function lookupClaimablePlayer(userName: string, firstName: string, lastName: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

修第一个用户访问慢的问题。两层一起做:

**A. Caffeine 后端缓存**
- 4 个重读 endpoint 加 \`@Cacheable\`: \`getAllSessionSummaries\` / \`getPlayerStats\` / \`getHomeSummary\` / \`getActiveSeasons\`
- 写路径调 \`evictAllCaches()\`: createSession / addRound / deleteRound / completeSession / deleteSession / updatePlayer / deletePlayer / reloadSettings + admin/tier/backfill
- 缓存语义: 没有 TTL, 写就 evict, 始终是最新数据

**B. 启动预热**
- \`ApplicationReadyEvent\` 触发时调一次 4 个查询, 把 cache 填好
- → deploy 后闲几小时 / 几天再有人来, 第一个用户也是秒开 (不靠 OS file cache 续命)

**清理**:
- 删掉 UI 端 \`ui/src/api/index.ts\` 那个 30s in-memory cache
- 后端 cache 后, 网络往返 ~10ms, UI cache 救不了那点延迟, 反而引入 tab 间数据不一致 + 每次命中都 \`structuredClone\` 大对象的开销
- 所有 \`cachedFetch(url)\` → \`authFetch(url)\`, 直走 fetch

## Test plan

- [ ] 部署后**立即**打开 /game, 应该秒开 (启动预热已填 cache)
- [ ] 闲置几小时后再打开, 也秒开 (cache 在 JVM heap 里, 不会被 OS evict)
- [ ] 创建新对局 / 加分 / 完成对局 → 立刻在 /game 列表里看到 (cache 已 evict)
- [ ] 多 tab 切换不再有 30s 数据卡顿/不一致
- [ ] /api/admin/tier/backfill 跑完, /stats 段位数据立即更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)