### PR TITLE
style(rank): mobile 段位 icon 缩小一档, 尺寸搬到 CSS 不再 inline

### DIFF
--- a/ui/src/components/RankBadge.tsx
+++ b/ui/src/components/RankBadge.tsx
@@ -14,8 +14,6 @@ interface Props {
   className?: string
 }
 
-const SIZE_PX: Record<'sm' | 'md' | 'lg', number> = { sm: 52, md: 112, lg: 220 }
-
 const TIER_TO_IMAGE: Record<TierKey, string | null> = {
   UNRANKED: null,
   LV1: 'lv1',
@@ -27,7 +25,6 @@ const TIER_TO_IMAGE: Record<TierKey, string | null> = {
 export const RankBadge: React.FC<Props> = ({ tier, size = 'sm', gamesNeeded, rating, onClick, className }) => {
   const [imgFailed, setImgFailed] = useState(false)
   if (!tier) return null
-  const px = SIZE_PX[size]
   const imageBase = TIER_TO_IMAGE[tier]
   // Always use _small.png — large versions are 3-6MB and tank performance.
   const src = imageBase ? `/rank/${imageBase}_small.png` : null
@@ -57,11 +54,7 @@ export const RankBadge: React.FC<Props> = ({ tier, size = 'sm', gamesNeeded, rat
   // Unranked + md/lg: bigger progress card without image
   if (tier === 'UNRANKED') {
     return (
-      <div
-        className={`rank-badge rank-badge-unranked rank-badge-${size} ${className ?? ''}`}
-        onClick={onClick}
-        style={{ width: px, height: px }}
-      >
+      <div className={`rank-badge rank-badge-unranked rank-badge-${size} ${className ?? ''}`} onClick={onClick}>
         <div className="rank-badge-progress">{showProgress ? `${progressPlayed}/5` : '未定段'}</div>
       </div>
     )
@@ -75,9 +68,7 @@ export const RankBadge: React.FC<Props> = ({ tier, size = 'sm', gamesNeeded, rat
         onClick={onClick}
         title={label}
       >
-        <span className="rank-badge-fallback" style={{ width: px, height: px }}>
-          {label.slice(0, 1)}
-        </span>
+        <span className="rank-badge-fallback">{label.slice(0, 1)}</span>
         {size !== 'sm' && (
           <span className="rank-badge-meta">
             <span className="rank-badge-name">{label}</span>
@@ -95,13 +86,7 @@ export const RankBadge: React.FC<Props> = ({ tier, size = 'sm', gamesNeeded, rat
       title={`${label}${rating !== undefined ? ` · ${rating.toFixed(0)}` : ''}`}
       onClick={onClick}
     >
-      <img
-        src={src}
-        alt={label}
-        className="rank-badge-img"
-        style={{ width: px, height: px }}
-        onError={() => setImgFailed(true)}
-      />
+      <img src={src} alt={label} className="rank-badge-img" onError={() => setImgFailed(true)} />
       {size !== 'sm' && (
         <span className="rank-badge-meta">
           <span className="rank-badge-name">{label}</span>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1165,6 +1165,27 @@ tr:hover td {
   object-fit: cover;
 }
 
+/* Per-size dimensions — applied to <img> / fallback box / UNRANKED card. */
+.rank-badge-sm .rank-badge-img,
+.rank-badge-sm .rank-badge-fallback {
+  width: 52px;
+  height: 52px;
+}
+
+.rank-badge-md .rank-badge-img,
+.rank-badge-md .rank-badge-fallback,
+.rank-badge-unranked.rank-badge-md {
+  width: 112px;
+  height: 112px;
+}
+
+.rank-badge-lg .rank-badge-img,
+.rank-badge-lg .rank-badge-fallback,
+.rank-badge-unranked.rank-badge-lg {
+  width: 220px;
+  height: 220px;
+}
+
 .rank-badge-sm {
   font-size: 0.75rem;
 }
@@ -1707,6 +1728,28 @@ tr:hover td {
 
   .quick-win-container {
     margin-bottom: 12px;
+  }
+
+  /* Rank badges: shrink across all sizes on mobile to keep dense layouts readable. */
+  .rank-badge-sm .rank-badge-img,
+  .rank-badge-sm .rank-badge-fallback,
+  .rank-badge-unranked-sm {
+    width: 38px;
+    height: 38px;
+  }
+
+  .rank-badge-md .rank-badge-img,
+  .rank-badge-md .rank-badge-fallback,
+  .rank-badge-unranked.rank-badge-md {
+    width: 80px;
+    height: 80px;
+  }
+
+  .rank-badge-lg .rank-badge-img,
+  .rank-badge-lg .rank-badge-fallback,
+  .rank-badge-unranked.rank-badge-lg {
+    width: 140px;
+    height: 140px;
   }
 }
 


### PR DESCRIPTION
之前 RankBadge 用 inline style={{ width, height }} 设尺寸 → CSS 想 mobile override 得 !important. 重构成纯 CSS class:

- .rank-badge-sm/md/lg .rank-badge-img/fallback 用 CSS 设 desktop 尺寸 (52/112/220)
- @media (width <= 640px) override: 38/80/140
- inline UNRANKED .rank-badge-unranked-sm 桌面 52px / mobile 38px

桌面尺寸不变, 手机上紧凑很多. 不影响 desktop UI.

## Summary
<!-- Brief description of what this PR does -->

## Test plan
<!-- How to verify the changes -->
- [ ] `./gradlew build` passes
- [ ] `cd ui && npm run build` passes
- [ ] `cd ui && npm run test:run` — all tests pass

---

<!-- CodeRabbit commands:
  @coderabbitai review      — trigger a review on new changes
  @coderabbitai full review — re-review the entire PR from scratch
  @coderabbitai summary     — regenerate the PR summary
  @coderabbitai ignore      — stop reviewing this PR entirely
  @coderabbitai resolve     — top-level: resolve all comments; reply: resolve that thread only
-->
