### PR TITLE
fix(auth): ProtectedRoute 识别 pendingAuth, 修复新用户登录死循环

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -81,6 +81,7 @@ function App() {
   const handleLogout = () => {
     localStorage.removeItem('mahjong_token')
     sessionStorage.removeItem('mahjong_me')
+    sessionStorage.removeItem('mahjong_google_credential')
     window.dispatchEvent(new Event('auth-change'))
     navigate('/login')
   }

--- a/ui/src/components/ProtectedRoute.tsx
+++ b/ui/src/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { fetchCurrentUser } from '../api'
 
 interface ProtectedRouteProps {
@@ -8,6 +8,8 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const token = localStorage.getItem('mahjong_token')
+  const pendingCredential = sessionStorage.getItem('mahjong_google_credential')
+  const location = useLocation()
   const [loading, setLoading] = useState(true)
   const [authenticated, setAuthenticated] = useState(false)
 
@@ -38,6 +40,12 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
         <p>正在验证身份信息...</p>
       </div>
     )
+  }
+
+  // pendingAuth — Google 凭证已暂存但 Player 还没建。只放行 /profile (setup 表单),
+  // 其它 protected 路由统一漏斗到 /profile, 而不是 /login.
+  if (!token && pendingCredential) {
+    return location.pathname === '/profile' ? children : <Navigate to="/profile" replace />
   }
 
   if (!token || !authenticated) {

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -109,6 +109,11 @@ export default function LoginPage() {
       navigate('/home', { replace: true })
       return
     }
+    const pendingCredential = sessionStorage.getItem('mahjong_google_credential')
+    if (pendingCredential) {
+      navigate('/profile', { replace: true })
+      return
+    }
     return initGis()
   }, [navigate, initGis])
 


### PR DESCRIPTION
## 概要

#136 (a8455b5) 引入 pendingAuth 状态后线上回归: 全新 Google 账号登录后看到 \`Google Auth verified successfully\` log, 但前端进不去任何页面, 卡在登录-profile 跳转循环里。3 个文件, +15 / -1。

## 根因

#136 把 Player 创建延后到 setupProfile, 所以 \`googleLogin\` 对全新用户**不发 \`mahjong_token\`**, 只在 sessionStorage 暂存 \`mahjong_google_credential\` 当做半授权状态。

但 \`ProtectedRoute\` 还是只看 \`localStorage.mahjong_token\`:

\`\`\`
loginWithGoogle → pendingAuth 响应 → 前端 navigate('/profile')
                                          ↓
                                  ProtectedRoute(/profile)
                                          ↓ (无 token)
                                  Navigate to /login
                                          ↓
                                  LoginPage useEffect 看 token 也没
                                          ↓
                                  显示 Google 登录按钮
                                          ↓
                                  用户再点 → 又 pendingAuth → 循环
\`\`\`

死循环, 用户进不去 /profile (那是唯一能完成 setup 的页面)。

## 修复 — ProtectedRoute 识别半授权状态

不把 /profile 移出 ProtectedRoute (那会丢掉 stale token 自动清理路径), 改成 ProtectedRoute 主动识别 pendingAuth:

| token | pendingCredential | 当前路径 | 行为 |
|---|---|---|---|
| ✅ | — | 任意 protected | 走原 fetchCurrentUser 验证 + 渲染 children (维持现状) |
| — | ✅ | \`/profile\` | **放行 children** (用户完成 setup) |
| — | ✅ | 其它 protected | **跳 \`/profile\`** (而不是 \`/login\`, 漏斗到唯一能继续的页面) |
| — | — | 任意 protected | 跳 \`/login\` (维持现状) |

\`ProtectedRoute.tsx\` 增加 \`useLocation\` 和 sessionStorage 检查, 总共 ~10 行。

## 配套小改动

- **LoginPage**: 主动访问 \`/login\` 时若 sessionStorage 已有 pendingCredential, 直接跳 \`/profile\` 不再 init Google 登录按钮。否则用户在 setup 流程中按浏览器后退能再点一次 Google 登录, 浪费一个新 credential 覆盖 sessionStorage (功能上没坏, 但 UX 不优雅)。
- **App.tsx handleLogout**: 顺手 \`sessionStorage.removeItem('mahjong_google_credential')\`。当前 pendingAuth 状态顶栏不显示 logout 按钮所以触不到, 防御性 (未来可能有 401 自动 logout 等)。

## audit 其他场景

| 场景 | 行为 |
|---|---|
| 已登录用户访问 /profile | token 验证 → 显示 profile, 维持现状 |
| 已登录用户 token 过期访问 protected | ProtectedRoute.fetchCurrentUser 清 token + Navigate /login, 维持现状 |
| 未登录用户访问 protected | Navigate /login, 维持现状 |
| pendingAuth 用户访问 /profile | **放行**, 显示 setup 表单 ✓ (本 PR 修复) |
| pendingAuth 用户访问 /game, /admin 等 | **跳 /profile** ✓ (本 PR 修复) |
| pendingAuth 用户主动访问 /login | LoginPage **跳 /profile** ✓ (本 PR 改动) |
| pendingAuth 用户 F5 刷新 /profile | sessionStorage 保留, ProtectedRoute 仍放行, 继续 setup ✓ |
| pendingAuth 用户关 tab 重开 | sessionStorage 自动清空, 回 LoginPage Google 登录, 重新走一遍 ✓ |
| setup 完成 | ProfilePage.handleSetupSubmit 存 token + clear credential, 跳 /home ✓ (已在 #136) |

## 测试要点

- [ ] **死循环复现 + 修复**: 用一个全新 Google 账号登录 → 应该进 ProfilePage 看到 setup 表单, 不应被踢回 /login
- [ ] **完成 setup**: 填表提交 → 成功后 token 写入 localStorage, sessionStorage credential 清掉, 跳 /home
- [ ] **pendingAuth 漫游**: 在 setup 中途, 浏览器地址栏输入 /game 或 /admin → 应被跳到 /profile
- [ ] **pendingAuth 主动访问 /login**: 在 setup 中途, 输入 /login → 应被跳到 /profile
- [ ] **F5 刷新**: 在 /profile setup 页 F5 → 表单仍可见, 凭证仍在 sessionStorage
- [ ] **关 tab 重开**: 在 /profile setup 页关 tab, 重开 → 回 LoginPage 重新登录
- [ ] **老用户回访不受影响**: merged=true 用户 Google 登录 → 直接进 /home
- [ ] **token 过期路径不受影响**: 把 localStorage.mahjong_token 改成无效值, 访问任意 protected route → 应清 token + 跳 /login (维持现状)

## 文件改动

- \`ui/src/components/ProtectedRoute.tsx\` — 加 pendingCredential 识别 + \`useLocation\`
- \`ui/src/pages/LoginPage.tsx\` — useEffect 看到 pendingCredential 跳 /profile
- \`ui/src/App.tsx\` — handleLogout 顺手清 credential (防御)

🤖 Generated with [Claude Code](https://claude.com/claude-code)