### PR TITLE
style(rank): mobile 上'新' / 🤖 字号跟圆圈一起缩

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1795,6 +1795,20 @@ tr:hover td {
     width: 140px;
     height: 140px;
   }
+
+  /* "新" / BOT 🤖 字号跟着圆圈一起缩, 不然字撑不满或溢出. */
+  .rank-badge-new {
+    font-size: 1.1rem;
+  }
+
+  .rank-badge-bot {
+    font-size: 1.3rem;
+  }
+
+  .rank-badge-bot.rank-badge-md,
+  .rank-badge-bot.rank-badge-lg {
+    font-size: 2.2rem;
+  }
 }
 
 /* Calculator page uses a wider breakpoint because the dense toggle/wind


### PR DESCRIPTION
## Summary

上次 mobile 改动 (PR #128) 把段位圆圈缩了 (sm: 52 → 38px) 但漏了里面的字:
- \`.rank-badge-new\` 桌面 1.4rem 在 38px 圆圈里塞不下
- \`.rank-badge-bot\` 桌面 1.6rem (sm) / 3rem (md/lg) 同样溢出

补上 mobile override:
- 新: 1.4rem → 1.1rem
- 🤖 sm: 1.6rem → 1.3rem
- 🤖 md/lg: 3rem → 2.2rem

## Test plan

- [ ] 手机视图 (≤ 640px) 看 UNRANKED 玩家徽章 — "新" 字应该在圆圈里居中, 不溢出
- [ ] 手机视图看 BOT 徽章 — 🤖 应该在圆圈里居中
- [ ] 桌面尺寸不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)