### PR TITLE
fix(time): 全站时间统一按 PT 显示, 后端 LocalDateTime 序列化为 UTC 'Z'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN chmod +x gradlew && ./gradlew build -x test -x spotlessCheck -x spotlessAppl
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
+ENV TZ=Etc/UTC
 RUN mkdir -p /app/data
 COPY --from=build /app/build/libs/mahjong-omakase-*-SNAPSHOT.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Xmx512m", "-Xms256m", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=UTC", "-Xmx512m", "-Xms256m", "-jar", "app.jar"]

--- a/server/src/main/java/com/mahjong/omakase/config/JacksonConfig.java
+++ b/server/src/main/java/com/mahjong/omakase/config/JacksonConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -15,12 +16,12 @@ import org.springframework.context.annotation.Configuration;
  * 没有时区标记的 ISO 字符串在浏览器里会被当成本地时间, 在 PT 浏览器上会把 UTC 时间显示成 PT 数字, 即 main 页"显示成 UTC". 加上 'Z' 后 `new
  * Date(...)` 准确解析为 UTC instant, 前端再用 `toLocaleString({ timeZone: 'America/Los_Angeles' })` 转成 PT
  * 即可.
+ *
+ * <p>使用 {@link DateTimeFormatter#ISO_INSTANT} 保留源 {@code LocalDateTime} 自带的精度 (秒 / 毫秒 / 纳秒 都按需输出),
+ * 不强行截到秒.
  */
 @Configuration
 public class JacksonConfig {
-
-  private static final DateTimeFormatter UTC_ISO =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
   @Bean
   Jackson2ObjectMapperBuilderCustomizer localDateTimeAsUtcCustomizer() {
@@ -36,7 +37,7 @@ public class JacksonConfig {
     @Override
     public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider provider)
         throws IOException {
-      gen.writeString(value.format(UTC_ISO));
+      gen.writeString(DateTimeFormatter.ISO_INSTANT.format(value.toInstant(ZoneOffset.UTC)));
     }
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/config/JacksonConfig.java
+++ b/server/src/main/java/com/mahjong/omakase/config/JacksonConfig.java
@@ -1,0 +1,42 @@
+package com.mahjong.omakase.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 全站 LocalDateTime 序列化为带 'Z' 的 ISO-8601 字符串. 我们的存储约定是「LocalDateTime 视为 UTC instant」(JVM TZ 锁在 UTC),
+ * 没有时区标记的 ISO 字符串在浏览器里会被当成本地时间, 在 PT 浏览器上会把 UTC 时间显示成 PT 数字, 即 main 页"显示成 UTC". 加上 'Z' 后 `new
+ * Date(...)` 准确解析为 UTC instant, 前端再用 `toLocaleString({ timeZone: 'America/Los_Angeles' })` 转成 PT
+ * 即可.
+ */
+@Configuration
+public class JacksonConfig {
+
+  private static final DateTimeFormatter UTC_ISO =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+  @Bean
+  Jackson2ObjectMapperBuilderCustomizer localDateTimeAsUtcCustomizer() {
+    return builder ->
+        builder.serializerByType(LocalDateTime.class, new UtcLocalDateTimeSerializer());
+  }
+
+  private static final class UtcLocalDateTimeSerializer extends StdSerializer<LocalDateTime> {
+    UtcLocalDateTimeSerializer() {
+      super(LocalDateTime.class);
+    }
+
+    @Override
+    public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException {
+      gen.writeString(value.format(UTC_ISO));
+    }
+  }
+}

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -71,7 +71,9 @@ export default function ProfilePage() {
     )
   }
 
-  const formattedDate = me.createdAt ? new Date(me.createdAt).toLocaleString('zh-CN') : '未知时间'
+  const formattedDate = me.createdAt
+    ? new Date(me.createdAt).toLocaleString('zh-CN', { timeZone: 'America/Los_Angeles' })
+    : '未知时间'
   const displayName = me.firstName ? `${me.firstName} ${me.lastName}`.trim() : me.userName
 
   // 提交账号设置:先查后端有没有匹配的老账号,再用对应文案确认
@@ -337,7 +339,8 @@ export default function ProfilePage() {
                             🏅 {fd.fanName}
                           </div>
                           <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
-                            发现日期: {new Date(fd.discoveredAt).toLocaleDateString()}
+                            发现日期:{' '}
+                            {new Date(fd.discoveredAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
                           </div>
                         </div>
                         <span className="profile-status-pill profile-status-pill-warning">+{fd.bonusRp || 0} RP</span>


### PR DESCRIPTION
## 概要

3 files changed, +49 / -3. 修复 main 页时间显示成 UTC 的 bug, 把后端 `LocalDateTime` 在线路上明确标注为 UTC instant (`Z` 后缀), 锁定 Docker JVM 时区为 UTC, 并补齐 ProfilePage 两处遗漏的 `timeZone: 'America/Los_Angeles'`. service 层既有的 UTC↔PT 转换不动, 无数据迁移.

## 一、后端 Jackson 序列化

**原因**: 现状 `LocalDateTime` 序列化为不带时区标记的 ISO 字符串 (例如 `"2026-06-22T22:30:00"`). 浏览器 `new Date(...)` 按本地时区解析, 在 PT 浏览器上会把 UTC instant 误读为 PT, 后续 `toLocaleString({ timeZone: 'America/Los_Angeles' })` 再"转一次", 最终展示出来的数字反而对齐 UTC 时钟 —— 就是 main 页看到的 bug.

**改动**: 新增 `config/JacksonConfig.java`, 通过 `Jackson2ObjectMapperBuilderCustomizer` 把 `LocalDateTime` 全局序列化为 `yyyy-MM-dd'T'HH:mm:ss'Z'`. 前端 `new Date(...)` 拿到 `Z` 后正确解析为 UTC instant, 现有的 `toLocaleString({ timeZone: 'America/Los_Angeles' })` 转出来就是真正的 PT 数字.

## 二、Dockerfile 锁定 JVM 时区

**原因**: 现有 service 层 (TierService / GameService) 假定 `LocalDateTime.now()` 返回 UTC instant, 并显式做 UTC↔PT 转换. 但 Dockerfile 之前没有声明 `TZ`, 一旦换基础镜像或宿主时区漂移, `LocalDateTime.now()` 就会返回非 UTC 值, 破坏这个约定.

**改动**: `ENV TZ=Etc/UTC` + `-Duser.timezone=UTC` 显式钉死. 不引入 `America/Los_Angeles` 是为了不破坏现有 DB 中按 UTC instant 写入的历史数据.

## 三、前端 ProfilePage 补齐 PT 时区

**原因**: 全站其它页面 (GameCard / SessionPage / AdminPage / StatsPage / PlayerDetailPage / DashboardPage) 都已经显式传 `timeZone: 'America/Los_Angeles'`, 唯独 ProfilePage 注册时间与番种发现日期漏掉了, 回落到浏览器本地时区.

**改动**:
- `ProfilePage.tsx:74` 注册时间 `toLocaleString('zh-CN')` → 追加 `{ timeZone: 'America/Los_Angeles' }`
- `ProfilePage.tsx:340` 番种发现日期 `toLocaleDateString()` → 追加 `{ timeZone: 'America/Los_Angeles' }`

## 测试要点

- [ ] main 页正在进行对局卡片的时间应显示为 PT (例如美西凌晨 0:30 对局, 在 PT 浏览器、UTC 浏览器、其它时区浏览器看到的都是同一个 PT 数字)
- [ ] 复测 SessionPage / AdminPage / StatsPage / PlayerDetailPage / DashboardPage 上的日期, 应与之前一致 (回归校验, 不应被 `Z` 改动破坏)
- [ ] ProfilePage 注册时间、番种发现日期应显示为 PT
- [ ] 月度边界相关功能 (荣誉殿堂排名 / 月度 ELO snapshot / MonthlyResetJob cron) 行为不变, 因为 service 层 UTC↔PT 转换没动
- [ ] 历史数据 (6 月已有 session / fan discovery) 显示时间合理, 没有出现集体偏移 7–8 小时的情况

## 文件改动

- `server/src/main/java/com/mahjong/omakase/config/JacksonConfig.java` (新增) — 全局 `LocalDateTime` → `Z` 序列化器
- `Dockerfile` — 增加 `TZ` env 与 `-Duser.timezone=UTC` JVM 参数
- `ui/src/pages/ProfilePage.tsx` — 注册时间与番种发现日期补上 PT 时区

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timezone handling to ensure accurate and consistent date and time displays across the platform. Account creation dates, discovery dates, and all timestamps now display correctly with improved timezone standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->