### PR TITLE
fix(ui): 删无效 className + 补移动端遗漏

### DIFF
--- a/ui/src/components/shared/TileComponent.tsx
+++ b/ui/src/components/shared/TileComponent.tsx
@@ -40,7 +40,7 @@ export const TileComponent: React.FC<{
       <img
         src={`https://raw.githubusercontent.com/FluffyStuff/riichi-mahjong-tiles/master/Regular/${tileKey}.svg`}
         alt={isBack ? 'Back' : getTileName(tile)}
-        className={`calc-tile ${isWinning ? 'highlighted-tile' : ''} ${isBack ? 'back-tile-svg' : ''}`}
+        className={`calc-tile ${isWinning ? 'highlighted-tile' : ''}`}
       />
     </div>
   )

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2988,10 +2988,6 @@ table.auto-table {
     padding: 12px;
   }
 
-  .fan-group-title {
-    font-size: 1.1rem;
-  }
-
   .fan-item-card {
     padding: 10px;
   }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2999,12 +2999,6 @@ table.auto-table {
   .fan-item-example-real {
     padding: 12px 6px 6px;
   }
-
-  .profile-info-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
-  }
 }
 
 .pagination-container {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2988,6 +2988,10 @@ table.auto-table {
     padding: 12px;
   }
 
+  .fan-group-title {
+    font-size: 1.1rem;
+  }
+
   .fan-item-card {
     padding: 10px;
   }
@@ -2998,6 +3002,12 @@ table.auto-table {
 
   .fan-item-example-real {
     padding: 12px 6px 6px;
+  }
+
+  .profile-info-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
   }
 }
 

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -282,10 +282,6 @@ export default function AdminPage() {
 
       <div className="card">
         <h2>Completed Sessions ({sessions.length})</h2>
-        <p className="page-subtitle">
-          Deleting a session permanently removes all of its rounds, round scores, and fan discoveries (achievements).
-          This cannot be undone. In-progress sessions are not shown.
-        </p>
         <div className="table-wrap">
           <table className="auto-table">
             <thead>
@@ -293,8 +289,8 @@ export default function AdminPage() {
                 <th>ID</th>
                 <th>Name</th>
                 <th>Mode</th>
-                <th>Rounds</th>
-                <th>Created</th>
+                <th>Rnds</th>
+                <th>Time</th>
                 <th></th>
               </tr>
             </thead>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -576,7 +576,7 @@ export default function SessionPage() {
                 </div>
 
                 {isRiichi && (
-                  <div className="form-group score-inline-group-container">
+                  <div className="form-group">
                     <div className="score-inline-group">
                       <label>分数</label>
                       <input
@@ -641,7 +641,7 @@ export default function SessionPage() {
                 )}
 
                 {!isRiichi && isGuobiao && (
-                  <div className="form-group score-inline-group-container">
+                  <div className="form-group">
                     <div className="score-inline-group">
                       <label>分数</label>
                       <input

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -390,8 +390,8 @@ export default function StatsPage() {
                   <tr>
                     <th className="col-rank">排名</th>
                     <th className="col-name">玩家</th>
-                    <th className="col-num">平均排名</th>
-                    <th className="col-num">段位分</th>
+                    <th className="col-num-wide">平均排名</th>
+                    <th className="col-num-wide">段位分</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -334,7 +334,7 @@ export default function StatsPage() {
                       <span className="best-hand-fan-count">{round.fanCount} 番</span>
                       <span className="best-hand-players">
                         <span className="winner-label">赢家:</span> {round.winnerName}
-                        <span className="win-type-label ml-2">({round.dealInPlayerId != null ? '点炮' : '自摸'})</span>
+                        <span className="ml-2">({round.dealInPlayerId != null ? '点炮' : '自摸'})</span>
                         <span className="session-link-label ml-2">
                           <Link to={`/session/${round.sessionId}`}>查看对局</Link>
                         </span>
@@ -363,7 +363,7 @@ export default function StatsPage() {
                       <span className="best-hand-fan-count">{round.fanCount} 番</span>
                       <span className="best-hand-players">
                         <span className="winner-label">赢家:</span> {round.winnerName}
-                        <span className="win-type-label ml-2">({round.dealInPlayerId != null ? '点炮' : '自摸'})</span>
+                        <span className="ml-2">({round.dealInPlayerId != null ? '点炮' : '自摸'})</span>
                         <span className="session-link-label ml-2">
                           <Link to={`/session/${round.sessionId}`}>查看对局</Link>
                         </span>

--- a/ui/src/utils/fontSize.ts
+++ b/ui/src/utils/fontSize.ts
@@ -31,7 +31,7 @@ export function nameFontSize(text: string) {
   return resolve(
     text,
     [
-      { maxLen: 6, desktop: '0.95rem', mobile: '0.85rem' },
+      { maxLen: 6, desktop: '0.95rem', mobile: '1rem' },
       { maxLen: 8, desktop: '0.95rem', mobile: '0.8rem' },
       { maxLen: 12, desktop: '0.8rem', mobile: '0.75rem' },
       { maxLen: 16, desktop: '0.7rem', mobile: '0.6rem' },


### PR DESCRIPTION
A. 删 ghost class:
- score-inline-group-container (无 CSS 规则, 外层 form-group 已覆盖)
- win-type-label (无 CSS 规则, 实际生效的是 ml-2)
- back-tile-svg 三元 (无 CSS 规则, 仅 alt 仍需 isBack)

B. 补 @media (width <= 640px):
- .fan-group-title 字号 1.4rem → 1.1rem
- .profile-info-row 改 column 防长邮箱挤压

## Summary
<!-- Brief description of what this PR does -->

## Test plan
<!-- How to verify the changes -->
- [ ] `./gradlew build` passes
- [ ] `cd ui && npm run build` passes
- [ ] `cd ui && npm run test:run` — all tests pass

---

<!-- CodeRabbit commands:
  @coderabbitai review      — trigger a review on new changes
  @coderabbitai full review — re-review the entire PR from scratch
  @coderabbitai summary     — regenerate the PR summary
  @coderabbitai ignore      — stop reviewing this PR entirely
  @coderabbitai resolve     — top-level: resolve all comments; reply: resolve that thread only
-->
