### PR TITLE
refactor(auth): Google 登录不再自动落 Player + admin 加 userName 编辑

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -72,9 +72,15 @@ public class AdminController {
       @RequestHeader("X-Admin-Password") String password,
       @RequestBody Map<String, String> body) {
     checkPassword(password);
-    Player updated = gameService.updatePlayer(id, body.get("firstName"), body.get("lastName"));
-    log.info("Admin updated player id={}", id);
-    return updated;
+    try {
+      Player updated =
+          gameService.updatePlayer(
+              id, body.get("userName"), body.get("firstName"), body.get("lastName"));
+      log.info("Admin updated player id={}", id);
+      return updated;
+    } catch (IllegalArgumentException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
   }
 
   @GetMapping("/sessions")

--- a/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AdminController.java
@@ -72,15 +72,11 @@ public class AdminController {
       @RequestHeader("X-Admin-Password") String password,
       @RequestBody Map<String, String> body) {
     checkPassword(password);
-    try {
-      Player updated =
-          gameService.updatePlayer(
-              id, body.get("userName"), body.get("firstName"), body.get("lastName"));
-      log.info("Admin updated player id={}", id);
-      return updated;
-    } catch (IllegalArgumentException e) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
-    }
+    Player updated =
+        gameService.updatePlayer(
+            id, body.get("userName"), body.get("firstName"), body.get("lastName"));
+    log.info("Admin updated player id={}", id);
+    return updated;
   }
 
   @GetMapping("/sessions")

--- a/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
@@ -157,8 +157,8 @@ public class AuthController {
   }
 
   /**
-   * Read-only check: does a claimable legacy player (matching userName/firstName/lastName, with no
-   * bound email) exist? Used by the profile setup form to show the right confirmation copy (绑定 vs
+   * Read-only check: does any player record exist matching userName/firstName/lastName exactly
+   * (case-insensitive)? Used by the profile setup form to show the right confirmation copy (绑定 vs
    * 注册) before submitting.
    */
   @GetMapping("/lookup-claimable")
@@ -175,30 +175,28 @@ public class AuthController {
       return ResponseEntity.badRequest().body(Map.of("error", "All fields are required"));
     }
     boolean exists =
-        playerRepo
-            .findClaimableLegacyPlayer(userName.trim(), firstName.trim(), lastName.trim())
-            .isPresent();
+        playerRepo.findByExactName(userName.trim(), firstName.trim(), lastName.trim()).isPresent();
     return ResponseEntity.ok(Map.of("exists", exists));
   }
 
   /**
    * Atomic profile finalization. The frontend resends the Google credential alongside the desired
    * userName/firstName/lastName; we re-verify it here so the server is the sole authority on
-   * email/picture. Two cases:
+   * email/picture. Two branches based on whether the typed (userName, firstName, lastName) exactly
+   * matches an existing row:
    *
    * <ul>
-   *   <li><b>register</b>: no claimable legacy match → INSERT a brand-new Player carrying the
-   *       Google identity.
-   *   <li><b>claim</b>: a legacy unbound Player matches the form → UPDATE that row with
-   *       email/picture/token, mark merged.
+   *   <li><b>claim</b>: exact-name match exists. Allowed only if the row's email is unset OR the
+   *       row's email equals the verified Google email; otherwise rejected (would let anyone with a
+   *       guessed name overwrite someone else's bound account). The row gets email/picture/token
+   *       attached and merged flipped to true.
+   *   <li><b>register</b>: no exact-name match. INSERT a brand-new Player. A defensive findByEmail
+   *       check first catches "user mistyped their name but their email is already bound" — would
+   *       otherwise crash on the email UNIQUE constraint with a 500.
    * </ul>
    *
-   * <p>Pre-condition: no merged-or-unmerged Player already exists for this Google email. The
-   * preceding {@link #googleLogin} path lets fully-merged users in directly, so this endpoint
-   * should only ever see emails that don't yet have a Player row. As a safety net, we reject with
-   * 400 if an unmerged Player for this email is somehow still around (would only happen for users
-   * created by the pre-#136 auto-create code who haven't completed onboarding yet — admin monitors
-   * and they finish setup on the previous code path).
+   * <p>All security-relevant rejections use generic "请联系管理员" text — we deliberately do not leak the
+   * other row's stored userName/firstName/lastName back to the caller.
    */
   @Transactional
   @PostMapping("/setup-profile")
@@ -236,30 +234,44 @@ public class AuthController {
     String trimmedFirstName = firstName.trim();
     String trimmedLastName = lastName.trim();
 
-    Optional<Player> existing = playerRepo.findByEmail(google.email);
-    if (existing.isPresent()) {
-      // merged=true should never reach here (googleLogin path handles them), but defend anyway.
-      // merged=false means an unmerged holdover from the pre-#136 auto-create code — those have
-      // to complete onboarding via the old token-based code path before this PR ships, or via an
-      // out-of-band admin fix. Either way, /setup-profile in the new flow should not see them.
-      log.warn(
-          "setupProfile blocked: Player id={} already exists for email={} (merged={})",
-          existing.get().getId(),
-          redactEmail(google.email),
-          existing.get().isMerged());
-      return ResponseEntity.badRequest().body(Map.of("error", "该 Google 账号已存在历史记录, 请联系管理员"));
-    }
-
-    Player legacy =
-        playerRepo
-            .findClaimableLegacyPlayer(trimmedUserName, trimmedFirstName, trimmedLastName)
-            .orElse(null);
+    Player match =
+        playerRepo.findByExactName(trimmedUserName, trimmedFirstName, trimmedLastName).orElse(null);
     String sessionToken = newSessionToken();
     Player result;
     String mode;
 
-    if (legacy == null) {
-      // register: brand new user, no legacy match. Single INSERT.
+    if (match != null) {
+      // claim/rename branch — name matched an existing row.
+      if (match.getEmail() != null && !match.getEmail().equals(google.email)) {
+        log.warn(
+            "setupProfile claim blocked (email mismatch): match.id={} for credential email={}",
+            match.getId(),
+            redactEmail(google.email));
+        return ResponseEntity.badRequest().body(Map.of("error", "无法完成绑定, 请联系管理员"));
+      }
+      if (match.isMerged()) {
+        log.warn("setupProfile claim blocked (already merged): match.id={}", match.getId());
+        return ResponseEntity.badRequest().body(Map.of("error", "该账号已完成绑定, 请联系管理员"));
+      }
+      mode = match.getEmail() == null ? "claim" : "rebind";
+      match.setEmail(google.email);
+      if (google.pictureUrl != null) {
+        match.setPictureUrl(google.pictureUrl);
+      }
+      match.setToken(sessionToken);
+      match.setMerged(true);
+      result = playerRepo.saveAndFlush(match);
+    } else {
+      // register branch — no exact-name match.
+      // Defensive: if this Google email is already bound to a different (name-mismatching) row,
+      // the INSERT below would crash on the email UNIQUE constraint with a 500. Friendly 400
+      // instead. Typical trigger: user mistyped their old account's name during setup.
+      if (playerRepo.findByEmail(google.email).isPresent()) {
+        log.warn(
+            "setupProfile register blocked (email already bound, name mismatch): email={}",
+            redactEmail(google.email));
+        return ResponseEntity.badRequest().body(Map.of("error", "无法完成绑定, 请联系管理员"));
+      }
       if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)) {
         return ResponseEntity.badRequest().body(Map.of("error", "用户名已被占用,请换一个"));
       }
@@ -270,14 +282,6 @@ public class AuthController {
       p.setMerged(true);
       result = playerRepo.saveAndFlush(p);
       mode = "register";
-    } else {
-      // claim: attach Google identity to the matching unbound legacy row.
-      legacy.setEmail(google.email);
-      legacy.setPictureUrl(google.pictureUrl);
-      legacy.setToken(sessionToken);
-      legacy.setMerged(true);
-      result = playerRepo.saveAndFlush(legacy);
-      mode = "claim";
     }
 
     log.info(

--- a/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
@@ -48,12 +48,10 @@ public class AuthController {
     final String lastName;
     final String pictureUrl;
 
-    GoogleProfile(String email, String fullName, String pictureUrl) {
+    GoogleProfile(String email, String firstName, String lastName, String pictureUrl) {
       this.email = email;
-      String[] parts =
-          (fullName != null && !fullName.isBlank()) ? fullName.split(" ", 2) : new String[] {""};
-      this.firstName = parts[0];
-      this.lastName = parts.length > 1 ? parts[1] : "";
+      this.firstName = firstName == null ? "" : firstName;
+      this.lastName = lastName == null ? "" : lastName;
       this.pictureUrl = pictureUrl;
     }
   }
@@ -66,15 +64,33 @@ public class AuthController {
 
   /**
    * Verify the Google ID Token and extract the bits we care about. Returns null if the token is
-   * invalid (caller should map to 401). Throws if verifier infrastructure (network / crypto) fails.
+   * invalid, the email claim is missing, or the email is not verified by Google (caller should map
+   * to 401). Throws if verifier infrastructure (network / crypto) fails.
+   *
+   * <p>Prefers the OIDC {@code given_name}/{@code family_name} claims; falls back to splitting
+   * {@code name} on the first space when those aren't present. Either of firstName/lastName can
+   * still come back blank — callers that mutate an existing Player record must avoid overwriting
+   * stored values with blanks.
    */
   private GoogleProfile verifyCredential(String credential)
       throws GeneralSecurityException, IOException {
     GoogleIdToken idToken = newVerifier().verify(credential);
     if (idToken == null) return null;
     GoogleIdToken.Payload payload = idToken.getPayload();
-    return new GoogleProfile(
-        payload.getEmail(), (String) payload.get("name"), (String) payload.get("picture"));
+    String email = payload.getEmail();
+    if (email == null || email.isBlank()) return null;
+    if (!Boolean.TRUE.equals(payload.getEmailVerified())) return null;
+    String firstName = (String) payload.get("given_name");
+    String lastName = (String) payload.get("family_name");
+    if ((firstName == null || firstName.isBlank()) && (lastName == null || lastName.isBlank())) {
+      String fullName = (String) payload.get("name");
+      if (fullName != null && !fullName.isBlank()) {
+        String[] parts = fullName.split(" ", 2);
+        firstName = parts[0];
+        lastName = parts.length > 1 ? parts[1] : "";
+      }
+    }
+    return new GoogleProfile(email, firstName, lastName, (String) payload.get("picture"));
   }
 
   private static String newSessionToken() {
@@ -108,7 +124,7 @@ public class AuthController {
     } catch (GeneralSecurityException | IOException e) {
       log.error("Failed to verify Google ID Token", e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .body(Map.of("error", "Verification failed: " + e.getMessage()));
+          .body(Map.of("error", "Verification failed"));
     }
     if (profile == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -120,9 +136,15 @@ public class AuthController {
 
     if (playerOpt.isPresent() && playerOpt.get().isMerged()) {
       // Fully bound returning user — rotate token, sync Google profile fields, done.
+      // Only update names if Google actually returned a value, otherwise a partial profile
+      // (no given_name/family_name, no name) would wipe what the user has on record.
       Player player = playerOpt.get();
-      player.setFirstName(profile.firstName);
-      player.setLastName(profile.lastName);
+      if (!profile.firstName.isBlank()) {
+        player.setFirstName(profile.firstName);
+      }
+      if (!profile.lastName.isBlank()) {
+        player.setLastName(profile.lastName);
+      }
       if (profile.pictureUrl != null) {
         player.setPictureUrl(profile.pictureUrl);
       }
@@ -212,7 +234,7 @@ public class AuthController {
     } catch (GeneralSecurityException | IOException e) {
       log.error("Failed to re-verify Google ID Token in setupProfile", e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .body(Map.of("error", "Verification failed: " + e.getMessage()));
+          .body(Map.of("error", "Verification failed"));
     }
     if (google == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
@@ -11,7 +11,10 @@ import com.mahjong.omakase.repository.PlayerMonthlySkillRepository;
 import com.mahjong.omakase.repository.PlayerRepository;
 import com.mahjong.omakase.repository.RoundRepository;
 import com.mahjong.omakase.repository.RoundScoreRepository;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -56,9 +59,63 @@ public class AuthController {
     if (email == null) return null;
     int atIdx = email.indexOf('@');
     if (atIdx <= 1) return "***";
-    return email.substring(0, 1) + "***" + email.substring(atIdx);
+    return email.charAt(0) + "***" + email.substring(atIdx);
   }
 
+  /** Holds the bits of a verified Google ID Token we actually care about. */
+  private static final class GoogleProfile {
+    final String email;
+    final String firstName;
+    final String lastName;
+    final String pictureUrl;
+
+    GoogleProfile(String email, String fullName, String pictureUrl) {
+      this.email = email;
+      String[] parts =
+          (fullName != null && !fullName.isBlank()) ? fullName.split(" ", 2) : new String[] {""};
+      this.firstName = parts[0];
+      this.lastName = parts.length > 1 ? parts[1] : "";
+      this.pictureUrl = pictureUrl;
+    }
+  }
+
+  private GoogleIdTokenVerifier newVerifier() {
+    return new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
+        .setAudience(Collections.singletonList(googleClientId))
+        .build();
+  }
+
+  /**
+   * Verify the Google ID Token and extract the bits we care about. Returns null if the token is
+   * invalid (caller should map to 401). Throws if verifier infrastructure (network / crypto) fails.
+   */
+  private GoogleProfile verifyCredential(String credential)
+      throws GeneralSecurityException, IOException {
+    GoogleIdToken idToken = newVerifier().verify(credential);
+    if (idToken == null) return null;
+    GoogleIdToken.Payload payload = idToken.getPayload();
+    return new GoogleProfile(
+        payload.getEmail(), (String) payload.get("name"), (String) payload.get("picture"));
+  }
+
+  private static String newSessionToken() {
+    return "token_" + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  /**
+   * Google sign-in entry point.
+   *
+   * <p>Verifies the Google credential and routes by what we already know about this email:
+   *
+   * <ul>
+   *   <li>If a fully bound Player exists (merged=true) — rotate session token and return {token,
+   *       player}.
+   *   <li>Otherwise (no Player, or a legacy unmerged Player from the old auto-create flow) — do NOT
+   *       touch the database. Return {pendingAuth: true, profile} so the frontend can route to
+   *       setup-profile. The Player record will be created or claimed only when the user commits to
+   *       a userName/firstName/lastName in setupProfile.
+   * </ul>
+   */
   @PostMapping("/google")
   public ResponseEntity<?> googleLogin(@RequestBody Map<String, String> request) {
     String idTokenString = request.get("credential");
@@ -66,79 +123,44 @@ public class AuthController {
       return ResponseEntity.badRequest().body(Map.of("error", "Missing credential"));
     }
 
-    String email;
-    String name;
-    String pictureUrl;
-
-    // 正常校验模式 (Google Sign-In JWT Verification)
+    GoogleProfile profile;
     try {
-      GoogleIdTokenVerifier verifier =
-          new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
-              .setAudience(Collections.singletonList(googleClientId))
-              .build();
-
-      GoogleIdToken idToken = verifier.verify(idTokenString);
-      if (idToken != null) {
-        GoogleIdToken.Payload payload = idToken.getPayload();
-        email = payload.getEmail();
-        name = (String) payload.get("name");
-        pictureUrl = (String) payload.get("picture");
-        log.info("Google Auth verified successfully for email={}", redactEmail(email));
-      } else {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-            .body(Map.of("error", "Invalid ID Token"));
-      }
-    } catch (Exception e) {
+      profile = verifyCredential(idTokenString);
+    } catch (GeneralSecurityException | IOException e) {
       log.error("Failed to verify Google ID Token", e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
           .body(Map.of("error", "Verification failed: " + e.getMessage()));
     }
+    if (profile == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+          .body(Map.of("error", "Invalid ID Token"));
+    }
+    log.info("Google Auth verified successfully for email={}", redactEmail(profile.email));
 
-    // 3. 匹配已有账号或自动创建新账号
-    Optional<Player> playerOpt = playerRepo.findByEmail(email);
-    Player player;
+    Optional<Player> playerOpt = playerRepo.findByEmail(profile.email);
 
-    if (playerOpt.isPresent()) {
-      player = playerOpt.get();
-      // 同步更新最新的 Google 个人 Profile 信息
-      if (name != null) {
-        String[] parts = name.split(" ", 2);
-        player.setFirstName(parts[0]);
-        if (parts.length > 1) {
-          player.setLastName(parts[1]);
-        } else {
-          player.setLastName("");
-        }
+    if (playerOpt.isPresent() && playerOpt.get().isMerged()) {
+      // Fully bound returning user — rotate token, sync Google profile fields, done.
+      Player player = playerOpt.get();
+      player.setFirstName(profile.firstName);
+      player.setLastName(profile.lastName);
+      if (profile.pictureUrl != null) {
+        player.setPictureUrl(profile.pictureUrl);
       }
-      if (pictureUrl != null) {
-        player.setPictureUrl(pictureUrl);
-      }
-    } else {
-      String preferredUserName = email.split("@")[0];
-      // 创建全新玩家
-      String firstName = name != null ? name.split(" ", 2)[0] : preferredUserName;
-      String lastName = (name != null && name.contains(" ")) ? name.split(" ", 2)[1] : "";
-
-      // 保证唯一的唯一用户名
-      String uniqueUserName = preferredUserName;
-      int suffix = 1;
-      while (playerRepo.existsByUserName(uniqueUserName)) {
-        uniqueUserName = preferredUserName + suffix;
-        suffix++;
-      }
-
-      player = new Player(uniqueUserName, firstName, lastName);
-      player.setEmail(email);
-      player.setPictureUrl(pictureUrl);
-      log.info("Created new Google Player userName={}", uniqueUserName);
+      String sessionToken = newSessionToken();
+      player.setToken(sessionToken);
+      playerRepo.save(player);
+      return ResponseEntity.ok(Map.of("token", sessionToken, "player", player));
     }
 
-    // 4. 分配会话 Token 并更新数据库
-    String sessionToken = "token_" + UUID.randomUUID().toString().replace("-", "");
-    player.setToken(sessionToken);
-    playerRepo.save(player);
-
-    return ResponseEntity.ok(Map.of("token", sessionToken, "player", player));
+    // No bound Player yet (either first time, or a legacy unmerged Player from the old code).
+    // Do NOT write anything. Frontend will keep the credential and call setupProfile.
+    Map<String, Object> profileMap = new HashMap<>();
+    profileMap.put("email", profile.email);
+    profileMap.put("firstName", profile.firstName);
+    profileMap.put("lastName", profile.lastName);
+    profileMap.put("picture", profile.pictureUrl);
+    return ResponseEntity.ok(Map.of("pendingAuth", true, "profile", profileMap));
   }
 
   @GetMapping("/me")
@@ -182,35 +204,47 @@ public class AuthController {
   }
 
   /**
-   * Atomic profile finalization: claim a matching legacy player if one exists, otherwise create a
-   * brand-new player with the supplied name fields. Either path ends with the current Google
-   * identity merged into the target player and the auto-created Google player deleted. The whole
-   * thing runs in a single transaction so a failure can't leave a half-created player record
-   * behind.
+   * Atomic profile finalization. The frontend resends the Google credential alongside the desired
+   * userName/firstName/lastName; we re-verify it here so the server is the sole authority on
+   * email/picture. Four cases:
+   *
+   * <ol>
+   *   <li><b>register (clean)</b>: no Player for this email and no matching legacy → INSERT new.
+   *   <li><b>claim (clean)</b>: no Player for this email, matching legacy unbound player exists →
+   *       attach email/token/picture to that legacy row.
+   *   <li><b>legacy-register</b>: an unmerged Player already exists for this email (created by the
+   *       old auto-create code), no matching legacy → rename in place, mark merged.
+   *   <li><b>legacy-claim</b>: an unmerged Player + matching legacy → reassign all FK references
+   *       from the temp to legacy, then delete temp. Same migration logic as before.
+   * </ol>
+   *
+   * Once the database stops accumulating new unmerged Players (this PR removes the auto-create
+   * branch from googleLogin), the legacy-* cases naturally drain and can be removed.
    */
   @Transactional
   @PostMapping("/setup-profile")
-  public ResponseEntity<?> setupProfile(
-      @RequestHeader(value = "Authorization", required = false) String authHeader,
-      @RequestBody Map<String, String> request) {
-    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Missing token"));
-    }
-    String token = authHeader.substring(7);
-    Optional<Player> currentOpt = playerRepo.findByToken(token);
-    if (currentOpt.isEmpty()) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Invalid token"));
+  public ResponseEntity<?> setupProfile(@RequestBody Map<String, String> request) {
+    String credential = request.get("credential");
+    if (credential == null || credential.isBlank()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "缺少 Google 凭证, 请重新登录"));
     }
 
-    Player current = currentOpt.get();
-    if (current.isMerged()) {
-      return ResponseEntity.badRequest().body(Map.of("error", "该账户已经完成绑定，无法再次设置"));
+    GoogleProfile google;
+    try {
+      google = verifyCredential(credential);
+    } catch (GeneralSecurityException | IOException e) {
+      log.error("Failed to re-verify Google ID Token in setupProfile", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body(Map.of("error", "Verification failed: " + e.getMessage()));
+    }
+    if (google == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+          .body(Map.of("error", "Google 凭证已失效, 请重新登录"));
     }
 
     String userName = request.get("userName");
     String firstName = request.get("firstName");
     String lastName = request.get("lastName");
-
     if (userName == null
         || userName.isBlank()
         || firstName == null
@@ -219,71 +253,99 @@ public class AuthController {
         || lastName.isBlank()) {
       return ResponseEntity.badRequest().body(Map.of("error", "请完整填写用户名、名、姓信息"));
     }
-
     String trimmedUserName = userName.trim();
     String trimmedFirstName = firstName.trim();
     String trimmedLastName = lastName.trim();
 
-    // 1. Try to find a matching unbound legacy player.
-    Player target =
+    Player existing = playerRepo.findByEmail(google.email).orElse(null);
+    if (existing != null && existing.isMerged()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "该账户已经完成绑定，无法再次设置"));
+    }
+
+    Player legacy =
         playerRepo
             .findClaimableLegacyPlayer(trimmedUserName, trimmedFirstName, trimmedLastName)
             .orElse(null);
 
-    boolean claimedExisting = target != null;
+    String sessionToken = newSessionToken();
+    Player result;
+    String mode;
 
-    if (claimedExisting) {
-      // Claim path: merge current's identity (and any in-flight game references) into the
-      // legacy target, then delete current. Reassigning FKs first is required because current
-      // may already be sitting at a table / have round scores from the brief temp window.
-      gameSessionPlayerRepo.reassignPlayer(current.getId(), target.getId());
-      roundScoreRepo.reassignPlayer(current.getId(), target.getId());
-      fanDiscoveryRepo.reassignPlayer(current.getId(), target.getId());
-      // Round.winnerId / dealInPlayerId are loose-FK scalar Longs (not JPA associations) but they
-      // are still read by Riichi round-level stats — must follow the merge or histograms break.
-      roundRepo.reassignWinner(current.getId(), target.getId());
-      roundRepo.reassignDealInPlayer(current.getId(), target.getId());
-      // Monthly skill snapshots are derived; clear BOTH sides so TierService rebuilds them on next
-      // read. current's rows would otherwise FK-block the delete; target's rows would otherwise
-      // be stale because round_scores just shifted.
-      monthlySkillRepo.deleteByPlayerId(current.getId());
-      monthlySkillRepo.deleteByPlayerId(target.getId());
-
-      String currentEmail = current.getEmail();
-      String currentPicture = current.getPictureUrl();
-      current.setEmail(null);
-      current.setToken(null);
-      playerRepo.saveAndFlush(current);
-
-      target.setEmail(currentEmail);
-      target.setPictureUrl(currentPicture);
-      target.setToken(token);
-      target.setMerged(true);
-      playerRepo.saveAndFlush(target);
-
-      playerRepo.delete(current);
-    } else {
-      // Register path: rename current in place. No new Player record and no delete — avoids the
-      // FK violation when current is already referenced by game_session_players / round_scores
-      // from a game that started during the onboarding window.
-      if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)
-          && !trimmedUserName.equalsIgnoreCase(current.getUserName())) {
+    if (existing == null && legacy == null) {
+      // Clean register: brand new user, no legacy to inherit. Single INSERT.
+      // Reject username collisions against bound accounts (case-insensitive).
+      if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)) {
         return ResponseEntity.badRequest().body(Map.of("error", "用户名已被占用,请换一个"));
       }
-      current.setUserName(trimmedUserName);
-      current.setFirstName(trimmedFirstName);
-      current.setLastName(trimmedLastName);
-      current.setMerged(true);
-      playerRepo.saveAndFlush(current);
-      target = current;
+      Player p = new Player(trimmedUserName, trimmedFirstName, trimmedLastName);
+      p.setEmail(google.email);
+      p.setPictureUrl(google.pictureUrl);
+      p.setToken(sessionToken);
+      p.setMerged(true);
+      result = playerRepo.saveAndFlush(p);
+      mode = "register";
+
+    } else if (existing == null) {
+      // Clean claim: legacy != null here (previous branch ruled out both-null).
+      // No temp Player to clean up, just attach identity to the legacy row.
+      legacy.setEmail(google.email);
+      legacy.setPictureUrl(google.pictureUrl);
+      legacy.setToken(sessionToken);
+      legacy.setMerged(true);
+      result = playerRepo.saveAndFlush(legacy);
+      mode = "claim";
+
+    } else if (legacy == null) {
+      // Legacy holdover, register path: an unmerged Player already exists (old auto-create code)
+      // and no claimable legacy matches the form. Rename in place — preserves all FK references.
+      if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)
+          && !trimmedUserName.equalsIgnoreCase(existing.getUserName())) {
+        return ResponseEntity.badRequest().body(Map.of("error", "用户名已被占用,请换一个"));
+      }
+      existing.setUserName(trimmedUserName);
+      existing.setFirstName(trimmedFirstName);
+      existing.setLastName(trimmedLastName);
+      if (google.pictureUrl != null) {
+        existing.setPictureUrl(google.pictureUrl);
+      }
+      existing.setToken(sessionToken);
+      existing.setMerged(true);
+      result = playerRepo.saveAndFlush(existing);
+      mode = "legacy-register";
+
+    } else {
+      // Legacy holdover, claim path: unmerged Player + claimable legacy match. Migrate all FK
+      // references from existing → legacy, then delete existing. See repository methods for the
+      // four tables involved (game_session_players, round_scores, fan_discoveries, rounds.winner_id
+      // / deal_in_player_id) and the monthly_skill snapshot invalidation on both sides.
+      gameSessionPlayerRepo.reassignPlayer(existing.getId(), legacy.getId());
+      roundScoreRepo.reassignPlayer(existing.getId(), legacy.getId());
+      fanDiscoveryRepo.reassignPlayer(existing.getId(), legacy.getId());
+      roundRepo.reassignWinner(existing.getId(), legacy.getId());
+      roundRepo.reassignDealInPlayer(existing.getId(), legacy.getId());
+      monthlySkillRepo.deleteByPlayerId(existing.getId());
+      monthlySkillRepo.deleteByPlayerId(legacy.getId());
+
+      existing.setEmail(null);
+      existing.setToken(null);
+      playerRepo.saveAndFlush(existing);
+
+      legacy.setEmail(google.email);
+      legacy.setPictureUrl(google.pictureUrl);
+      legacy.setToken(sessionToken);
+      legacy.setMerged(true);
+      result = playerRepo.saveAndFlush(legacy);
+
+      playerRepo.delete(existing);
+      mode = "legacy-claim";
     }
 
     log.info(
         "Profile setup complete (mode={}) for username={}, id={}",
-        claimedExisting ? "claim" : "register",
-        target.getUserName(),
-        target.getId());
+        mode,
+        result.getUserName(),
+        result.getId());
 
-    return ResponseEntity.ok(target);
+    return ResponseEntity.ok(Map.of("token", sessionToken, "player", result));
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/AuthController.java
@@ -5,12 +5,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.mahjong.omakase.model.Player;
-import com.mahjong.omakase.repository.FanDiscoveryRepository;
-import com.mahjong.omakase.repository.GameSessionPlayerRepository;
-import com.mahjong.omakase.repository.PlayerMonthlySkillRepository;
 import com.mahjong.omakase.repository.PlayerRepository;
-import com.mahjong.omakase.repository.RoundRepository;
-import com.mahjong.omakase.repository.RoundScoreRepository;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
@@ -31,28 +26,12 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
   private final PlayerRepository playerRepo;
-  private final GameSessionPlayerRepository gameSessionPlayerRepo;
-  private final RoundRepository roundRepo;
-  private final RoundScoreRepository roundScoreRepo;
-  private final FanDiscoveryRepository fanDiscoveryRepo;
-  private final PlayerMonthlySkillRepository monthlySkillRepo;
 
   @Value("${google.client-id:123456-dummy.apps.googleusercontent.com}")
   private String googleClientId;
 
-  public AuthController(
-      PlayerRepository playerRepo,
-      GameSessionPlayerRepository gameSessionPlayerRepo,
-      RoundRepository roundRepo,
-      RoundScoreRepository roundScoreRepo,
-      FanDiscoveryRepository fanDiscoveryRepo,
-      PlayerMonthlySkillRepository monthlySkillRepo) {
+  public AuthController(PlayerRepository playerRepo) {
     this.playerRepo = playerRepo;
-    this.gameSessionPlayerRepo = gameSessionPlayerRepo;
-    this.roundRepo = roundRepo;
-    this.roundScoreRepo = roundScoreRepo;
-    this.fanDiscoveryRepo = fanDiscoveryRepo;
-    this.monthlySkillRepo = monthlySkillRepo;
   }
 
   private String redactEmail(String email) {
@@ -110,10 +89,10 @@ public class AuthController {
    * <ul>
    *   <li>If a fully bound Player exists (merged=true) — rotate session token and return {token,
    *       player}.
-   *   <li>Otherwise (no Player, or a legacy unmerged Player from the old auto-create flow) — do NOT
-   *       touch the database. Return {pendingAuth: true, profile} so the frontend can route to
-   *       setup-profile. The Player record will be created or claimed only when the user commits to
-   *       a userName/firstName/lastName in setupProfile.
+   *   <li>Otherwise (no Player at all) — do NOT touch the database. Return {pendingAuth: true,
+   *       profile} so the frontend can route to setup-profile. The Player record is created (or a
+   *       legacy unbound row is claimed) only when the user commits to a
+   *       userName/firstName/lastName in setupProfile.
    * </ul>
    */
   @PostMapping("/google")
@@ -153,8 +132,7 @@ public class AuthController {
       return ResponseEntity.ok(Map.of("token", sessionToken, "player", player));
     }
 
-    // No bound Player yet (either first time, or a legacy unmerged Player from the old code).
-    // Do NOT write anything. Frontend will keep the credential and call setupProfile.
+    // No bound Player. Do NOT write anything; frontend keeps the credential and calls setupProfile.
     Map<String, Object> profileMap = new HashMap<>();
     profileMap.put("email", profile.email);
     profileMap.put("firstName", profile.firstName);
@@ -206,20 +184,21 @@ public class AuthController {
   /**
    * Atomic profile finalization. The frontend resends the Google credential alongside the desired
    * userName/firstName/lastName; we re-verify it here so the server is the sole authority on
-   * email/picture. Four cases:
+   * email/picture. Two cases:
    *
-   * <ol>
-   *   <li><b>register (clean)</b>: no Player for this email and no matching legacy → INSERT new.
-   *   <li><b>claim (clean)</b>: no Player for this email, matching legacy unbound player exists →
-   *       attach email/token/picture to that legacy row.
-   *   <li><b>legacy-register</b>: an unmerged Player already exists for this email (created by the
-   *       old auto-create code), no matching legacy → rename in place, mark merged.
-   *   <li><b>legacy-claim</b>: an unmerged Player + matching legacy → reassign all FK references
-   *       from the temp to legacy, then delete temp. Same migration logic as before.
-   * </ol>
+   * <ul>
+   *   <li><b>register</b>: no claimable legacy match → INSERT a brand-new Player carrying the
+   *       Google identity.
+   *   <li><b>claim</b>: a legacy unbound Player matches the form → UPDATE that row with
+   *       email/picture/token, mark merged.
+   * </ul>
    *
-   * Once the database stops accumulating new unmerged Players (this PR removes the auto-create
-   * branch from googleLogin), the legacy-* cases naturally drain and can be removed.
+   * <p>Pre-condition: no merged-or-unmerged Player already exists for this Google email. The
+   * preceding {@link #googleLogin} path lets fully-merged users in directly, so this endpoint
+   * should only ever see emails that don't yet have a Player row. As a safety net, we reject with
+   * 400 if an unmerged Player for this email is somehow still around (would only happen for users
+   * created by the pre-#136 auto-create code who haven't completed onboarding yet — admin monitors
+   * and they finish setup on the previous code path).
    */
   @Transactional
   @PostMapping("/setup-profile")
@@ -257,23 +236,30 @@ public class AuthController {
     String trimmedFirstName = firstName.trim();
     String trimmedLastName = lastName.trim();
 
-    Player existing = playerRepo.findByEmail(google.email).orElse(null);
-    if (existing != null && existing.isMerged()) {
-      return ResponseEntity.badRequest().body(Map.of("error", "该账户已经完成绑定，无法再次设置"));
+    Optional<Player> existing = playerRepo.findByEmail(google.email);
+    if (existing.isPresent()) {
+      // merged=true should never reach here (googleLogin path handles them), but defend anyway.
+      // merged=false means an unmerged holdover from the pre-#136 auto-create code — those have
+      // to complete onboarding via the old token-based code path before this PR ships, or via an
+      // out-of-band admin fix. Either way, /setup-profile in the new flow should not see them.
+      log.warn(
+          "setupProfile blocked: Player id={} already exists for email={} (merged={})",
+          existing.get().getId(),
+          redactEmail(google.email),
+          existing.get().isMerged());
+      return ResponseEntity.badRequest().body(Map.of("error", "该 Google 账号已存在历史记录, 请联系管理员"));
     }
 
     Player legacy =
         playerRepo
             .findClaimableLegacyPlayer(trimmedUserName, trimmedFirstName, trimmedLastName)
             .orElse(null);
-
     String sessionToken = newSessionToken();
     Player result;
     String mode;
 
-    if (existing == null && legacy == null) {
-      // Clean register: brand new user, no legacy to inherit. Single INSERT.
-      // Reject username collisions against bound accounts (case-insensitive).
+    if (legacy == null) {
+      // register: brand new user, no legacy match. Single INSERT.
       if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)) {
         return ResponseEntity.badRequest().body(Map.of("error", "用户名已被占用,请换一个"));
       }
@@ -284,60 +270,14 @@ public class AuthController {
       p.setMerged(true);
       result = playerRepo.saveAndFlush(p);
       mode = "register";
-
-    } else if (existing == null) {
-      // Clean claim: legacy != null here (previous branch ruled out both-null).
-      // No temp Player to clean up, just attach identity to the legacy row.
+    } else {
+      // claim: attach Google identity to the matching unbound legacy row.
       legacy.setEmail(google.email);
       legacy.setPictureUrl(google.pictureUrl);
       legacy.setToken(sessionToken);
       legacy.setMerged(true);
       result = playerRepo.saveAndFlush(legacy);
       mode = "claim";
-
-    } else if (legacy == null) {
-      // Legacy holdover, register path: an unmerged Player already exists (old auto-create code)
-      // and no claimable legacy matches the form. Rename in place — preserves all FK references.
-      if (playerRepo.existsByUserNameIgnoreCase(trimmedUserName)
-          && !trimmedUserName.equalsIgnoreCase(existing.getUserName())) {
-        return ResponseEntity.badRequest().body(Map.of("error", "用户名已被占用,请换一个"));
-      }
-      existing.setUserName(trimmedUserName);
-      existing.setFirstName(trimmedFirstName);
-      existing.setLastName(trimmedLastName);
-      if (google.pictureUrl != null) {
-        existing.setPictureUrl(google.pictureUrl);
-      }
-      existing.setToken(sessionToken);
-      existing.setMerged(true);
-      result = playerRepo.saveAndFlush(existing);
-      mode = "legacy-register";
-
-    } else {
-      // Legacy holdover, claim path: unmerged Player + claimable legacy match. Migrate all FK
-      // references from existing → legacy, then delete existing. See repository methods for the
-      // four tables involved (game_session_players, round_scores, fan_discoveries, rounds.winner_id
-      // / deal_in_player_id) and the monthly_skill snapshot invalidation on both sides.
-      gameSessionPlayerRepo.reassignPlayer(existing.getId(), legacy.getId());
-      roundScoreRepo.reassignPlayer(existing.getId(), legacy.getId());
-      fanDiscoveryRepo.reassignPlayer(existing.getId(), legacy.getId());
-      roundRepo.reassignWinner(existing.getId(), legacy.getId());
-      roundRepo.reassignDealInPlayer(existing.getId(), legacy.getId());
-      monthlySkillRepo.deleteByPlayerId(existing.getId());
-      monthlySkillRepo.deleteByPlayerId(legacy.getId());
-
-      existing.setEmail(null);
-      existing.setToken(null);
-      playerRepo.saveAndFlush(existing);
-
-      legacy.setEmail(google.email);
-      legacy.setPictureUrl(google.pictureUrl);
-      legacy.setToken(sessionToken);
-      legacy.setMerged(true);
-      result = playerRepo.saveAndFlush(legacy);
-
-      playerRepo.delete(existing);
-      mode = "legacy-claim";
     }
 
     log.info(

--- a/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/FanDiscoveryRepository.java
@@ -4,8 +4,6 @@ import com.mahjong.omakase.model.FanDiscovery;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,14 +15,4 @@ public interface FanDiscoveryRepository extends JpaRepository<FanDiscovery, Long
   List<FanDiscovery> findBySeason(String season);
 
   List<FanDiscovery> findByRoundGameSessionId(Long sessionId);
-
-  /**
-   * Native bulk FK reassign. JPQL "SET fd.player.id = :toId" is not portably supported by Hibernate
-   * for path expressions in the SET clause, so we update the FK column directly.
-   */
-  @Modifying(clearAutomatically = true)
-  @Query(
-      value = "UPDATE fan_discoveries SET player_id = :toId WHERE player_id = :fromId",
-      nativeQuery = true)
-  void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/GameSessionPlayerRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/GameSessionPlayerRepository.java
@@ -9,14 +9,4 @@ public interface GameSessionPlayerRepository extends JpaRepository<GameSessionPl
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM GameSessionPlayer gsp WHERE gsp.player.id = :playerId")
   void deleteByPlayerId(Long playerId);
-
-  /**
-   * Native bulk FK reassign. JPQL "SET gsp.player.id = :toId" is not portably supported by
-   * Hibernate for path expressions in the SET clause, so we update the FK column directly.
-   */
-  @Modifying(clearAutomatically = true)
-  @Query(
-      value = "UPDATE game_session_players SET player_id = :toId WHERE player_id = :fromId",
-      nativeQuery = true)
-  void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/repository/PlayerRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/PlayerRepository.java
@@ -16,16 +16,16 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
   Optional<Player> findByToken(String token);
 
   /**
-   * Finds a legacy player record (no Google email bound) whose userName/firstName/lastName all
-   * match case-insensitively. Used by the profile-setup flow to decide whether the user is claiming
-   * an existing record or registering a fresh one.
+   * Finds any player whose userName/firstName/lastName all match case-insensitively, regardless of
+   * email/merged state. The setup-profile flow uses this as the entry point: a match means
+   * "rename/claim this row (if your Google email matches its bound email, or it is unbound)", a
+   * miss means "register a new row".
    */
   @Query(
       "SELECT p FROM Player p WHERE LOWER(p.userName) = LOWER(:userName) "
           + "AND LOWER(p.firstName) = LOWER(:firstName) "
-          + "AND LOWER(p.lastName) = LOWER(:lastName) "
-          + "AND p.email IS NULL")
-  Optional<Player> findClaimableLegacyPlayer(
+          + "AND LOWER(p.lastName) = LOWER(:lastName)")
+  Optional<Player> findByExactName(
       @Param("userName") String userName,
       @Param("firstName") String firstName,
       @Param("lastName") String lastName);

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundRepository.java
@@ -7,26 +7,11 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface RoundRepository extends JpaRepository<Round, Long> {
   int countByGameSessionId(Long gameSessionId);
-
-  /**
-   * Reassign the loose-FK player references stored directly on {@code Round} (winnerId and
-   * dealInPlayerId — scalar Longs, not JPA associations). Used by the auth merge flow so that
-   * Riichi round-level stats (and 牌率/放铳率, accumulated via getRoundDetailsBySessions) keep resolving
-   * to the surviving player after a temp Player is merged away.
-   */
-  @Modifying(clearAutomatically = true)
-  @Query("UPDATE Round r SET r.winnerId = :toId WHERE r.winnerId = :fromId")
-  void reassignWinner(@Param("fromId") Long fromId, @Param("toId") Long toId);
-
-  @Modifying(clearAutomatically = true)
-  @Query("UPDATE Round r SET r.dealInPlayerId = :toId WHERE r.dealInPlayerId = :fromId")
-  void reassignDealInPlayer(@Param("fromId") Long fromId, @Param("toId") Long toId);
 
   @Query("SELECT MAX(r.fanCount) FROM Round r")
   Integer findMaxFanCount();

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -42,14 +42,4 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
   @Modifying(clearAutomatically = true)
   @Query("UPDATE RoundScore rs SET rs.player = null WHERE rs.player.id = :playerId")
   void nullifyPlayerScores(Long playerId);
-
-  /**
-   * Native bulk FK reassign. JPQL "SET rs.player.id = :toId" is not portably supported by Hibernate
-   * for path expressions in the SET clause, so we update the FK column directly.
-   */
-  @Modifying(clearAutomatically = true)
-  @Query(
-      value = "UPDATE round_scores SET player_id = :toId WHERE player_id = :fromId",
-      nativeQuery = true)
-  void reassignPlayer(Long fromId, Long toId);
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -257,6 +257,9 @@ public class GameService {
             .orElseThrow(() -> new IllegalArgumentException("Player not found"));
     if (userName != null && !userName.isBlank()) {
       String trimmed = userName.trim();
+      if ("BOT".equalsIgnoreCase(trimmed)) {
+        throw new IllegalArgumentException("Username 'BOT' is reserved");
+      }
       if (!trimmed.equalsIgnoreCase(player.getUserName())
           && playerRepo.existsByUserNameIgnoreCase(trimmed)) {
         throw new IllegalArgumentException("Username already taken");

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -250,18 +250,31 @@ public class GameService {
     return playerRepo.existsByUserName(userName);
   }
 
-  public Player updatePlayer(Long id, String firstName, String lastName) {
+  public Player updatePlayer(Long id, String userName, String firstName, String lastName) {
     Player player =
         playerRepo
             .findById(Objects.requireNonNull(id))
             .orElseThrow(() -> new IllegalArgumentException("Player not found"));
+    if (userName != null && !userName.isBlank()) {
+      String trimmed = userName.trim();
+      if (!trimmed.equalsIgnoreCase(player.getUserName())
+          && playerRepo.existsByUserNameIgnoreCase(trimmed)) {
+        throw new IllegalArgumentException("Username already taken");
+      }
+      player.setUserName(trimmed);
+    }
     if (firstName != null && !firstName.isBlank()) {
       player.setFirstName(firstName.trim());
     }
     if (lastName != null && !lastName.isBlank()) {
       player.setLastName(lastName.trim());
     }
-    log.info("Updated player id={}, name='{} {}'", id, player.getFirstName(), player.getLastName());
+    log.info(
+        "Updated player id={}, userName='{}', name='{} {}'",
+        id,
+        player.getUserName(),
+        player.getFirstName(),
+        player.getLastName());
     Player saved = playerRepo.save(player);
     evictAllCaches();
     return saved;

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -37,13 +37,33 @@ async function authFetch<T>(url: string, signal?: AbortSignal): Promise<T> {
   return handleResponse<T>(res)
 }
 
-export async function loginWithGoogle(credential: string): Promise<{ token: string; player: Player }> {
+export type PendingAuthProfile = {
+  email: string
+  firstName: string
+  lastName: string
+  picture: string | null
+}
+
+export type LoginResponse =
+  | { pendingAuth: false; token: string; player: Player }
+  | { pendingAuth: true; profile: PendingAuthProfile }
+
+export async function loginWithGoogle(credential: string): Promise<LoginResponse> {
   const res = await fetch(`${API}/auth/google`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ credential }),
   })
-  return handleResponse<{ token: string; player: Player }>(res)
+  const data = await handleResponse<{
+    pendingAuth?: boolean
+    profile?: PendingAuthProfile
+    token?: string
+    player?: Player
+  }>(res)
+  if (data.pendingAuth) {
+    return { pendingAuth: true, profile: data.profile as PendingAuthProfile }
+  }
+  return { pendingAuth: false, token: data.token as string, player: data.player as Player }
 }
 
 export async function fetchCurrentUser(): Promise<Player> {
@@ -187,13 +207,18 @@ export async function fetchFanDiscoveries(
   return authFetch(`${API}/stats/fan-discoveries${qs ? `?${qs}` : ''}`, signal)
 }
 
-export async function setupProfile(userName: string, firstName: string, lastName: string): Promise<Player> {
+export async function setupProfile(
+  credential: string,
+  userName: string,
+  firstName: string,
+  lastName: string
+): Promise<{ token: string; player: Player }> {
   const res = await fetch(`${API}/auth/setup-profile`, {
     method: 'POST',
-    headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify({ userName, firstName, lastName }),
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ credential, userName, firstName, lastName }),
   })
-  return handleResponse<Player>(res)
+  return handleResponse<{ token: string; player: Player }>(res)
 }
 
 export async function lookupClaimablePlayer(userName: string, firstName: string, lastName: string): Promise<boolean> {

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -11,6 +11,7 @@ export default function AdminPage() {
   const [sessions, setSessions] = useState<GameSession[]>([])
   const [loading, setLoading] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
+  const [editUserName, setEditUserName] = useState('')
   const [editFirst, setEditFirst] = useState('')
   const [editLast, setEditLast] = useState('')
   const [bonus, setBonus] = useState('0')
@@ -152,25 +153,31 @@ export default function AdminPage() {
 
   const startEdit = (p: Player) => {
     setEditingId(p.id)
+    setEditUserName(p.userName)
     setEditFirst(p.firstName)
     setEditLast(p.lastName)
   }
 
   const cancelEdit = () => {
     setEditingId(null)
+    setEditUserName('')
     setEditFirst('')
     setEditLast('')
   }
 
   const handleSave = async (id: number) => {
-    if (!editFirst.trim() || !editLast.trim()) return
+    if (!editUserName.trim() || !editFirst.trim() || !editLast.trim()) return
     const res = await fetch(`${API}/players/${id}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
         'X-Admin-Password': password,
       },
-      body: JSON.stringify({ firstName: editFirst.trim(), lastName: editLast.trim() }),
+      body: JSON.stringify({
+        userName: editUserName.trim(),
+        firstName: editFirst.trim(),
+        lastName: editLast.trim(),
+      }),
     })
     if (res.ok) {
       const updated = await res.json()
@@ -265,7 +272,19 @@ export default function AdminPage() {
               {players.map((p) => (
                 <tr key={p.id}>
                   <td>{p.id}</td>
-                  <td>{p.userName}</td>
+                  <td>
+                    {editingId === p.id ? (
+                      <input
+                        value={editUserName}
+                        onChange={(e) => setEditUserName(e.target.value)}
+                        style={{ width: '100%', maxWidth: 120 }}
+                        placeholder="Username"
+                        autoFocus
+                      />
+                    ) : (
+                      p.userName
+                    )}
+                  </td>
                   <td>
                     {editingId === p.id ? (
                       <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
@@ -274,7 +293,6 @@ export default function AdminPage() {
                           onChange={(e) => setEditFirst(e.target.value)}
                           style={{ width: '100%', maxWidth: 80 }}
                           placeholder="First"
-                          autoFocus
                         />
                         <input
                           value={editLast}

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -23,9 +23,6 @@ export default function LoginPage() {
       try {
         const data = await loginWithGoogle(response.credential)
         if (data.pendingAuth) {
-          // No bound Player yet — server didn't write anything. Stash the credential
-          // (we'll re-send it from the setup-profile form) and route to /profile, where
-          // ProfilePage renders the 找回 / 新建 form for unmerged users.
           sessionStorage.setItem('mahjong_google_credential', response.credential)
           const pendingMe = {
             pendingAuth: true,

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -22,10 +22,28 @@ export default function LoginPage() {
       setLoading(true)
       try {
         const data = await loginWithGoogle(response.credential)
-        localStorage.setItem('mahjong_token', data.token)
-        sessionStorage.setItem('mahjong_me', JSON.stringify(data.player))
-        window.dispatchEvent(new Event('auth-change'))
-        navigate('/home', { replace: true })
+        if (data.pendingAuth) {
+          // No bound Player yet — server didn't write anything. Stash the credential
+          // (we'll re-send it from the setup-profile form) and route to /profile, where
+          // ProfilePage renders the 找回 / 新建 form for unmerged users.
+          sessionStorage.setItem('mahjong_google_credential', response.credential)
+          const pendingMe = {
+            pendingAuth: true,
+            email: data.profile.email,
+            firstName: data.profile.firstName,
+            lastName: data.profile.lastName,
+            pictureUrl: data.profile.picture,
+            merged: false,
+          }
+          sessionStorage.setItem('mahjong_me', JSON.stringify(pendingMe))
+          window.dispatchEvent(new Event('auth-change'))
+          navigate('/profile', { replace: true })
+        } else {
+          localStorage.setItem('mahjong_token', data.token)
+          sessionStorage.setItem('mahjong_me', JSON.stringify(data.player))
+          window.dispatchEvent(new Event('auth-change'))
+          navigate('/home', { replace: true })
+        }
       } catch (err: any) {
         setError(err.message || '登录验证失败，请重试')
       } finally {

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -107,7 +107,7 @@ export default function ProfilePage() {
       const claimable = await lookupClaimablePlayer(userName, firstName, lastName)
 
       const confirmMsg = claimable
-        ? `确认提交「${userName}」吗?\n\n如该名字已对应历史账号且邮箱归属验证通过, 战绩会自动归入您的 Google 身份。`
+        ? `确认绑定老账号「${userName}」吗?\n\n该账号下的历史战绩与积分将合并到您当前的 Google 身份。`
         : `确认使用「${userName}」作为新账号吗?\n\n系统将注册一个全新雀士档案并绑定您的 Google 身份。`
 
       if (!window.confirm(confirmMsg)) {
@@ -121,7 +121,7 @@ export default function ProfilePage() {
       sessionStorage.setItem('mahjong_me', JSON.stringify(result.player))
       sessionStorage.removeItem('mahjong_google_credential')
       setMe(result.player)
-      setSetupSuccess(claimable ? '完成! 账号已就位。' : '注册成功!您的雀士档案已创建。')
+      setSetupSuccess(claimable ? '绑定成功!历史战绩已同步继承。' : '注册成功!您的雀士档案已创建。')
       setSetupForm({ userName: '', firstName: '', lastName: '' })
       window.dispatchEvent(new Event('auth-change'))
     } catch (err: any) {
@@ -176,201 +176,199 @@ export default function ProfilePage() {
         </div>
       </div>
 
-      {/* 2. 个人战绩(下拉切换模式) — 占位 me 时整块不渲染, 避免显示空 card */}
-      {!me.pendingAuth &&
-        me.id &&
-        (() => {
-          const stats = statsByMode[selectedMode]
-          const hasStats = stats && stats.gamesPlayed > 0
-          return (
-            <div className="profile-card">
-              <div
+      {/* 2. 个人战绩(下拉切换模式) */}
+      {(() => {
+        const stats = statsByMode[selectedMode]
+        const hasStats = stats && stats.gamesPlayed > 0
+        return (
+          <div className="profile-card">
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: '12px',
+                marginBottom: '20px',
+                flexWrap: 'wrap',
+              }}
+            >
+              <h3
                 style={{
+                  margin: 0,
+                  fontSize: '18px',
+                  color: 'var(--primary)',
                   display: 'flex',
-                  justifyContent: 'space-between',
                   alignItems: 'center',
-                  gap: '12px',
-                  marginBottom: '20px',
-                  flexWrap: 'wrap',
+                  gap: '8px',
                 }}
               >
-                <h3
+                📊 个人战绩
+              </h3>
+              <select
+                value={selectedMode}
+                onChange={(e) => setSelectedMode(e.target.value as GameModeKey)}
+                className="select-inline"
+              >
+                {GAME_MODES.map((m) => (
+                  <option key={m.key} value={m.key}>
+                    {m.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* 段位显示: 国标 / 立直 跟随上面 selectedMode 切换 */}
+            {tier && (selectedMode === 'GUOBIAO' || selectedMode === 'RIICHI') && (
+              <div className="profile-tier-section">
+                <RankBadge
+                  tier={selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier}
+                  size="lg"
+                  rating={
+                    (selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier) === 'UNRANKED'
+                      ? undefined
+                      : selectedMode === 'GUOBIAO'
+                      ? tier.guobiao.rating
+                      : tier.riichi.rating
+                  }
+                  gamesNeeded={selectedMode === 'GUOBIAO' ? tier.guobiao.gamesNeeded : tier.riichi.gamesNeeded}
+                />
+              </div>
+            )}
+
+            {hasStats ? (
+              <div className="profile-stats-grid">
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-teal">{stats.gamesPlayed}</div>
+                  <div className="profile-stat-label">总局数</div>
+                </div>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-teal">
+                    {stats.wins}{' '}
+                    <span className="profile-stat-suffix">
+                      ({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)
+                    </span>
+                  </div>
+                  <div className="profile-stat-label">胜场 (胜率)</div>
+                </div>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-gold">
+                    {stats.totalRP > 0 ? `+${stats.totalRP.toFixed(1)}` : stats.totalRP.toFixed(1)}
+                  </div>
+                  <div className="profile-stat-label">总积分 (RP)</div>
+                </div>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-gold">
+                    {stats.avgScore > 0 ? `+${stats.avgScore.toFixed(0)}` : stats.avgScore.toFixed(0)}
+                  </div>
+                  <div className="profile-stat-label">场均表现</div>
+                </div>
+                <div className="profile-stat-card">
+                  <div className="profile-stat-value profile-stat-value-teal">{stats.avgRank.toFixed(2)}</div>
+                  <div className="profile-stat-label">平均排名</div>
+                </div>
+              </div>
+            ) : (
+              <div className="empty-state empty-state-compact">
+                <p>本模式暂无对局统计。</p>
+              </div>
+            )}
+
+            {selectedMode === 'RIICHI' && hasStats && stats.roundsPlayed > 0 && (
+              <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
+                <h4
                   style={{
-                    margin: 0,
-                    fontSize: '18px',
+                    margin: '0 0 16px 0',
+                    fontSize: '15px',
                     color: 'var(--primary)',
                     display: 'flex',
                     alignItems: 'center',
-                    gap: '8px',
+                    gap: '6px',
                   }}
                 >
-                  📊 个人战绩
-                </h3>
-                <select
-                  value={selectedMode}
-                  onChange={(e) => setSelectedMode(e.target.value as GameModeKey)}
-                  className="select-inline"
-                >
-                  {GAME_MODES.map((m) => (
-                    <option key={m.key} value={m.key}>
-                      {m.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* 段位显示: 国标 / 立直 跟随上面 selectedMode 切换 */}
-              {tier && (selectedMode === 'GUOBIAO' || selectedMode === 'RIICHI') && (
-                <div className="profile-tier-section">
-                  <RankBadge
-                    tier={selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier}
-                    size="lg"
-                    rating={
-                      (selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier) === 'UNRANKED'
-                        ? undefined
-                        : selectedMode === 'GUOBIAO'
-                        ? tier.guobiao.rating
-                        : tier.riichi.rating
-                    }
-                    gamesNeeded={selectedMode === 'GUOBIAO' ? tier.guobiao.gamesNeeded : tier.riichi.gamesNeeded}
-                  />
-                </div>
-              )}
-
-              {hasStats ? (
+                  📈 数据统计
+                </h4>
                 <div className="profile-stats-grid">
                   <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-teal">{stats.gamesPlayed}</div>
-                    <div className="profile-stat-label">总局数</div>
+                    <div className="profile-stat-value profile-stat-value-teal">
+                      {((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%
+                    </div>
+                    <div className="profile-stat-label">和牌率</div>
                   </div>
                   <div className="profile-stat-card">
                     <div className="profile-stat-value profile-stat-value-teal">
-                      {stats.wins}{' '}
-                      <span className="profile-stat-suffix">
-                        ({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)
-                      </span>
+                      {((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%
                     </div>
-                    <div className="profile-stat-label">胜场 (胜率)</div>
+                    <div className="profile-stat-label">放铳率</div>
                   </div>
                   <div className="profile-stat-card">
                     <div className="profile-stat-value profile-stat-value-gold">
-                      {stats.totalRP > 0 ? `+${stats.totalRP.toFixed(1)}` : stats.totalRP.toFixed(1)}
+                      {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
                     </div>
-                    <div className="profile-stat-label">总积分 (RP)</div>
+                    <div className="profile-stat-label">平均打点</div>
                   </div>
                   <div className="profile-stat-card">
                     <div className="profile-stat-value profile-stat-value-gold">
-                      {stats.avgScore > 0 ? `+${stats.avgScore.toFixed(0)}` : stats.avgScore.toFixed(0)}
+                      {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
                     </div>
-                    <div className="profile-stat-label">场均表现</div>
-                  </div>
-                  <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-teal">{stats.avgRank.toFixed(2)}</div>
-                    <div className="profile-stat-label">平均排名</div>
+                    <div className="profile-stat-label">平均铳点</div>
                   </div>
                 </div>
-              ) : (
-                <div className="empty-state empty-state-compact">
-                  <p>本模式暂无对局统计。</p>
-                </div>
-              )}
+              </div>
+            )}
 
-              {selectedMode === 'RIICHI' && hasStats && stats.roundsPlayed > 0 && (
-                <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
-                  <h4
-                    style={{
-                      margin: '0 0 16px 0',
-                      fontSize: '15px',
-                      color: 'var(--primary)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                    }}
-                  >
-                    📈 数据统计
-                  </h4>
-                  <div className="profile-stats-grid">
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-teal">
-                        {((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%
-                      </div>
-                      <div className="profile-stat-label">和牌率</div>
-                    </div>
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-teal">
-                        {((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%
-                      </div>
-                      <div className="profile-stat-label">放铳率</div>
-                    </div>
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-gold">
-                        {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
-                      </div>
-                      <div className="profile-stat-label">平均打点</div>
-                    </div>
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-gold">
-                        {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
-                      </div>
-                      <div className="profile-stat-label">平均铳点</div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* 番种成就只在国标模式下显示(其他模式没有番种系统) */}
-              {selectedMode === 'GUOBIAO' && (
-                <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
-                  <h4
-                    style={{
-                      margin: '0 0 16px 0',
-                      fontSize: '15px',
-                      color: 'var(--primary)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                    }}
-                  >
-                    🏆 番种成就
-                  </h4>
-                  {discoveries.length > 0 ? (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-                      {discoveries.map((fd, i) => (
-                        <div
-                          key={i}
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                            background: 'linear-gradient(135deg, rgba(33, 140, 116, 0.02), rgba(181, 137, 0, 0.02))',
-                            border: '1px solid #eef7f4',
-                            borderRadius: '10px',
-                            padding: '12px 16px',
-                          }}
-                        >
-                          <div>
-                            <div style={{ fontWeight: 700, color: 'var(--mj-teal)', fontSize: '15px' }}>
-                              🏅 {fd.fanName}
-                            </div>
-                            <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
-                              发现日期:{' '}
-                              {new Date(fd.discoveredAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
-                            </div>
+            {/* 番种成就只在国标模式下显示(其他模式没有番种系统) */}
+            {selectedMode === 'GUOBIAO' && (
+              <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
+                <h4
+                  style={{
+                    margin: '0 0 16px 0',
+                    fontSize: '15px',
+                    color: 'var(--primary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  🏆 番种成就
+                </h4>
+                {discoveries.length > 0 ? (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                    {discoveries.map((fd, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          background: 'linear-gradient(135deg, rgba(33, 140, 116, 0.02), rgba(181, 137, 0, 0.02))',
+                          border: '1px solid #eef7f4',
+                          borderRadius: '10px',
+                          padding: '12px 16px',
+                        }}
+                      >
+                        <div>
+                          <div style={{ fontWeight: 700, color: 'var(--mj-teal)', fontSize: '15px' }}>
+                            🏅 {fd.fanName}
                           </div>
-                          <span className="profile-status-pill profile-status-pill-warning">+{fd.bonusRp || 0} RP</span>
+                          <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
+                            发现日期:{' '}
+                            {new Date(fd.discoveredAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
+                          </div>
                         </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="empty-state empty-state-compact">
-                      <p>暂未发现首和番种成就。</p>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )
-        })()}
+                        <span className="profile-status-pill profile-status-pill-warning">+{fd.bonusRp || 0} RP</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="empty-state empty-state-compact">
+                    <p>暂未发现首和番种成就。</p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })()}
 
       {/* 4. 完善账号:关联老账号 / 注册新账号 */}
       {!me.merged && (

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -25,6 +25,9 @@ export default function ProfilePage() {
   // 异步获取数据
   useEffect(() => {
     if (!me) return
+    // pendingAuth 状态下 me 是从 Google profile 拼出来的占位对象, 没 id, 不能调任何
+    // 用 me.id 的接口 (会 NPE 或 401), 等用户在本页提交 setup-profile 走完之后再拉数据
+    if (me.pendingAuth || !me.id) return
 
     // 切账号时立即清掉上一个账号的 stale 数据, 避免短暂闪烁错的段位
     setStatsByMode({})
@@ -51,6 +54,7 @@ export default function ProfilePage() {
   // 个人战绩按需拉取: 只拉当前选中模式的, 切模式时再拉. 避免开页就触发 3 次重的 stats 请求.
   useEffect(() => {
     if (!me) return
+    if (me.pendingAuth || !me.id) return
     if (statsByMode[selectedMode]) return
     fetchStats(selectedMode)
       .then((data) => {
@@ -93,6 +97,13 @@ export default function ProfilePage() {
 
     setSubmitting(true)
     try {
+      const credential = sessionStorage.getItem('mahjong_google_credential')
+      if (!credential) {
+        setSetupError('Google 凭证已失效, 请重新登录')
+        setSubmitting(false)
+        return
+      }
+
       const claimable = await lookupClaimablePlayer(userName, firstName, lastName)
 
       const confirmMsg = claimable
@@ -104,11 +115,12 @@ export default function ProfilePage() {
         return
       }
 
-      let mergedMe: any
-      mergedMe = await setupProfile(userName, firstName, lastName)
+      const result = await setupProfile(credential, userName, firstName, lastName)
 
-      sessionStorage.setItem('mahjong_me', JSON.stringify(mergedMe))
-      setMe(mergedMe)
+      localStorage.setItem('mahjong_token', result.token)
+      sessionStorage.setItem('mahjong_me', JSON.stringify(result.player))
+      sessionStorage.removeItem('mahjong_google_credential')
+      setMe(result.player)
       setSetupSuccess(claimable ? '绑定成功!历史战绩已同步继承。' : '注册成功!您的雀士档案已创建。')
       setSetupForm({ userName: '', firstName: '', lastName: '' })
       window.dispatchEvent(new Event('auth-change'))

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -107,7 +107,7 @@ export default function ProfilePage() {
       const claimable = await lookupClaimablePlayer(userName, firstName, lastName)
 
       const confirmMsg = claimable
-        ? `确认提交「${userName}」吗?\n\n如该名字已对应历史账号且邮箱归属验证通过, 战绩会自动归入您的 Google 身份。`
+        ? `确认绑定老账号「${userName}」吗?\n\n该账号下的历史战绩与积分将合并到您当前的 Google 身份。`
         : `确认使用「${userName}」作为新账号吗?\n\n系统将注册一个全新雀士档案并绑定您的 Google 身份。`
 
       if (!window.confirm(confirmMsg)) {
@@ -121,7 +121,7 @@ export default function ProfilePage() {
       sessionStorage.setItem('mahjong_me', JSON.stringify(result.player))
       sessionStorage.removeItem('mahjong_google_credential')
       setMe(result.player)
-      setSetupSuccess(claimable ? '完成! 账号已就位。' : '注册成功!您的雀士档案已创建。')
+      setSetupSuccess(claimable ? '绑定成功!历史战绩已同步继承。' : '注册成功!您的雀士档案已创建。')
       setSetupForm({ userName: '', firstName: '', lastName: '' })
       window.dispatchEvent(new Event('auth-change'))
     } catch (err: any) {

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -107,7 +107,7 @@ export default function ProfilePage() {
       const claimable = await lookupClaimablePlayer(userName, firstName, lastName)
 
       const confirmMsg = claimable
-        ? `确认绑定老账号「${userName}」吗?\n\n该账号下的历史战绩与积分将合并到您当前的 Google 身份。`
+        ? `确认提交「${userName}」吗?\n\n如该名字已对应历史账号且邮箱归属验证通过, 战绩会自动归入您的 Google 身份。`
         : `确认使用「${userName}」作为新账号吗?\n\n系统将注册一个全新雀士档案并绑定您的 Google 身份。`
 
       if (!window.confirm(confirmMsg)) {
@@ -121,7 +121,7 @@ export default function ProfilePage() {
       sessionStorage.setItem('mahjong_me', JSON.stringify(result.player))
       sessionStorage.removeItem('mahjong_google_credential')
       setMe(result.player)
-      setSetupSuccess(claimable ? '绑定成功!历史战绩已同步继承。' : '注册成功!您的雀士档案已创建。')
+      setSetupSuccess(claimable ? '完成! 账号已就位。' : '注册成功!您的雀士档案已创建。')
       setSetupForm({ userName: '', firstName: '', lastName: '' })
       window.dispatchEvent(new Event('auth-change'))
     } catch (err: any) {
@@ -176,199 +176,201 @@ export default function ProfilePage() {
         </div>
       </div>
 
-      {/* 2. 个人战绩(下拉切换模式) */}
-      {(() => {
-        const stats = statsByMode[selectedMode]
-        const hasStats = stats && stats.gamesPlayed > 0
-        return (
-          <div className="profile-card">
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                gap: '12px',
-                marginBottom: '20px',
-                flexWrap: 'wrap',
-              }}
-            >
-              <h3
+      {/* 2. 个人战绩(下拉切换模式) — 占位 me 时整块不渲染, 避免显示空 card */}
+      {!me.pendingAuth &&
+        me.id &&
+        (() => {
+          const stats = statsByMode[selectedMode]
+          const hasStats = stats && stats.gamesPlayed > 0
+          return (
+            <div className="profile-card">
+              <div
                 style={{
-                  margin: 0,
-                  fontSize: '18px',
-                  color: 'var(--primary)',
                   display: 'flex',
+                  justifyContent: 'space-between',
                   alignItems: 'center',
-                  gap: '8px',
+                  gap: '12px',
+                  marginBottom: '20px',
+                  flexWrap: 'wrap',
                 }}
               >
-                📊 个人战绩
-              </h3>
-              <select
-                value={selectedMode}
-                onChange={(e) => setSelectedMode(e.target.value as GameModeKey)}
-                className="select-inline"
-              >
-                {GAME_MODES.map((m) => (
-                  <option key={m.key} value={m.key}>
-                    {m.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* 段位显示: 国标 / 立直 跟随上面 selectedMode 切换 */}
-            {tier && (selectedMode === 'GUOBIAO' || selectedMode === 'RIICHI') && (
-              <div className="profile-tier-section">
-                <RankBadge
-                  tier={selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier}
-                  size="lg"
-                  rating={
-                    (selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier) === 'UNRANKED'
-                      ? undefined
-                      : selectedMode === 'GUOBIAO'
-                      ? tier.guobiao.rating
-                      : tier.riichi.rating
-                  }
-                  gamesNeeded={selectedMode === 'GUOBIAO' ? tier.guobiao.gamesNeeded : tier.riichi.gamesNeeded}
-                />
-              </div>
-            )}
-
-            {hasStats ? (
-              <div className="profile-stats-grid">
-                <div className="profile-stat-card">
-                  <div className="profile-stat-value profile-stat-value-teal">{stats.gamesPlayed}</div>
-                  <div className="profile-stat-label">总局数</div>
-                </div>
-                <div className="profile-stat-card">
-                  <div className="profile-stat-value profile-stat-value-teal">
-                    {stats.wins}{' '}
-                    <span className="profile-stat-suffix">
-                      ({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)
-                    </span>
-                  </div>
-                  <div className="profile-stat-label">胜场 (胜率)</div>
-                </div>
-                <div className="profile-stat-card">
-                  <div className="profile-stat-value profile-stat-value-gold">
-                    {stats.totalRP > 0 ? `+${stats.totalRP.toFixed(1)}` : stats.totalRP.toFixed(1)}
-                  </div>
-                  <div className="profile-stat-label">总积分 (RP)</div>
-                </div>
-                <div className="profile-stat-card">
-                  <div className="profile-stat-value profile-stat-value-gold">
-                    {stats.avgScore > 0 ? `+${stats.avgScore.toFixed(0)}` : stats.avgScore.toFixed(0)}
-                  </div>
-                  <div className="profile-stat-label">场均表现</div>
-                </div>
-                <div className="profile-stat-card">
-                  <div className="profile-stat-value profile-stat-value-teal">{stats.avgRank.toFixed(2)}</div>
-                  <div className="profile-stat-label">平均排名</div>
-                </div>
-              </div>
-            ) : (
-              <div className="empty-state empty-state-compact">
-                <p>本模式暂无对局统计。</p>
-              </div>
-            )}
-
-            {selectedMode === 'RIICHI' && hasStats && stats.roundsPlayed > 0 && (
-              <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
-                <h4
+                <h3
                   style={{
-                    margin: '0 0 16px 0',
-                    fontSize: '15px',
+                    margin: 0,
+                    fontSize: '18px',
                     color: 'var(--primary)',
                     display: 'flex',
                     alignItems: 'center',
-                    gap: '6px',
+                    gap: '8px',
                   }}
                 >
-                  📈 数据统计
-                </h4>
+                  📊 个人战绩
+                </h3>
+                <select
+                  value={selectedMode}
+                  onChange={(e) => setSelectedMode(e.target.value as GameModeKey)}
+                  className="select-inline"
+                >
+                  {GAME_MODES.map((m) => (
+                    <option key={m.key} value={m.key}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* 段位显示: 国标 / 立直 跟随上面 selectedMode 切换 */}
+              {tier && (selectedMode === 'GUOBIAO' || selectedMode === 'RIICHI') && (
+                <div className="profile-tier-section">
+                  <RankBadge
+                    tier={selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier}
+                    size="lg"
+                    rating={
+                      (selectedMode === 'GUOBIAO' ? tier.guobiao.tier : tier.riichi.tier) === 'UNRANKED'
+                        ? undefined
+                        : selectedMode === 'GUOBIAO'
+                        ? tier.guobiao.rating
+                        : tier.riichi.rating
+                    }
+                    gamesNeeded={selectedMode === 'GUOBIAO' ? tier.guobiao.gamesNeeded : tier.riichi.gamesNeeded}
+                  />
+                </div>
+              )}
+
+              {hasStats ? (
                 <div className="profile-stats-grid">
                   <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-teal">
-                      {((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%
-                    </div>
-                    <div className="profile-stat-label">和牌率</div>
+                    <div className="profile-stat-value profile-stat-value-teal">{stats.gamesPlayed}</div>
+                    <div className="profile-stat-label">总局数</div>
                   </div>
                   <div className="profile-stat-card">
                     <div className="profile-stat-value profile-stat-value-teal">
-                      {((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%
+                      {stats.wins}{' '}
+                      <span className="profile-stat-suffix">
+                        ({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)
+                      </span>
                     </div>
-                    <div className="profile-stat-label">放铳率</div>
+                    <div className="profile-stat-label">胜场 (胜率)</div>
                   </div>
                   <div className="profile-stat-card">
                     <div className="profile-stat-value profile-stat-value-gold">
-                      {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
+                      {stats.totalRP > 0 ? `+${stats.totalRP.toFixed(1)}` : stats.totalRP.toFixed(1)}
                     </div>
-                    <div className="profile-stat-label">平均打点</div>
+                    <div className="profile-stat-label">总积分 (RP)</div>
                   </div>
                   <div className="profile-stat-card">
                     <div className="profile-stat-value profile-stat-value-gold">
-                      {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
+                      {stats.avgScore > 0 ? `+${stats.avgScore.toFixed(0)}` : stats.avgScore.toFixed(0)}
                     </div>
-                    <div className="profile-stat-label">平均铳点</div>
+                    <div className="profile-stat-label">场均表现</div>
+                  </div>
+                  <div className="profile-stat-card">
+                    <div className="profile-stat-value profile-stat-value-teal">{stats.avgRank.toFixed(2)}</div>
+                    <div className="profile-stat-label">平均排名</div>
                   </div>
                 </div>
-              </div>
-            )}
+              ) : (
+                <div className="empty-state empty-state-compact">
+                  <p>本模式暂无对局统计。</p>
+                </div>
+              )}
 
-            {/* 番种成就只在国标模式下显示(其他模式没有番种系统) */}
-            {selectedMode === 'GUOBIAO' && (
-              <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
-                <h4
-                  style={{
-                    margin: '0 0 16px 0',
-                    fontSize: '15px',
-                    color: 'var(--primary)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '6px',
-                  }}
-                >
-                  🏆 番种成就
-                </h4>
-                {discoveries.length > 0 ? (
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-                    {discoveries.map((fd, i) => (
-                      <div
-                        key={i}
-                        style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                          background: 'linear-gradient(135deg, rgba(33, 140, 116, 0.02), rgba(181, 137, 0, 0.02))',
-                          border: '1px solid #eef7f4',
-                          borderRadius: '10px',
-                          padding: '12px 16px',
-                        }}
-                      >
-                        <div>
-                          <div style={{ fontWeight: 700, color: 'var(--mj-teal)', fontSize: '15px' }}>
-                            🏅 {fd.fanName}
-                          </div>
-                          <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
-                            发现日期:{' '}
-                            {new Date(fd.discoveredAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
-                          </div>
-                        </div>
-                        <span className="profile-status-pill profile-status-pill-warning">+{fd.bonusRp || 0} RP</span>
+              {selectedMode === 'RIICHI' && hasStats && stats.roundsPlayed > 0 && (
+                <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
+                  <h4
+                    style={{
+                      margin: '0 0 16px 0',
+                      fontSize: '15px',
+                      color: 'var(--primary)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                    }}
+                  >
+                    📈 数据统计
+                  </h4>
+                  <div className="profile-stats-grid">
+                    <div className="profile-stat-card">
+                      <div className="profile-stat-value profile-stat-value-teal">
+                        {((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%
                       </div>
-                    ))}
+                      <div className="profile-stat-label">和牌率</div>
+                    </div>
+                    <div className="profile-stat-card">
+                      <div className="profile-stat-value profile-stat-value-teal">
+                        {((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%
+                      </div>
+                      <div className="profile-stat-label">放铳率</div>
+                    </div>
+                    <div className="profile-stat-card">
+                      <div className="profile-stat-value profile-stat-value-gold">
+                        {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
+                      </div>
+                      <div className="profile-stat-label">平均打点</div>
+                    </div>
+                    <div className="profile-stat-card">
+                      <div className="profile-stat-value profile-stat-value-gold">
+                        {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
+                      </div>
+                      <div className="profile-stat-label">平均铳点</div>
+                    </div>
                   </div>
-                ) : (
-                  <div className="empty-state empty-state-compact">
-                    <p>暂未发现首和番种成就。</p>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        )
-      })()}
+                </div>
+              )}
+
+              {/* 番种成就只在国标模式下显示(其他模式没有番种系统) */}
+              {selectedMode === 'GUOBIAO' && (
+                <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
+                  <h4
+                    style={{
+                      margin: '0 0 16px 0',
+                      fontSize: '15px',
+                      color: 'var(--primary)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                    }}
+                  >
+                    🏆 番种成就
+                  </h4>
+                  {discoveries.length > 0 ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                      {discoveries.map((fd, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            background: 'linear-gradient(135deg, rgba(33, 140, 116, 0.02), rgba(181, 137, 0, 0.02))',
+                            border: '1px solid #eef7f4',
+                            borderRadius: '10px',
+                            padding: '12px 16px',
+                          }}
+                        >
+                          <div>
+                            <div style={{ fontWeight: 700, color: 'var(--mj-teal)', fontSize: '15px' }}>
+                              🏅 {fd.fanName}
+                            </div>
+                            <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
+                              发现日期:{' '}
+                              {new Date(fd.discoveredAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
+                            </div>
+                          </div>
+                          <span className="profile-status-pill profile-status-pill-warning">+{fd.bonusRp || 0} RP</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="empty-state empty-state-compact">
+                      <p>暂未发现首和番种成就。</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })()}
 
       {/* 4. 完善账号:关联老账号 / 注册新账号 */}
       {!me.merged && (


### PR DESCRIPTION
## 概要

把 #135 留下的尾巴整体收掉, **Google 登录不再写 DB**, Player 行只在用户点了"找回"或"新建"之后才被创建。setupProfile 改用 `findByExactName` 作唯一入口, 用邮箱所有权代替"email 是否为 null"这种脆弱信号。顺手把 admin 改 userName 的能力补上, 后续少数手动维护需求可以在管理后台直接做。

9 个文件, 净改动 ~200 行。

## 背景

#135 修了 onboarding 期间炸 FK 的事故 (临时 Player 已被 game_session_players 引用却又要被 delete), 但临时 Player 这件事本身仍在: 每次有新 Google 用户进来都会 auto-create 一行 `merged=false` 的 Player。这造成两个长期负担:

1. 每次新加一张 player_id 外键的表, AuthController 都要补一个 `reassignPlayer` 调用, 否则 claim 路径会丢数据 (CodeRabbit 在 #135 上抓的 `Round.winnerId` / `Round.dealInPlayerId` 漏掉就是典型例子)。
2. DB 长期累积"半成品"账号行, 数据状态不干净。

本 PR 的核心是: **不存在临时 Player, 这两个问题就根本不会出现**。

## 一、AuthController.googleLogin 不再自动建 Player

只有"老用户回访" (`findByEmail` 命中且 `merged=true`) 走正常登录, 旋转 session token + 同步 Google profile, 返回 `{ token, player }`。

其他情况 (全新用户, 或 `findByEmail` 没命中) **不写 DB, 不发 token**, 返回:

```json
{ "pendingAuth": true, "profile": { "email": "...", "firstName": "...", "lastName": "...", "picture": "..." } }
```

前端收到这种响应就把 credential 暂存, 把 profile hint 当占位用户显示在 setup 页, 等用户填完表再提交。

## 二、setupProfile 改写: findByExactName + 邮箱所有权校验

不再依赖 Authorization 头, 改为请求体里带 `credential`, 服务端**再次**用 `GoogleIdTokenVerifier` 验签拿 email/picture (验签器内部缓存 Google 公钥, 二次验签成本可忽略)。

入口换成 `findByExactName(userName, firstName, lastName)` — 不再用 "email IS NULL" 来判定"是否可 claim", 改用**用户输入的姓名是否精确匹配某行**作为路径选择信号:

### claim/rebind 分支 (姓名命中)

按邮箱所有权决定:

| `match.email` | `match.merged` | 行为 |
|---|---|---|
| `null` | (隐含 false) | mode=`claim`: 老 legacy 玩家被首次绑定, UPDATE 灌 email/picture/token/merged=true |
| 等于 Google email | `false` | mode=`rebind`: 同一用户完成 onboarding 或重新登录覆写, UPDATE 同上 |
| 等于 Google email | `true` | 400 "该账号已完成绑定, 请联系管理员" (不允许自助改名, 改名走 admin) |
| 不等于 Google email | 任意 | 400 "无法完成绑定, 请联系管理员" (防 mallory 知道公开 userName 抢号) |

### register 分支 (姓名未命中)

防御性 `findByEmail(google.email)` — 如果 Google 邮箱已经绑定在**其他姓名行**上 (常见原因: 用户拼错了自己原账号的姓名), 友好 400 而不是让后续 INSERT 撞 email UNIQUE 爆 500。

随后正常的 INSERT 新 Player + merged=true。

### 安全文案

所有失败统一返回 "请联系管理员", **不向 caller 泄露其他行的 userName/firstName/lastName**, 防止枚举攻击。管理员 (=你) 在 admin 页可以看到真实数据, 手动告知用户应该怎么填。

### 顺带清理

- 删 `PlayerRepository.findClaimableLegacyPlayer` (已无引用)
- `lookup-claimable` endpoint 也切到 `findByExactName`, 行为更贴近真实 setup 流程

## 三、AuthController 内部清理

- 抽 `verifyCredential` / `newVerifier` / `newSessionToken` 三个 helper, googleLogin 和 setupProfile 复用
- 新增 `GoogleProfile` private static 内嵌类承载验签后的 4 个字段, 避免函数返回 4 元素 array / Map
- 构造函数注入从 6 个 repo 缩到 1 个 (只剩 `PlayerRepository`)
- 收紧 catch 子句: `catch (Exception e)` → `catch (GeneralSecurityException | IOException e)` (满足 PMD `SignatureDeclareThrowsException`)
- `redactEmail` 用 `charAt(0)` 代替 `substring(0, 1)` (静态分析建议)

## 四、删除 dead repository 方法

PR #135 + CodeRabbit 修复时为旧 legacy-claim 路径加的, 现在没有任何路径调用它们:

- `GameSessionPlayerRepository.reassignPlayer`
- `RoundScoreRepository.reassignPlayer`
- `FanDiscoveryRepository.reassignPlayer`
- `RoundRepository.reassignWinner`
- `RoundRepository.reassignDealInPlayer`
- `PlayerRepository.findClaimableLegacyPlayer`

## 五、前端: LoginPage / ProfilePage / api

- `api.loginWithGoogle` 返回类型改为 discriminated union: `{ pendingAuth: false, token, player } | { pendingAuth: true, profile }`
- `api.setupProfile` 签名加 `credential` 入参, 不再走 `Authorization` 头, 返回 `{ token, player }`
- `LoginPage`: 收到 `pendingAuth: true` 时把 `response.credential` 存进 `sessionStorage`, 同时把 Google profile hint 拼装成占位 `me` 也存 sessionStorage, 跳到 `/profile`。这里复用了 ProfilePage 自带的 setup 表单, UX 上和现状完全一样
- `ProfilePage`: 提交 setup 时从 sessionStorage 取出 credential 一起 POST, 成功后存正式 token + 真 Player, 清掉 credential。新增 `me.pendingAuth || !me.id` 保护, 跳过那两个按 `me.id` 拉战绩/段位的 useEffect (占位 me 没 id, 会触发 NPE / 401)

## 六、Admin: 加 userName 编辑能力

PR #136 deploy 后, 用户名变更不再走 setupProfile 自助路径 (会被 merged=true 分支拒绝), 改由管理员在 admin 页上代为修改。

- `GameService.updatePlayer` 加 `userName` 入参, 校验 case-insensitive 唯一性 (跟当前值相同则跳过), 命中已被占用抛 `IllegalArgumentException`
- `AdminController.PUT /admin/players/{id}` 把 `IllegalArgumentException` 翻成 400 `ResponseStatusException` (保留 stack trace, 满足 PMD `PreserveStackTrace`)
- `AdminPage`: 编辑模式下 userName 列变可编辑 (新增 `editUserName` state), `handleSave` 一起带过去
- DB schema 没有动 (userName 那列本来就是 `@Column(unique=true)`)

## 历史数据自适应

DB 里 `merged=false AND email IS NOT NULL` 的 2 个用户 (id=20 honkwan / id=21 alex) **无需事先 drain**, 本 PR 合并后他们直接登录新版即可:

- 登录 → `googleLogin` → `findByEmail` 命中且 `merged=false` → 返回 pendingAuth + profile (不写 DB)
- 进 ProfilePage 看到 setup 表单, 填**精确匹配 DB 里那行**的 userName/firstName/lastName 提交
- `setupProfile` → `findByExactName` 命中自己那行 → 邮箱一致 + `merged=false` → 走 rebind 分支 → 标 merged=true, 旋转 token, 返回真正登录态

只要他们不把姓名拼错, 自助走完不需要任何管理员介入。

万一拼错触发了 register 分支但又撞了 email UNIQUE, 防御性检查会返回 "无法完成绑定, 请联系管理员", 此时管理员可以在 admin 页查实际记录的 userName 并告诉他们怎么填 (或者直接帮他们修 userName, 见第六节)。

## 测试要点

- [ ] **全新 Google 账号 (register)**: 用没用过的 Google 账号登录 → 看到 setup 表单 (占位 me 用 Google 给的姓名预填), 不应该看到段位/战绩区块加载错误 → 填一个新用户名提交 → 成功后存 token, 头部显示新用户名
- [ ] **全新 Google 账号 + 匹配 legacy unbound (claim)**: 用没用过的 Google 账号登录 → setup 页填和某个 legacy unbound 玩家名字完全一致的 userName/firstName/lastName → confirm 弹"���定老账号" → 提交 → 老账号被接管, 历史战绩立刻可见
- [ ] **历史遗留 merged=false (rebind)**: 用 id=20 / id=21 之一登录 → 看到 setup 表单 → 精确填���他们 DB 里那行的姓名 → 提交 → 成功登录, merged=true
- [ ] **老用户回访 (merged=true)**: 已经 merged 的用户 Google 登录 → 直接进 home, 没有 setup 表单
- [ ] **邮箱所有权校验 (mallory 攻击)**: 自己用一个**别人**的 Google 账号登录, setup 页填某个已绑定用户的姓名 (比如 id=20 honkwan) → 应该看到 "无法完成绑定, 请联系管理员", **不能接管**
- [ ] **拼错保护**: 改 id=20 的姓名为"故意拼错版本", 用 id=20 的 Google 账号登录, setup 表单填新姓名 → register 分支应该被防御性 findByEmail 挡住, 返回 "无法完成绑定, 请联系管理员"
- [ ] **用户名占用 (register)**: register 时填一个**别人**已经在用的 userName → "用户名已被占用,请换一个"
- [ ] **credential 过期**: 用户登录后挂机 1+ 小时再提交 setup 表单 → "Google 凭证已失效, 请重新登录" (而不是 500)
- [ ] **页面刷新 mid-setup**: 在 setup 表单页 F5 → sessionStorage 还在, 表单仍可提交; localStorage 没 token, 不会被路由跳到 /home
- [ ] **Admin 改 userName**: admin 页编辑某玩家, 把 userName 改成空闲值 → 成功; 改成另一个玩家在用的 userName → 收到 "Username already taken" alert; 改成自己当前同值 → 直接保存通过

## 文件改动

- `server/.../controller/AuthController.java` — googleLogin 不再 auto-create; setupProfile 改 findByExactName 入口 + 邮箱所有权校验 + 防御 findByEmail; 抽 helper 和 GoogleProfile DTO; 注入收紧到 1 个 repo
- `server/.../controller/AdminController.java` — PUT /admin/players/{id} 接受 userName + 转 IllegalArgumentException 为 400
- `server/.../service/GameService.java` — updatePlayer 加 userName 入参 + 唯一性校验
- `server/.../repository/PlayerRepository.java` — 加 findByExactName, 删 findClaimableLegacyPlayer
- `server/.../repository/FanDiscoveryRepository.java` — 删 reassignPlayer
- `server/.../repository/GameSessionPlayerRepository.java` — 删 reassignPlayer
- `server/.../repository/RoundRepository.java` — 删 reassignWinner / reassignDealInPlayer
- `server/.../repository/RoundScoreRepository.java` — 删 reassignPlayer
- `ui/src/api/index.ts` — loginWithGoogle 返回类型 union; setupProfile 加 credential
- `ui/src/pages/LoginPage.tsx` — 区分 pendingAuth 和正常登录两条路径
- `ui/src/pages/ProfilePage.tsx` — 提交 setup 带 credential; 占位 me 跳过 stats useEffect
- `ui/src/pages/AdminPage.tsx` — 编辑模式 userName 可编辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google sign-in now supports a pending setup flow for users who still need to finish profile creation.
  * Admins can now edit a player’s username, first name, and last name directly.

* **Bug Fixes**
  * Improved username validation so duplicate usernames are rejected during profile updates and setup.
  * Profile setup now handles account claiming and new registration more reliably.

* **Chores**
  * Some account and player data handling was streamlined behind the scenes for more consistent auth and profile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->