### PR TITLE
fix(ui): 长用户名自适应缩放 + 多表 fixed-table 化避免横滑

### DIFF
--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { scoreClass } from '../utils/format'
+import { nameFontSize } from '../utils/fontSize'
 import { TierKey } from '../types'
 import { RankBadge } from './RankBadge'
 import { TableStrengthTag } from './TableStrengthTag'
@@ -55,13 +56,15 @@ export const GameCard: React.FC<Props> = ({
       </div>
       <div className="session-card-players">
         {players.map((p, idx) => (
-          <div key={idx} className={`player-rank-item rank-${p.rank}`}>
-            <div className="player-rank-main">
-              <span className="rank-number">#{p.rank}</span>
+          <div key={idx} className="player-rank-item">
+            <span className="player-name-with-rank">
+              <span className={`rank-number${p.rank <= 3 ? ` rank-tag-${p.rank}` : ''}`}>#{p.rank}</span>
               {p.wind && <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>{p.wind}</span>}
               <RankBadge tier={p.tier} size="sm" userName={p.name} />
-              <span className="player-name">{p.name}</span>
-            </div>
+              <span className="player-name" style={{ fontSize: nameFontSize(p.name) }}>
+                {p.name}
+              </span>
+            </span>
             <span className={`player-score ${scoreClass(p.score)}`}>{p.score > 0 ? `+${p.score}` : p.score}</span>
           </div>
         ))}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -380,10 +380,6 @@ tr:hover td {
   opacity: 1;
 }
 
-.score-table {
-  overflow-x: auto;
-}
-
 .score-table table {
   min-width: 100%;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -409,7 +409,7 @@ table.fixed-table .col-rank {
   width: 44px;
 }
 
-table.fixed-table .col-num-narrow {
+table.fixed-table .col-num {
   width: 52px;
   text-align: right;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -409,7 +409,7 @@ table.fixed-table .col-rank {
   width: 44px;
 }
 
-table.fixed-table .col-num {
+table.fixed-table .col-num-narrow {
   width: 52px;
   text-align: right;
 }
@@ -423,7 +423,7 @@ table.fixed-table .col-name {
   padding-left: 12px;
 }
 
-table.flex-table {
+table.auto-table {
   table-layout: auto;
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -380,50 +380,54 @@ tr:hover td {
   opacity: 1;
 }
 
-.score-table {
+.table-wrap {
   overflow-x: auto;
 }
 
-.score-table table {
+.table-wrap table {
   min-width: 100%;
 }
 
-.score-table th,
-.score-table td {
+.table-wrap th,
+.table-wrap td {
   vertical-align: middle;
 }
 
-.score-table table.fixed-table {
+table.fixed-table {
   table-layout: fixed;
   width: 100%;
   min-width: 0;
 }
 
-.score-table table.fixed-table th,
-.score-table table.fixed-table td {
+table.fixed-table th,
+table.fixed-table td {
   padding-left: 6px;
   padding-right: 6px;
 }
 
-.score-table table.fixed-table .col-rank {
+table.fixed-table .col-rank {
   width: 44px;
 }
 
-.score-table table.fixed-table .col-num {
+table.fixed-table .col-num {
   width: 52px;
   text-align: right;
 }
 
-.score-table table.fixed-table .col-num-wide {
+table.fixed-table .col-num-wide {
   width: 68px;
   text-align: right;
 }
 
-.score-table table.fixed-table .col-name {
+table.fixed-table .col-name {
   padding-left: 12px;
 }
 
-.score-table td.score-cell {
+table.flex-table {
+  table-layout: auto;
+}
+
+.table-wrap td.score-cell {
   text-align: center;
   font-variant-numeric: tabular-nums;
 }
@@ -438,7 +442,7 @@ tr:hover td {
   color: var(--danger);
 }
 
-.score-table .total-row td {
+.table-wrap .total-row td {
   font-weight: 700;
   background: var(--bg);
   border-top: 2px solid var(--primary);

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -380,6 +380,10 @@ tr:hover td {
   opacity: 1;
 }
 
+.score-table {
+  overflow-x: auto;
+}
+
 .score-table table {
   min-width: 100%;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -393,6 +393,36 @@ tr:hover td {
   vertical-align: middle;
 }
 
+.score-table table.fixed-table {
+  table-layout: fixed;
+  width: 100%;
+  min-width: 0;
+}
+
+.score-table table.fixed-table th,
+.score-table table.fixed-table td {
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.score-table table.fixed-table .col-rank {
+  width: 44px;
+}
+
+.score-table table.fixed-table .col-num {
+  width: 52px;
+  text-align: right;
+}
+
+.score-table table.fixed-table .col-num-wide {
+  width: 68px;
+  text-align: right;
+}
+
+.score-table table.fixed-table .col-name {
+  padding-left: 12px;
+}
+
 .score-table td.score-cell {
   text-align: center;
   font-variant-numeric: tabular-nums;
@@ -498,12 +528,6 @@ tr:hover td {
   margin-bottom: 24px;
 }
 
-.profile-stats-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
-}
-
 .login-container {
   display: flex;
   flex-direction: column;
@@ -593,39 +617,6 @@ tr:hover td {
 .profile-card-warning {
   background: rgb(181 137 0 / 2%);
   border: 1px dashed var(--mj-gold);
-}
-
-.profile-stat-card {
-  background: var(--card-muted);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 16px;
-  text-align: center;
-}
-
-.profile-stat-value {
-  font-size: 24px;
-  font-weight: 700;
-}
-
-.profile-stat-value-teal {
-  color: var(--mj-teal);
-}
-
-.profile-stat-value-gold {
-  color: var(--mj-gold);
-}
-
-.profile-stat-suffix {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-muted);
-}
-
-.profile-stat-label {
-  font-size: 12px;
-  color: var(--text-light);
-  margin-top: 4px;
 }
 
 .profile-info-row {
@@ -1012,53 +1003,11 @@ tr:hover td {
   opacity: 1;
 }
 
-/* Sign Up page */
-.signup-container {
-  display: flex;
-  justify-content: center;
-  padding-top: 20px;
-}
-
-.signup-card {
-  width: 100%;
-  max-width: 480px;
-}
-
-.signup-title {
-  font-size: 1.15rem;
-  font-weight: 600;
-  color: var(--primary);
-  text-align: center;
-  margin-bottom: 28px;
-}
-
-.signup-btn {
-  width: 100%;
-  justify-content: center;
-  margin-top: 8px;
-  padding: 12px;
-  font-size: 1rem;
-}
-
-.signup-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .field-hint {
   display: block;
   margin-top: 4px;
   font-size: 0.8rem;
   color: var(--text-light);
-}
-
-.error-banner {
-  background: #fdecea;
-  color: var(--danger);
-  padding: 10px 14px;
-  border-radius: 8px;
-  font-size: 0.9rem;
-  margin-bottom: 16px;
 }
 
 .error-text {
@@ -1273,7 +1222,7 @@ tr:hover td {
 }
 
 .player-name-with-rank {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 6px;
 }
@@ -1504,6 +1453,16 @@ tr:hover td {
 
 /* ===== Mobile responsive ===== */
 @media (width <= 640px) {
+  .player-detail-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .player-detail-tiers {
+    justify-content: flex-end;
+  }
+
   .login-container {
     min-height: 0;
     justify-content: flex-start;
@@ -2026,10 +1985,6 @@ tr:hover td {
 
   .win-action-row-three {
     flex-direction: column;
-  }
-
-  .profile-stats-grid {
-    grid-template-columns: 1fr;
   }
 
   .claim-name-row {
@@ -2846,12 +2801,6 @@ tr:hover td {
   margin-bottom: 12px;
 }
 
-.rank-number {
-  font-weight: 900;
-  font-size: 1.2rem;
-  width: 24px;
-}
-
 .rank-info {
   flex: 1;
   display: flex;
@@ -2996,12 +2945,6 @@ tr:hover td {
   padding-bottom: 8px;
 }
 
-.player-rank-main {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .game-card .rank-number {
   font-weight: 900;
   font-size: 0.75rem;
@@ -3009,18 +2952,9 @@ tr:hover td {
   opacity: 0.4;
 }
 
-.game-card .rank-1 .rank-number {
-  color: var(--sol-yellow);
-  opacity: 1;
-}
-
-.game-card .rank-2 .rank-number {
-  color: var(--sol-base0);
-  opacity: 1;
-}
-
-.game-card .rank-3 .rank-number {
-  color: var(--sol-orange);
+.game-card .rank-number.rank-tag-1,
+.game-card .rank-number.rank-tag-2,
+.game-card .rank-number.rank-tag-3 {
   opacity: 1;
 }
 

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -195,8 +195,8 @@ export default function AdminPage() {
 
       <div className="card">
         <h2>Players ({players.length})</h2>
-        <div className="score-table">
-          <table>
+        <div className="table-wrap">
+          <table className="flex-table">
             <thead>
               <tr>
                 <th>ID</th>
@@ -286,8 +286,8 @@ export default function AdminPage() {
           Deleting a session permanently removes all of its rounds, round scores, and fan discoveries (achievements).
           This cannot be undone. In-progress sessions are not shown.
         </p>
-        <div className="score-table">
-          <table>
+        <div className="table-wrap">
+          <table className="flex-table">
             <thead>
               <tr>
                 <th>ID</th>

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -196,7 +196,7 @@ export default function AdminPage() {
       <div className="card">
         <h2>Players ({players.length})</h2>
         <div className="table-wrap">
-          <table className="flex-table">
+          <table className="auto-table">
             <thead>
               <tr>
                 <th>ID</th>
@@ -287,7 +287,7 @@ export default function AdminPage() {
           This cannot be undone. In-progress sessions are not shown.
         </p>
         <div className="table-wrap">
-          <table className="flex-table">
+          <table className="auto-table">
             <thead>
               <tr>
                 <th>ID</th>

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -196,14 +196,14 @@ export default function AdminPage() {
       <div className="card">
         <h2>Players ({players.length})</h2>
         <div className="score-table">
-          <table className="fixed-table">
+          <table>
             <thead>
               <tr>
-                <th style={{ width: '48px' }}>ID</th>
+                <th>ID</th>
                 <th>Username</th>
                 <th>Name</th>
-                <th style={{ width: '90px' }}>Joined</th>
-                <th style={{ width: '130px' }}></th>
+                <th>Joined</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -287,15 +287,15 @@ export default function AdminPage() {
           This cannot be undone. In-progress sessions are not shown.
         </p>
         <div className="score-table">
-          <table className="fixed-table">
+          <table>
             <thead>
               <tr>
-                <th style={{ width: '48px' }}>ID</th>
+                <th>ID</th>
                 <th>Name</th>
-                <th style={{ width: '64px' }}>Mode</th>
-                <th style={{ width: '56px' }}>Rounds</th>
-                <th style={{ width: '90px' }}>Created</th>
-                <th style={{ width: '80px' }}></th>
+                <th>Mode</th>
+                <th>Rounds</th>
+                <th>Created</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -173,7 +173,7 @@ export default function AdminPage() {
               inputMode="decimal"
               value={bonus}
               onChange={(e) => setBonus(e.target.value)}
-              style={{ width: '100%', maxWidth: 120 }}
+              style={{ flex: '0 1 120px', minWidth: 0 }}
             />
             <button
               className="btn btn-primary btn-small"
@@ -213,7 +213,7 @@ export default function AdminPage() {
                         <input
                           value={editUserName}
                           onChange={(e) => setEditUserName(e.target.value)}
-                          style={{ width: '100%', maxWidth: 120 }}
+                          style={{ width: '100%', maxWidth: 120, minWidth: 0 }}
                           placeholder="Username"
                           autoFocus
                         />
@@ -227,13 +227,13 @@ export default function AdminPage() {
                           <input
                             value={editFirst}
                             onChange={(e) => setEditFirst(e.target.value)}
-                            style={{ width: '100%', maxWidth: 80 }}
+                            style={{ flex: '1 1 70px', minWidth: 0, maxWidth: 100 }}
                             placeholder="First"
                           />
                           <input
                             value={editLast}
                             onChange={(e) => setEditLast(e.target.value)}
-                            style={{ width: '100%', maxWidth: 80 }}
+                            style={{ flex: '1 1 70px', minWidth: 0, maxWidth: 100 }}
                             placeholder="Last"
                             onKeyDown={(e) => e.key === 'Enter' && handleSave(p.id)}
                           />

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { Navigate } from 'react-router-dom'
 import { Player, GameSession } from '../types'
 
 const API = '/api/admin'
@@ -13,6 +14,7 @@ export default function AdminPage() {
   const [players, setPlayers] = useState<Player[]>([])
   const [sessions, setSessions] = useState<GameSession[]>([])
   const [loading, setLoading] = useState(true)
+  const [authorized, setAuthorized] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
   const [editUserName, setEditUserName] = useState('')
   const [editFirst, setEditFirst] = useState('')
@@ -22,21 +24,25 @@ export default function AdminPage() {
   const [savingSettings, setSavingSettings] = useState(false)
   const [deletingSessionId, setDeletingSessionId] = useState<number | null>(null)
 
-  const loadPlayers = async () => {
+  const loadPlayers = async (): Promise<boolean> => {
     const res = await fetch(`${API}/players`, { headers: authHeaders() })
     if (res.ok) {
       setPlayers(await res.json())
+      return true
     }
+    return false
   }
 
-  const loadSessions = async () => {
+  const loadSessions = async (): Promise<boolean> => {
     const res = await fetch(`${API}/sessions`, { headers: authHeaders() })
     if (res.ok) {
       setSessions(await res.json())
+      return true
     }
+    return false
   }
 
-  const loadSettings = async () => {
+  const loadSettings = async (): Promise<boolean> => {
     const res = await fetch(`${API}/settings`, { headers: authHeaders() })
     if (res.ok) {
       const data = await res.json()
@@ -47,11 +53,15 @@ export default function AdminPage() {
           setSavedBonus(String(val))
         }
       }
+      return true
     }
+    return false
   }
 
   useEffect(() => {
-    Promise.all([loadPlayers(), loadSessions(), loadSettings()]).finally(() => setLoading(false))
+    Promise.all([loadPlayers(), loadSessions(), loadSettings()])
+      .then((results) => setAuthorized(results.every(Boolean)))
+      .finally(() => setLoading(false))
   }, [])
 
   const handleSaveSettings = async () => {
@@ -150,12 +160,8 @@ export default function AdminPage() {
     }
   }
 
-  if (loading)
-    return (
-      <div className="empty-state">
-        <p>Loading...</p>
-      </div>
-    )
+  if (loading) return null
+  if (!authorized) return <Navigate to="/" replace />
 
   return (
     <>
@@ -190,14 +196,14 @@ export default function AdminPage() {
       <div className="card">
         <h2>Players ({players.length})</h2>
         <div className="score-table">
-          <table>
+          <table className="fixed-table">
             <thead>
               <tr>
-                <th>ID</th>
+                <th style={{ width: '48px' }}>ID</th>
                 <th>Username</th>
                 <th>Name</th>
-                <th>Joined</th>
-                <th></th>
+                <th style={{ width: '90px' }}>Joined</th>
+                <th style={{ width: '130px' }}></th>
               </tr>
             </thead>
             <tbody>
@@ -281,15 +287,15 @@ export default function AdminPage() {
           This cannot be undone. In-progress sessions are not shown.
         </p>
         <div className="score-table">
-          <table>
+          <table className="fixed-table">
             <thead>
               <tr>
-                <th>ID</th>
+                <th style={{ width: '48px' }}>ID</th>
                 <th>Name</th>
-                <th>Mode</th>
-                <th>Rounds</th>
-                <th>Created</th>
-                <th></th>
+                <th style={{ width: '64px' }}>Mode</th>
+                <th style={{ width: '56px' }}>Rounds</th>
+                <th style={{ width: '90px' }}>Created</th>
+                <th style={{ width: '80px' }}></th>
               </tr>
             </thead>
             <tbody>

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { GAME_MODES, SessionDetail, PlayerStats, BestRound, getCurrentSeason } f
 import { GameCard } from '../components/GameCard'
 import { RankBadge } from '../components/RankBadge'
 import { deriveGameState, getWindName } from '../utils/gameState'
+import { nameFontSize } from '../utils/fontSize'
 import { MSG } from '../constants'
 
 export default function HomePage() {
@@ -121,7 +122,7 @@ export default function HomePage() {
                     ) : (
                       data.top.map((player, idx) => (
                         <div key={player.playerId} className="rank-item">
-                          <span className={`rank-number rank-tag-${idx + 1}`}>#{idx + 1}</span>
+                          <span className={`rank-tag rank-tag-${idx + 1}`}>#{idx + 1}</span>
                           <div className="rank-info">
                             <span className="player-name-with-rank">
                               <RankBadge
@@ -130,7 +131,9 @@ export default function HomePage() {
                                 gamesNeeded={undefined}
                                 userName={player.userName}
                               />
-                              <span className="player-name">{player.userName}</span>
+                              <span className="player-name" style={{ fontSize: nameFontSize(player.userName) }}>
+                                {player.userName}
+                              </span>
                             </span>
                             <span className="player-score">{player.totalRP.toFixed(1)} RP</span>
                           </div>

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -86,7 +86,7 @@ export default function PlayerDetailPage() {
             <p>暂无游戏记录。</p>
           </div>
         ) : (
-          <div className="score-table">
+          <div className="table-wrap">
             <table className="fixed-table">
               <thead>
                 <tr>

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -87,14 +87,16 @@ export default function PlayerDetailPage() {
           </div>
         ) : (
           <div className="score-table">
-            <table>
+            <table className="fixed-table">
               <thead>
                 <tr>
                   <th>游戏</th>
-                  <th>模式</th>
-                  <th>日期</th>
-                  <th>状态</th>
-                  <th className="text-right">分数</th>
+                  <th style={{ width: '56px' }}>模式</th>
+                  <th style={{ width: '80px' }}>日期</th>
+                  <th style={{ width: '60px' }}>状态</th>
+                  <th className="text-right" style={{ width: '68px' }}>
+                    分数
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -104,7 +106,9 @@ export default function PlayerDetailPage() {
                     onClick={() => navigate(`/session/${g.sessionId}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    <td>{g.sessionName || `Game #${g.sessionId}`}</td>
+                    <td style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {g.sessionName || `Game #${g.sessionId}`}
+                    </td>
                     <td>{g.gameModeDisplayName}</td>
                     <td>{new Date(g.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
                     <td>

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -238,35 +238,55 @@ export default function ProfilePage() {
               )}
 
               {hasStats ? (
-                <div className="profile-stats-grid">
-                  <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-teal">{stats.gamesPlayed}</div>
-                    <div className="profile-stat-label">总局数</div>
+                <div className="stats-grid">
+                  <div className="stat-card">
+                    <div className="stat-value">{stats.gamesPlayed}</div>
+                    <div className="stat-label">总局数</div>
                   </div>
-                  <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-teal">
-                      {stats.wins}{' '}
-                      <span className="profile-stat-suffix">
+                  <div className="stat-card">
+                    <div className="stat-value">{stats.avgRank.toFixed(2)}</div>
+                    <div className="stat-label">平均排名</div>
+                  </div>
+                  <div className="stat-card">
+                    <div className="stat-value">
+                      {stats.wins}
+                      <span
+                        style={{
+                          fontSize: '0.6rem',
+                          color: 'var(--text-light)',
+                          verticalAlign: 'bottom',
+                          marginLeft: 2,
+                        }}
+                      >
                         ({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)
                       </span>
                     </div>
-                    <div className="profile-stat-label">胜场 (胜率)</div>
+                    <div className="stat-label">胜场</div>
                   </div>
-                  <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-gold">
+                  <div className="stat-card">
+                    <div
+                      className="stat-value"
+                      style={{
+                        color: stats.totalRP > 0 ? 'var(--success)' : stats.totalRP < 0 ? 'var(--danger)' : undefined,
+                      }}
+                    >
+                      {(() => {
+                        const avgRP = stats.totalRP / stats.gamesPlayed
+                        return avgRP > 0 ? `+${avgRP.toFixed(1)}` : avgRP.toFixed(1)
+                      })()}
+                    </div>
+                    <div className="stat-label">场均(RP)</div>
+                  </div>
+                  <div className="stat-card">
+                    <div
+                      className="stat-value"
+                      style={{
+                        color: stats.totalRP > 0 ? 'var(--success)' : stats.totalRP < 0 ? 'var(--danger)' : undefined,
+                      }}
+                    >
                       {stats.totalRP > 0 ? `+${stats.totalRP.toFixed(1)}` : stats.totalRP.toFixed(1)}
                     </div>
-                    <div className="profile-stat-label">总积分 (RP)</div>
-                  </div>
-                  <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-gold">
-                      {stats.avgScore > 0 ? `+${stats.avgScore.toFixed(0)}` : stats.avgScore.toFixed(0)}
-                    </div>
-                    <div className="profile-stat-label">场均表现</div>
-                  </div>
-                  <div className="profile-stat-card">
-                    <div className="profile-stat-value profile-stat-value-teal">{stats.avgRank.toFixed(2)}</div>
-                    <div className="profile-stat-label">平均排名</div>
+                    <div className="stat-label">总积分(RP)</div>
                   </div>
                 </div>
               ) : (
@@ -287,32 +307,28 @@ export default function ProfilePage() {
                       gap: '6px',
                     }}
                   >
-                    📈 数据统计
+                    🪪 数据统计
                   </h4>
-                  <div className="profile-stats-grid">
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-teal">
-                        {((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%
-                      </div>
-                      <div className="profile-stat-label">和牌率</div>
+                  <div className="stats-grid">
+                    <div className="stat-card">
+                      <div className="stat-value">{((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%</div>
+                      <div className="stat-label">和牌率</div>
                     </div>
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-teal">
-                        {((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%
-                      </div>
-                      <div className="profile-stat-label">放铳率</div>
+                    <div className="stat-card">
+                      <div className="stat-value">{((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%</div>
+                      <div className="stat-label">放铳率</div>
                     </div>
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-gold">
+                    <div className="stat-card">
+                      <div className="stat-value">
                         {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
                       </div>
-                      <div className="profile-stat-label">平均打点</div>
+                      <div className="stat-label">平均打点</div>
                     </div>
-                    <div className="profile-stat-card">
-                      <div className="profile-stat-value profile-stat-value-gold">
+                    <div className="stat-card">
+                      <div className="stat-value">
                         {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
                       </div>
-                      <div className="profile-stat-label">平均铳点</div>
+                      <div className="stat-label">平均铳点</div>
                     </div>
                   </div>
                 </div>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -766,7 +766,7 @@ export default function SessionPage() {
             )}
           </div>
         </div>
-        <div className="score-table">
+        <div className="table-wrap">
           <table className="fixed-table">
             <thead>
               <tr>
@@ -897,7 +897,7 @@ export default function SessionPage() {
       {session.rounds.length > 0 && (
         <div className="card">
           <h2>排名</h2>
-          <div className="score-table">
+          <div className="table-wrap">
             <table className="fixed-table">
               <thead>
                 <tr>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -300,8 +300,11 @@ export default function SessionPage() {
     return state.displayName
   }
 
-  const playerColPct = `${Math.floor(90 / session.players.length)}%`
-  const playerColStyle = { textAlign: 'center' as const, width: playerColPct, minWidth: 56 }
+  const fixedColPx = 60 + (session.status === 'IN_PROGRESS' ? 32 : 0)
+  const playerColStyle = {
+    textAlign: 'center' as const,
+    width: `calc((100% - ${fixedColPx}px) / ${session.players.length})`,
+  }
 
   const otherPlayers = session.players.filter((p) => p.id !== Number(winnerId))
   const dealerId = String(gameState.dealerPlayerId)
@@ -764,7 +767,7 @@ export default function SessionPage() {
           </div>
         </div>
         <div className="score-table">
-          <table>
+          <table className="fixed-table">
             <thead>
               <tr>
                 <th style={{ textAlign: 'center', width: '60px' }}>局</th>
@@ -779,7 +782,7 @@ export default function SessionPage() {
                     </div>
                   </th>
                 ))}
-                {session.status === 'IN_PROGRESS' && <th></th>}
+                {session.status === 'IN_PROGRESS' && <th style={{ width: '32px' }}></th>}
               </tr>
             </thead>
             <tbody>
@@ -895,13 +898,17 @@ export default function SessionPage() {
         <div className="card">
           <h2>排名</h2>
           <div className="score-table">
-            <table>
+            <table className="fixed-table">
               <thead>
                 <tr>
-                  <th>名次</th>
+                  <th className="col-rank">排名</th>
                   <th>玩家</th>
-                  <th className="text-right">分数</th>
-                  <th className="text-right">积分(RP)</th>
+                  <th className="text-right" style={{ width: '72px' }}>
+                    分数
+                  </th>
+                  <th className="text-right" style={{ width: '92px' }}>
+                    积分(RP)
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -912,10 +919,14 @@ export default function SessionPage() {
                   const rank = rankMap[p.id]?.rank ?? i + 1
                   return (
                     <tr key={p.id}>
-                      <td>
+                      <td className="col-rank">
                         <span className={`rank-tag rank-tag-${rank}`}>#{rank}</span>
                       </td>
-                      <td>{p.userName}</td>
+                      <td>
+                        <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
+                          {p.userName}
+                        </span>
+                      </td>
                       <td className={`${scoreClass(val)} num-cell`}>{val > 0 ? `+${val}` : val}</td>
                       <td className="num-cell-rp">
                         {baseRp > 0 ? `+${baseRp.toFixed(1)}` : baseRp.toFixed(1)}

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -255,8 +255,8 @@ export default function StatsPage() {
                     <tr>
                       <th className="col-rank">排名</th>
                       <th className="col-name">玩家</th>
-                      <th className="col-num-narrow">胜场</th>
-                      <th className="col-num-narrow">场均</th>
+                      <th className="col-num">胜场</th>
+                      <th className="col-num">场均</th>
                       <th className="col-num-wide">积分</th>
                     </tr>
                   </thead>
@@ -390,8 +390,8 @@ export default function StatsPage() {
                   <tr>
                     <th className="col-rank">排名</th>
                     <th className="col-name">玩家</th>
-                    <th className="col-num-narrow">平均排名</th>
-                    <th className="col-num-narrow">段位分</th>
+                    <th className="col-num">平均排名</th>
+                    <th className="col-num">段位分</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -9,8 +9,8 @@ type Tab = 'games' | 'players'
 
 const currentSeason = getCurrentSeason()
 
-import { statFontSize } from '../utils/fontSize'
-import { abbrName, parseError } from '../utils/format'
+import { statFontSize, nameFontSize } from '../utils/fontSize'
+import { parseError } from '../utils/format'
 import { MSG } from '../constants'
 import { useActiveSeasons } from '../hooks/useActiveSeasons'
 
@@ -143,6 +143,7 @@ export default function StatsPage() {
         skillRating: stat?.skillRating,
         totalGames: stat?.gamesPlayed ?? 0,
         gamesNeeded: stat?.gamesNeeded,
+        avgRank: stat?.avgRank,
       }
     })
     .sort((a, b) => (b.skillRating ?? 0) - (a.skillRating ?? 0))
@@ -249,14 +250,14 @@ export default function StatsPage() {
             <div className="card">
               <h2>排行榜</h2>
               <div className="score-table">
-                <table>
+                <table className="fixed-table">
                   <thead>
                     <tr>
-                      <th>名次</th>
-                      <th>玩家</th>
-                      <th className="text-right">场次</th>
-                      <th className="text-right">胜场</th>
-                      <th className="text-right">积分(RP)</th>
+                      <th className="col-rank">排名</th>
+                      <th className="col-name">玩家</th>
+                      <th className="col-num">胜场</th>
+                      <th className="col-num">场均</th>
+                      <th className="col-num-wide">积分</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -267,7 +268,7 @@ export default function StatsPage() {
                         style={{ cursor: 'pointer' }}
                       >
                         <td>
-                          {i < 3 ? <span className={`rank-number rank-tag-${i + 1}`}>#{i + 1}</span> : <>#{i + 1}</>}
+                          {i < 3 ? <span className={`rank-tag rank-tag-${i + 1}`}>#{i + 1}</span> : <>#{i + 1}</>}
                         </td>
                         <td>
                           <span className="player-name-with-rank">
@@ -277,11 +278,32 @@ export default function StatsPage() {
                               userName={s.userName}
                               gamesNeeded={s.tier === 'UNRANKED' ? s.gamesNeeded : undefined}
                             />
-                            <span className="player-name">{s.userName}</span>
+                            <span className="player-name" style={{ fontSize: nameFontSize(s.userName) }}>
+                              {s.userName}
+                            </span>
                           </span>
                         </td>
-                        <td className="text-right">{s.gamesPlayed}</td>
-                        <td className="text-right">{s.wins}</td>
+                        <td className="num-cell">
+                          {s.wins}
+                          <span
+                            style={{
+                              fontSize: '0.6rem',
+                              color: 'var(--text-light)',
+                              verticalAlign: 'bottom',
+                              marginLeft: 2,
+                            }}
+                          >
+                            ({((s.wins / s.gamesPlayed) * 100).toFixed(0)}%)
+                          </span>
+                        </td>
+                        <td
+                          className="num-cell"
+                          style={{
+                            color: s.avgScore > 0 ? 'var(--success)' : s.avgScore < 0 ? 'var(--danger)' : undefined,
+                          }}
+                        >
+                          {s.avgScore > 0 ? `+${s.avgScore.toFixed(0)}` : s.avgScore.toFixed(0)}
+                        </td>
                         <td className="num-cell-rp">
                           {s.totalRP > 0 ? `+${s.totalRP.toFixed(1)}` : s.totalRP.toFixed(1)}
                         </td>
@@ -363,13 +385,13 @@ export default function StatsPage() {
           <div className="card">
             <h2>全部玩家</h2>
             <div className="score-table">
-              <table>
+              <table className="fixed-table">
                 <thead>
                   <tr>
-                    <th>排名</th>
-                    <th>用户名</th>
-                    <th>姓名</th>
-                    {gameMode !== 'DONGBEI' && <th>段位</th>}
+                    <th className="col-rank">排名</th>
+                    <th className="col-name">玩家</th>
+                    <th className="col-num">平均排名</th>
+                    <th className="col-num">段位分</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -379,24 +401,24 @@ export default function StatsPage() {
                       onClick={() => navigate(`/player/${p.id}?from=players`)}
                       style={{ cursor: 'pointer' }}
                     >
-                      <td>{i + 1}</td>
-                      <td style={{ color: 'var(--primary)', fontWeight: 600 }}>{p.userName}</td>
-                      <td>{abbrName(p.firstName + ' ' + p.lastName)}</td>
-                      {gameMode !== 'DONGBEI' && (
-                        <td>
-                          <span className="player-name-with-rank">
-                            <RankBadge
-                              tier={p.tier ?? 'UNRANKED'}
-                              size="sm"
-                              userName={p.userName}
-                              gamesNeeded={p.tier === 'UNRANKED' || !p.tier ? p.gamesNeeded : undefined}
-                            />
-                            {p.tier && p.tier !== 'UNRANKED' && (
-                              <span className="player-tier-rating">{p.skillRating?.toFixed(0)}</span>
-                            )}
+                      <td>{i < 3 ? <span className={`rank-tag rank-tag-${i + 1}`}>#{i + 1}</span> : <>#{i + 1}</>}</td>
+                      <td>
+                        <span className="player-name-with-rank">
+                          <RankBadge
+                            tier={p.tier ?? 'UNRANKED'}
+                            size="sm"
+                            userName={p.userName}
+                            gamesNeeded={p.tier === 'UNRANKED' || !p.tier ? p.gamesNeeded : undefined}
+                          />
+                          <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
+                            {p.userName}
                           </span>
-                        </td>
-                      )}
+                        </span>
+                      </td>
+                      <td className="num-cell">{p.totalGames > 0 ? p.avgRank?.toFixed(2) : '-'}</td>
+                      <td className="num-cell-rp">
+                        {p.tier && p.tier !== 'UNRANKED' ? p.skillRating?.toFixed(0) : '-'}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -255,8 +255,8 @@ export default function StatsPage() {
                     <tr>
                       <th className="col-rank">排名</th>
                       <th className="col-name">玩家</th>
-                      <th className="col-num">胜场</th>
-                      <th className="col-num">场均</th>
+                      <th className="col-num-narrow">胜场</th>
+                      <th className="col-num-narrow">场均</th>
                       <th className="col-num-wide">积分</th>
                     </tr>
                   </thead>
@@ -390,8 +390,8 @@ export default function StatsPage() {
                   <tr>
                     <th className="col-rank">排名</th>
                     <th className="col-name">玩家</th>
-                    <th className="col-num">平均排名</th>
-                    <th className="col-num">段位分</th>
+                    <th className="col-num-narrow">平均排名</th>
+                    <th className="col-num-narrow">段位分</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -370,7 +370,6 @@ export default function StatsPage() {
                     <th>用户名</th>
                     <th>姓名</th>
                     {gameMode !== 'DONGBEI' && <th>段位</th>}
-                    <th>注册日期</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -398,7 +397,6 @@ export default function StatsPage() {
                           </span>
                         </td>
                       )}
-                      <td>{new Date(p.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -249,7 +249,7 @@ export default function StatsPage() {
           ) : (
             <div className="card">
               <h2>排行榜</h2>
-              <div className="score-table">
+              <div className="table-wrap">
                 <table className="fixed-table">
                   <thead>
                     <tr>
@@ -384,7 +384,7 @@ export default function StatsPage() {
         <>
           <div className="card">
             <h2>全部玩家</h2>
-            <div className="score-table">
+            <div className="table-wrap">
               <table className="fixed-table">
                 <thead>
                   <tr>

--- a/ui/src/utils/fontSize.ts
+++ b/ui/src/utils/fontSize.ts
@@ -32,10 +32,11 @@ export function nameFontSize(text: string) {
     text,
     [
       { maxLen: 6, desktop: '0.95rem', mobile: '0.85rem' },
-      { maxLen: 8, desktop: '0.95rem', mobile: '0.7rem' },
-      { maxLen: 12, desktop: '0.8rem', mobile: '0.7rem' },
+      { maxLen: 8, desktop: '0.95rem', mobile: '0.8rem' },
+      { maxLen: 12, desktop: '0.8rem', mobile: '0.75rem' },
+      { maxLen: 16, desktop: '0.7rem', mobile: '0.6rem' },
     ],
-    { desktop: '0.7rem', mobile: '0.6rem' }
+    { desktop: '0.65rem', mobile: '0.45rem' }
   )
 }
 


### PR DESCRIPTION
## Summary
- 新增 `nameFontSize` 分级缩放 util,按用户名长度自动调字号,长名不再撑列或被默认 ellipsis 截掉
- 多张得分表升级为 `table-layout: fixed`,移动端不再横滑:
  - StatsPage 排行榜 / 玩家 tab
  - SessionPage 主计分板 + 排名 mini-table
  - PlayerDetailPage 历史游戏表(长 sessionName 用 ellipsis 截断)
  - AdminPage Players / Sessions 表(为移除 .score-table 横滑兜底)
- 删除 `.score-table { overflow-x: auto }`,所有表都 fixed-table 化后不再需要
- AdminPage 加 admin 授权门:任一 admin API 返回非 200 立即重定向到 `/`,loading 期间渲染 null,不再泄露页面骨架
- PlayerDetailPage 头部移动端(≤640px)强制堆叠成两行,短/长名玩家布局一致
- ProfilePage 场均 → 场均RP(`totalRP / gamesPlayed`),正负绿/红色彩
- HomePage 本月荣誉殿堂 + GameCard 玩家行 统一用 nameFontSize

## Test plan
- [ ] iPhone 14 Pro Max(440px)和 14 Pro(393px)真机各跑一遍
- [ ] 16 字长名("MonkeyAlwaysKing")在 StatsPage 排行榜 / SessionPage 计分板 / 排名表 / GameCard 不撑列,不横滑
- [ ] SessionPage 主计分板 IN_PROGRESS + 4 玩家 列均匀分布,有删除按钮列(32px)
- [ ] SessionPage 主计分板 已结束状态 没有删除列,玩家列加宽
- [ ] PlayerDetailPage 短名 + 长名玩家头部布局一致(都是两行)
- [ ] PlayerDetailPage 历史游戏表 不横滑,长 sessionName ellipsis
- [ ] 桌面端 ≥640px PlayerDetailPage 头部仍单行(名字左 + 段位右)
- [ ] ProfilePage 场均RP 正值绿色 / 负值红色 / 零无色
- [ ] HomePage 殿堂 / NewSessionPage 选玩家卡片 显示正常
- [ ] **非 admin 用户访问 /admin → 立即跳 `/`,不闪管理面板骨架**
- [ ] admin 用户访问 /admin → 正常加载所有表,无横滑