### PR TITLE
chore(ci): GH Actions 升到 Node 24 runtime 兼容版本

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -30,7 +30,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,16 @@ jobs:
     name: Server Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -36,10 +36,10 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
## 概要

GitHub Actions 在 [2025-09-19](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) 弃用了 Node 20 runner。我们 workflow 里多个 action 还在 declare Node 20 作为运行时, build 时被强制跑在 Node 24 + 吐 deprecation 警告。各 action 现在都有 Node 24 目标的新版, 统一升一下。

2 个文件, +7 / −7。

## 版本变化

### `deploy.yml`
| Action | 旧 | 新 | 备注 |
|---|---|---|---|
| `actions/checkout` | v5 | **v7** | v7.0.0 主要为 Node 24 兼容 |
| `docker/build-push-action` | v6 | **v7** | v7.0.0 (2026-03) 是触发本 PR 的告警源 |
| `docker/setup-buildx-action` | v4 | (不动) | v4.1.0 已 Node 24 兼容 |
| `docker/login-action` | v4 | (不动) | v4.2.0 已 Node 24 兼容 |
| `appleboy/ssh-action` | v1 | (不动) | 还在 v1 主版本, 最新 v1.2.5 |

### `test.yml`
| Action | 旧 | 新 |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-java` | v4 | **v5** |
| `actions/cache` | v4 | **v5** |
| `actions/setup-node` | v4 | **v6** |

> 注: \`test.yml\` 里 \`node-version: '20'\` **不动** — 那是项目自己用的 Node 版本 (npm / vite / tsc 跑在上面), 跟 action runtime 是两回事。Node 20 还在 LTS 维护期。

## audit 兼容性

这些都是官方维护的 actions (\`actions/*\` 是 GitHub 自己的, \`docker/*\` 是 Docker 官方的), 大版本通常只为了升级 Node 运行时, 没有 input/output 破坏。我们的 workflow 用法都是 mainstream (\`with: path / key / restore-keys\`、\`with: distribution / java-version\`、\`with: node-version / cache\`), 不依赖 deprecated input。

如果 CI 真挂了哪一条, 单独把那个 action pin 回老版本就行 — 但实际不太可能。

## 测试要点

- [ ] 合并后看一眼 GH Actions tab, 确认下次 build 不再有 "Node.js 20 is deprecated" 警告
- [ ] \`test.yml\` 在下一个 PR 上正常跑通 (server tests + ui tests 两个 job)
- [ ] \`deploy.yml\` 触发 (push 到 main) 后 image 正常 build + push 到 GHCR, deploy 步骤正常 SSH 登服务器拉新 image

## 文件改动

- \`.github/workflows/deploy.yml\` — checkout v5→v7, build-push v6→v7
- \`.github/workflows/test.yml\` — checkout v4→v7, setup-java v4→v5, cache v4→v5, setup-node v4→v6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and deployment workflows to use newer versions of GitHub Actions.
  * Improved the build and test pipeline by refreshing checkout, Java, Node, caching, and container image actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->