### PR TITLE
fix: 修复立直分数输入回写 + Google 临时玩家注册绑定 FK 违反

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
@@ -5,7 +5,11 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.mahjong.omakase.model.Player;
+import com.mahjong.omakase.repository.FanDiscoveryRepository;
+import com.mahjong.omakase.repository.GameSessionPlayerRepository;
+import com.mahjong.omakase.repository.PlayerMonthlySkillRepository;
 import com.mahjong.omakase.repository.PlayerRepository;
+import com.mahjong.omakase.repository.RoundScoreRepository;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -23,12 +27,25 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
   private final PlayerRepository playerRepo;
+  private final GameSessionPlayerRepository gameSessionPlayerRepo;
+  private final RoundScoreRepository roundScoreRepo;
+  private final FanDiscoveryRepository fanDiscoveryRepo;
+  private final PlayerMonthlySkillRepository monthlySkillRepo;
 
   @Value("${google.client-id:123456-dummy.apps.googleusercontent.com}")
   private String googleClientId;
 
-  public AuthController(PlayerRepository playerRepo) {
+  public AuthController(
+      PlayerRepository playerRepo,
+      GameSessionPlayerRepository gameSessionPlayerRepo,
+      RoundScoreRepository roundScoreRepo,
+      FanDiscoveryRepository fanDiscoveryRepo,
+      PlayerMonthlySkillRepository monthlySkillRepo) {
     this.playerRepo = playerRepo;
+    this.gameSessionPlayerRepo = gameSessionPlayerRepo;
+    this.roundScoreRepo = roundScoreRepo;
+    this.fanDiscoveryRepo = fanDiscoveryRepo;
+    this.monthlySkillRepo = monthlySkillRepo;
   }
 
   private String redactEmail(String email) {
@@ -211,33 +228,43 @@ public class AuthController {
 
     boolean claimedExisting = target != null;
 
-    // 2. Fall back to creating a fresh player record.
-    if (target == null) {
-      // Reject if the userName collides with someone else's bound (email != null) account.
-      // Case-insensitive to match the lookup above and the typical DB collation.
-      if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)) {
-        return ResponseEntity.badRequest()
-            .body(Map.of("error", "用户名「" + trimmedUserName + "」已被占用,请换一个"));
+    if (claimedExisting) {
+      // Claim path: merge current's identity (and any in-flight game references) into the
+      // legacy target, then delete current. Reassigning FKs first is required because current
+      // may already be sitting at a table / have round scores from the brief temp window.
+      gameSessionPlayerRepo.reassignPlayer(current.getId(), target.getId());
+      roundScoreRepo.reassignPlayer(current.getId(), target.getId());
+      fanDiscoveryRepo.reassignPlayer(current.getId(), target.getId());
+      monthlySkillRepo.deleteByPlayerId(current.getId());
+
+      String currentEmail = current.getEmail();
+      String currentPicture = current.getPictureUrl();
+      current.setEmail(null);
+      current.setToken(null);
+      playerRepo.saveAndFlush(current);
+
+      target.setEmail(currentEmail);
+      target.setPictureUrl(currentPicture);
+      target.setToken(token);
+      target.setMerged(true);
+      playerRepo.saveAndFlush(target);
+
+      playerRepo.delete(current);
+    } else {
+      // Register path: rename current in place. No new Player record and no delete — avoids the
+      // FK violation when current is already referenced by game_session_players / round_scores
+      // from a game that started during the onboarding window.
+      if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)
+          && !trimmedUserName.equalsIgnoreCase(current.getUserName())) {
+        return ResponseEntity.badRequest().body(Map.of("error", "用户名已被占用,请换一个"));
       }
-      target = playerRepo.save(new Player(trimmedUserName, trimmedFirstName, trimmedLastName));
+      current.setUserName(trimmedUserName);
+      current.setFirstName(trimmedFirstName);
+      current.setLastName(trimmedLastName);
+      current.setMerged(true);
+      playerRepo.saveAndFlush(current);
+      target = current;
     }
-
-    // 3. Merge current Google identity (email/picture/token) into target, mark merged, delete temp.
-    String currentEmail = current.getEmail();
-    String currentPicture = current.getPictureUrl();
-
-    // Release current's email/token first so the unique-index constraint doesn't trip on flush.
-    current.setEmail(null);
-    current.setToken(null);
-    playerRepo.saveAndFlush(current);
-
-    target.setEmail(currentEmail);
-    target.setPictureUrl(currentPicture);
-    target.setToken(token);
-    target.setMerged(true);
-    playerRepo.saveAndFlush(target);
-
-    playerRepo.delete(current);
 
     log.info(
         "Profile setup complete (mode={}) for username={}, id={}",

--- a/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.mahjong.omakase.repository.FanDiscoveryRepository;
 import com.mahjong.omakase.repository.GameSessionPlayerRepository;
 import com.mahjong.omakase.repository.PlayerMonthlySkillRepository;
 import com.mahjong.omakase.repository.PlayerRepository;
+import com.mahjong.omakase.repository.RoundRepository;
 import com.mahjong.omakase.repository.RoundScoreRepository;
 import java.util.Collections;
 import java.util.Map;
@@ -28,6 +29,7 @@ public class AuthController {
 
   private final PlayerRepository playerRepo;
   private final GameSessionPlayerRepository gameSessionPlayerRepo;
+  private final RoundRepository roundRepo;
   private final RoundScoreRepository roundScoreRepo;
   private final FanDiscoveryRepository fanDiscoveryRepo;
   private final PlayerMonthlySkillRepository monthlySkillRepo;
@@ -38,11 +40,13 @@ public class AuthController {
   public AuthController(
       PlayerRepository playerRepo,
       GameSessionPlayerRepository gameSessionPlayerRepo,
+      RoundRepository roundRepo,
       RoundScoreRepository roundScoreRepo,
       FanDiscoveryRepository fanDiscoveryRepo,
       PlayerMonthlySkillRepository monthlySkillRepo) {
     this.playerRepo = playerRepo;
     this.gameSessionPlayerRepo = gameSessionPlayerRepo;
+    this.roundRepo = roundRepo;
     this.roundScoreRepo = roundScoreRepo;
     this.fanDiscoveryRepo = fanDiscoveryRepo;
     this.monthlySkillRepo = monthlySkillRepo;
@@ -235,7 +239,15 @@ public class AuthController {
       gameSessionPlayerRepo.reassignPlayer(current.getId(), target.getId());
       roundScoreRepo.reassignPlayer(current.getId(), target.getId());
       fanDiscoveryRepo.reassignPlayer(current.getId(), target.getId());
+      // Round.winnerId / dealInPlayerId are loose-FK scalar Longs (not JPA associations) but they
+      // are still read by Riichi round-level stats — must follow the merge or histograms break.
+      roundRepo.reassignWinner(current.getId(), target.getId());
+      roundRepo.reassignDealInPlayer(current.getId(), target.getId());
+      // Monthly skill snapshots are derived; clear BOTH sides so TierService rebuilds them on next
+      // read. current's rows would otherwise FK-block the delete; target's rows would otherwise
+      // be stale because round_scores just shifted.
       monthlySkillRepo.deleteByPlayerId(current.getId());
+      monthlySkillRepo.deleteByPlayerId(target.getId());
 
       String currentEmail = current.getEmail();
       String currentPicture = current.getPictureUrl();

--- a/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
@@ -4,6 +4,8 @@ import com.mahjong.omakase.model.FanDiscovery;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +17,8 @@ public interface FanDiscoveryRepository extends JpaRepository<FanDiscovery, Long
   List<FanDiscovery> findBySeason(String season);
 
   List<FanDiscovery> findByRoundGameSessionId(Long sessionId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE FanDiscovery fd SET fd.player.id = :toId WHERE fd.player.id = :fromId")
+  void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
@@ -18,7 +18,13 @@ public interface FanDiscoveryRepository extends JpaRepository<FanDiscovery, Long
 
   List<FanDiscovery> findByRoundGameSessionId(Long sessionId);
 
+  /**
+   * Native bulk FK reassign. JPQL "SET fd.player.id = :toId" is not portably supported by Hibernate
+   * for path expressions in the SET clause, so we update the FK column directly.
+   */
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE FanDiscovery fd SET fd.player.id = :toId WHERE fd.player.id = :fromId")
+  @Query(
+      value = "UPDATE fan_discoveries SET player_id = :toId WHERE player_id = :fromId",
+      nativeQuery = true)
   void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionPlayerRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionPlayerRepository.java
@@ -10,7 +10,13 @@ public interface GameSessionPlayerRepository extends JpaRepository<GameSessionPl
   @Query("DELETE FROM GameSessionPlayer gsp WHERE gsp.player.id = :playerId")
   void deleteByPlayerId(Long playerId);
 
+  /**
+   * Native bulk FK reassign. JPQL "SET gsp.player.id = :toId" is not portably supported by
+   * Hibernate for path expressions in the SET clause, so we update the FK column directly.
+   */
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE GameSessionPlayer gsp SET gsp.player.id = :toId WHERE gsp.player.id = :fromId")
+  @Query(
+      value = "UPDATE game_session_players SET player_id = :toId WHERE player_id = :fromId",
+      nativeQuery = true)
   void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionPlayerRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionPlayerRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface GameSessionPlayerRepository extends JpaRepository<GameSessionPlayer, Long> {
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("DELETE FROM GameSessionPlayer gsp WHERE gsp.player.id = :playerId")
   void deleteByPlayerId(Long playerId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE GameSessionPlayer gsp SET gsp.player.id = :toId WHERE gsp.player.id = :fromId")
+  void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/PlayerMonthlySkillRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/PlayerMonthlySkillRepository.java
@@ -16,7 +16,7 @@ public interface PlayerMonthlySkillRepository extends JpaRepository<PlayerMonthl
   Optional<PlayerMonthlySkill> findByPlayerIdAndModeAndYearAndMonth(
       Long playerId, GameMode mode, int year, int month);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("DELETE FROM PlayerMonthlySkill p WHERE p.player.id = :playerId")
   void deleteByPlayerId(@Param("playerId") Long playerId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -7,11 +7,26 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface RoundRepository extends JpaRepository<Round, Long> {
   int countByGameSessionId(Long gameSessionId);
+
+  /**
+   * Reassign the loose-FK player references stored directly on {@code Round} (winnerId and
+   * dealInPlayerId — scalar Longs, not JPA associations). Used by the auth merge flow so that
+   * Riichi round-level stats (and 牌率/放铳率, accumulated via getRoundDetailsBySessions) keep resolving
+   * to the surviving player after a temp Player is merged away.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE Round r SET r.winnerId = :toId WHERE r.winnerId = :fromId")
+  void reassignWinner(@Param("fromId") Long fromId, @Param("toId") Long toId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE Round r SET r.dealInPlayerId = :toId WHERE r.dealInPlayerId = :fromId")
+  void reassignDealInPlayer(@Param("fromId") Long fromId, @Param("toId") Long toId);
 
   @Query("SELECT MAX(r.fanCount) FROM Round r")
   Integer findMaxFanCount();

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -43,7 +43,13 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
   @Query("UPDATE RoundScore rs SET rs.player = null WHERE rs.player.id = :playerId")
   void nullifyPlayerScores(Long playerId);
 
+  /**
+   * Native bulk FK reassign. JPQL "SET rs.player.id = :toId" is not portably supported by Hibernate
+   * for path expressions in the SET clause, so we update the FK column directly.
+   */
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE RoundScore rs SET rs.player.id = :toId WHERE rs.player.id = :fromId")
+  @Query(
+      value = "UPDATE round_scores SET player_id = :toId WHERE player_id = :fromId",
+      nativeQuery = true)
   void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -39,7 +39,11 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
           + "WHERE r.gameSession.id IN :sessionIds AND rs.player IS NOT NULL")
   List<Object[]> getRoundDetailsBySessions(List<Long> sessionIds);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("UPDATE RoundScore rs SET rs.player = null WHERE rs.player.id = :playerId")
   void nullifyPlayerScores(Long playerId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE RoundScore rs SET rs.player.id = :toId WHERE rs.player.id = :fromId")
+  void reassignPlayer(Long fromId, Long toId);
 }

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -50,6 +50,10 @@ export default function SessionPage() {
     }
   }, [])
 
+  const handleCalcError = useCallback((msg: string | null) => {
+    setCalcError(msg || '')
+  }, [])
+
   const handleRiichiCalcSelect = useCallback(
     (
       s: number | null,
@@ -598,7 +602,7 @@ export default function SessionPage() {
                       <RiichiCalculator
                         key="riichi-calc"
                         onSelectScore={handleRiichiCalcSelect}
-                        onError={(msg) => setCalcError(msg || '')}
+                        onError={handleCalcError}
                         initialOptions={{
                           changfeng: gameState.prevalentWind,
                           zifeng: winnerMenfeng,


### PR DESCRIPTION
## 概要

修复两个用户反馈的 bug, 加一组防御性硬化。涉及 6 个文件, +75 / -30。

**Bug 1 (前端)** 立直局进行中分数输入框看上去"打不动" — `SessionPage` 把 `onError` 用内联箭头函数传给 `RiichiCalculator`, 每次 SessionPage re-render 都是新引用, 触发子组件 `useEffect` 在 `currentCount !== 14` 分支调 `onSelectScore(null)`, 反过来把父组件 `score` 写回 `''`。用户每按一个字符都被立刻清空。

**Bug 2 (后端)** 已登录用户去注册页绑定身份时报 FK 违反 (`FKLB68HAVAWXEB36JWVSMWJ8CUA`) — Google 登录会自动建一个临时 Player, 如果用户在完成 profile 设置之前就已经被拉进 game session, 那么 `setupProfile` 末尾的 `playerRepo.delete(current)` 会撞上 `game_session_players` 的外键, 事务整体回滚。日志里看到同一个用户连点 4 次, 每次 IDENTITY 跳号但都失败。

## 一、AuthController.setupProfile 重构

把单一 "新建 target + delete current" 流程拆成两条:

- **Claim 路径** (匹配到 unbound legacy player): 在 delete current 之前先把所有外键引用重指到 target — `game_session_players` / `round_scores` / `fan_discoveries` 全部 reassign; `player_monthly_skills` 是派生快照, 直接删 current 这边的, `TierService` 后续会按需重建。然后才转移 email / picture / token, 标 `merged`, 最后 delete current。
- **Register 路径** (没有 legacy): 不再新建 Player, 改为**就地把 current 改名**为新 userName/firstName/lastName, 标 `merged`。临时 Player 的所有现有引用 (包括 onboarding 期间已经入桌的 session 关联) 自动归属到新身份, 完全绕开 DELETE。

两条路径仍在同一个 `@Transactional` 里, 失败整体回滚不留半成品。

## 二、Repository 加 reassignPlayer + clearAutomatically

为 claim 路径补三个 bulk 重指方法:

- `GameSessionPlayerRepository.reassignPlayer(fromId, toId)`
- `RoundScoreRepository.reassignPlayer(fromId, toId)`
- `FanDiscoveryRepository.reassignPlayer(fromId, toId)`

顺手把仓库里所有 `@Modifying` (新增 + 原有的 `deleteByPlayerId` / `nullifyPlayerScores`) 统一改成 `@Modifying(clearAutomatically = true)`, bulk SQL 之后自动清持久化上下文, 防止后续在同事务中读到陈旧 entity。当前调用链没踩坑, 属于防御性硬化。

## 三、关掉用户名占用错误文案的 XSS sink

`AuthController` 里 "用户名「X」已被占用" 把 `trimmedUserName` 拼进了响应体, 被 IDE SAST 标为 XSS sink。虽然是 JSON 而不是 HTML, 真实利用面接近 0, 但用户输入完全不需要回显, 直接改成静态文案 `"用户名已被占用,请换一个"`, 彻底消除告警。

## 四、SessionPage onError 稳定化

把 `onError={(msg) => setCalcError(msg || '')}` 提到组件顶部的 `handleCalcError` (`useCallback` 包裹), 引用稳定后 `RiichiCalculator` 的 `useEffect` 不再被父组件 re-render 误触发。GuobiaoCalculator 没有 `onError` prop, 所以国标局不受这个 bug 影响。

## 测试要点

- [ ] **立直局**: 创建立直 session, 在添加 round 时直接在"分数"输入框里手敲数字, 字符不再被吞, 输入框可正常编辑
- [ ] **立直计算器联动**: 在 RiichiCalculator 里点击牌张, 凑齐 14 张且和牌成立时, 父组件分数输入框被正确填入计算结果; 凑不齐 14 张时输入框保持空
- [ ] **国标局回归**: 国标 session 添加 round, 分数输入与点选计算器双向都正常 (没动到这条路径但还是确认一下)
- [ ] **Google 新用户注册路径**: 全新 Google 账号登录 → 立刻把这个临时身份加入一桌并打一局 → 进 setup-profile 页填新用户名提交 → 应该一次成功, `merged=true`, session 里那一席的玩家归到新用户名下
- [ ] **Google 用户 claim 路径**: 全新 Google 账号登录 + 立刻入桌打一局, 然后在 setup-profile 页填一个匹配现存 legacy 玩家 (`email IS NULL`) 的 userName/firstName/lastName 提交 → 临时 Player 的 session 引用迁到 legacy player, 临时 Player 被删, legacy player 获得 email/token
- [ ] **用户名占用**: 试图用一个**别人**的 userName 注册 → 返回 "用户名已被占用,请换一个" (没有引号包用户输入)
- [ ] **保留自己已有 userName**: 用户在 register 路径提交时输入和当前临时 userName 一致的值, 不应被误判为占用
- [ ] DB 检查: 部署后 `SELECT id, user_name, email IS NOT NULL bound, merged FROM players WHERE merged = false AND email IS NOT NULL;` — 这些是之前卡住的账号, 重新登一次应该都能走完

## 文件改动

- `server/.../controller/AuthController.java` — setupProfile 拆双路径 + 注入新 repository + 关 XSS sink
- `server/.../repository/GameSessionPlayerRepository.java` — 加 `reassignPlayer` + `clearAutomatically`
- `server/.../repository/RoundScoreRepository.java` — 加 `reassignPlayer` + `clearAutomatically`
- `server/.../repository/FanDiscoveryRepository.java` — 加 `reassignPlayer` + `clearAutomatically`
- `server/.../repository/PlayerMonthlySkillRepository.java` — 给已有 `deleteByPlayerId` 加 `clearAutomatically`
- `ui/src/pages/SessionPage.tsx` — `onError` 由内联箭头函数提到 `useCallback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile setup so existing accounts are handled more reliably during signup or claim flows.
  * Prevented username conflicts with clearer feedback when a name is already taken.
  * Made account consolidation safer by keeping related game and score history attached to the right profile.
  * Improved calculator error handling on the session page so errors display more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->