### PR TITLE
fix(rank): PlayerDetailPage 段位徽章传 userName

### DIFF
--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -59,6 +59,7 @@ export default function PlayerDetailPage() {
                 <RankBadge
                   tier={tier.guobiao.tier}
                   size="md"
+                  userName={tier.userName}
                   rating={tier.guobiao.tier === 'UNRANKED' ? undefined : tier.guobiao.rating}
                   gamesNeeded={tier.guobiao.gamesNeeded}
                 />
@@ -68,6 +69,7 @@ export default function PlayerDetailPage() {
                 <RankBadge
                   tier={tier.riichi.tier}
                   size="md"
+                  userName={tier.userName}
                   rating={tier.riichi.tier === 'UNRANKED' ? undefined : tier.riichi.rating}
                   gamesNeeded={tier.riichi.gamesNeeded}
                 />


### PR DESCRIPTION
## Summary

之前的 PR #129 漏了 PlayerDetailPage 的两个 md 段位徽章 (国标 + 立直) 没传 \`userName\`. BOT 玩家的 detail 页会显示 "未定段" 而不是 🤖.

其他 5 个 RankBadge 调用点 (GameCard / SessionPage / HomePage / StatsPage × 2) 都已经传了.

## Test plan

- [ ] 进入 BOT 玩家详情页 \`/player/<bot-id>\`, 国标 + 立直两张大徽章应该都是 🤖, 不是"未定段"
- [ ] 进入普通玩家详情页, 段位显示不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced rank badge display on the player detail page to include user information in both rating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->