### PR TITLE
feat: 数据统计移到玩家详情页并支持多模式切换

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerDetailResponse.java
@@ -2,6 +2,7 @@ package com.mahjong.omakase.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +15,9 @@ public class PlayerDetailResponse {
   private String lastName;
   private List<GameEntry> games;
 
+  /** Per-mode round-level metrics (和牌率/放铳率/平均打点/平均铳点), keyed by GameMode name. */
+  private Map<String, ModeStats> statsByMode;
+
   @Getter
   @Setter
   public static class GameEntry {
@@ -24,5 +28,16 @@ public class PlayerDetailResponse {
     private String status;
     private LocalDateTime createdAt;
     private int totalScore;
+  }
+
+  @Getter
+  @Setter
+  public static class ModeStats {
+    private int roundsPlayed;
+    private int handWins;
+    private int tsumoWins;
+    private int dealIns;
+    private double avgWinPoints;
+    private double avgDealInPoints;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -1033,7 +1033,7 @@ public class GameService {
         // Other modes have different scoring semantics where these don't translate cleanly.
         if (session.getGameMode() == GameMode.RIICHI) {
           List<Object[]> rows = riichiRoundsBySessionId.getOrDefault(session.getId(), List.of());
-          accumulateRiichiRoundStats(
+          accumulateRoundStats(
               rows, roundsPlayed, handWins, dealIns, winPointsSum, dealInPointsSum);
         }
       }
@@ -1117,7 +1117,7 @@ public class GameService {
    * round.winnerId; dealIns/avgDealInPoints land on the round.dealInPlayerId (self-draws are
    * dealInPlayerId == null, so no deal-in is recorded for those rounds).
    */
-  private void accumulateRiichiRoundStats(
+  private void accumulateRoundStats(
       List<Object[]> rows,
       Map<Long, Integer> roundsPlayed,
       Map<Long, Integer> handWins,
@@ -1193,7 +1193,73 @@ public class GameService {
     resp.setFirstName(player.getFirstName());
     resp.setLastName(player.getLastName());
     resp.setGames(games);
+    resp.setStatsByMode(computeModeStats(playerId, sessions));
     return resp;
+  }
+
+  /**
+   * Per-mode round-level metrics (和牌率/放铳率/平均打点/平均铳点) for a single player, scoped to that player's
+   * own completed sessions. Cheaper than {@link #getPlayerStats} which aggregates the whole table.
+   * Only modes in which the player actually has rounds are included.
+   */
+  private Map<String, PlayerDetailResponse.ModeStats> computeModeStats(
+      Long playerId, List<GameSession> sessions) {
+    List<GameSession> completed =
+        sessions.stream().filter(s -> s.getStatus() == SessionStatus.COMPLETED).toList();
+    if (completed.isEmpty()) return Map.of();
+
+    Map<Long, GameMode> modeBySession = new HashMap<>();
+    for (GameSession s : completed) modeBySession.put(s.getId(), s.getGameMode());
+
+    // Partition round-detail rows by mode, reshaping to the [roundId, winnerId, dealInPlayerId,
+    // playerId, score] tuple that accumulateRoundStats expects (dropping the leading sessionId).
+    Map<GameMode, List<Object[]>> rowsByMode = new EnumMap<>(GameMode.class);
+    List<Long> ids = completed.stream().map(GameSession::getId).toList();
+    for (Object[] row : roundScoreRepo.getRoundDetailsBySessions(ids)) {
+      GameMode mode = modeBySession.get((Long) row[0]);
+      if (mode == null) continue;
+      rowsByMode
+          .computeIfAbsent(mode, k -> new ArrayList<>())
+          .add(new Object[] {row[1], row[2], row[3], row[4], row[5]});
+    }
+
+    Map<String, PlayerDetailResponse.ModeStats> statsByMode = new HashMap<>();
+    for (var entry : rowsByMode.entrySet()) {
+      Map<Long, Integer> roundsPlayed = new HashMap<>();
+      Map<Long, Integer> handWins = new HashMap<>();
+      Map<Long, Integer> dealIns = new HashMap<>();
+      Map<Long, Integer> winPointsSum = new HashMap<>();
+      Map<Long, Integer> dealInPointsSum = new HashMap<>();
+      accumulateRoundStats(
+          entry.getValue(), roundsPlayed, handWins, dealIns, winPointsSum, dealInPointsSum);
+
+      int rounds = roundsPlayed.getOrDefault(playerId, 0);
+      if (rounds == 0) continue;
+      int hw = handWins.getOrDefault(playerId, 0);
+      int di = dealIns.getOrDefault(playerId, 0);
+
+      // 自摸 (self-draw) wins for this player — 荣和 count is derivable as handWins - tsumoWins.
+      Set<Long> seenWinRounds = new HashSet<>();
+      int tsumo = 0;
+      for (Object[] row : entry.getValue()) {
+        Long roundId = (Long) row[0];
+        Long winnerId = (Long) row[1];
+        Long dealInPlayerId = (Long) row[2];
+        if (playerId.equals(winnerId) && dealInPlayerId == null && seenWinRounds.add(roundId)) {
+          tsumo++;
+        }
+      }
+
+      PlayerDetailResponse.ModeStats ms = new PlayerDetailResponse.ModeStats();
+      ms.setRoundsPlayed(rounds);
+      ms.setHandWins(hw);
+      ms.setTsumoWins(tsumo);
+      ms.setDealIns(di);
+      ms.setAvgWinPoints(hw > 0 ? (double) winPointsSum.getOrDefault(playerId, 0) / hw : 0);
+      ms.setAvgDealInPoints(di > 0 ? (double) dealInPointsSum.getOrDefault(playerId, 0) / di : 0);
+      statsByMode.put(entry.getKey().name(), ms);
+    }
+    return statsByMode;
   }
 
   private GameModeHandler getHandler(GameMode mode) {

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { fetchPlayerDetail, fetchPlayerTier } from '../api'
-import { PlayerDetail, PlayerTierResponse } from '../types'
+import { PlayerDetail, PlayerTierResponse, GameModeKey, GAME_MODES } from '../types'
 import { abbrName, scoreClass, parseError } from '../utils/format'
 import { MSG } from '../constants'
 import { RankBadge } from '../components/RankBadge'
@@ -11,6 +11,7 @@ export default function PlayerDetailPage() {
   const navigate = useNavigate()
   const [player, setPlayer] = useState<PlayerDetail | null>(null)
   const [tier, setTier] = useState<PlayerTierResponse | null>(null)
+  const [statsMode, setStatsMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -77,6 +78,80 @@ export default function PlayerDetailPage() {
             </div>
           )}
         </div>
+      </div>
+
+      <div className="card">
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '12px',
+            marginBottom: '20px',
+            flexWrap: 'wrap',
+          }}
+        >
+          <h2 style={{ margin: 0 }}>🪪 数据统计</h2>
+          <select
+            value={statsMode}
+            onChange={(e) => setStatsMode(e.target.value as GameModeKey)}
+            className="select-inline"
+          >
+            {GAME_MODES.map((m) => (
+              <option key={m.key} value={m.key}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        {(() => {
+          const stats = player.statsByMode?.[statsMode]
+          if (!stats || stats.roundsPlayed === 0) {
+            return (
+              <div className="empty-state empty-state-compact">
+                <p>本模式暂无数据统计。</p>
+              </div>
+            )
+          }
+          return (
+            <div className="stats-grid">
+              <div className="stat-card">
+                <div className="stat-value">
+                  {((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%
+                  {stats.handWins > 0 && (
+                    <span
+                      style={{
+                        fontSize: '0.6rem',
+                        color: 'var(--text-light)',
+                        verticalAlign: 'bottom',
+                        marginLeft: 2,
+                      }}
+                    >
+                      ({((stats.tsumoWins / stats.handWins) * 100).toFixed(0)}%)
+                    </span>
+                  )}
+                </div>
+                <div className="stat-label">和牌率(自摸率)</div>
+              </div>
+              <div className="stat-card">
+                <div className="stat-value">{((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%</div>
+                <div className="stat-label">放铳率</div>
+              </div>
+              <div className="stat-card">
+                <div className="stat-value">
+                  {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
+                </div>
+                <div className="stat-label">平均打点</div>
+              </div>
+              <div className="stat-card">
+                <div className="stat-value">
+                  {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
+                </div>
+                <div className="stat-label">平均铳点</div>
+              </div>
+            </div>
+          )
+        })()}
       </div>
 
       <div className="card">

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -295,45 +295,6 @@ export default function ProfilePage() {
                 </div>
               )}
 
-              {selectedMode === 'RIICHI' && hasStats && stats.roundsPlayed > 0 && (
-                <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
-                  <h4
-                    style={{
-                      margin: '0 0 16px 0',
-                      fontSize: '15px',
-                      color: 'var(--primary)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                    }}
-                  >
-                    🪪 数据统计
-                  </h4>
-                  <div className="stats-grid">
-                    <div className="stat-card">
-                      <div className="stat-value">{((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%</div>
-                      <div className="stat-label">和牌率</div>
-                    </div>
-                    <div className="stat-card">
-                      <div className="stat-value">{((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%</div>
-                      <div className="stat-label">放铳率</div>
-                    </div>
-                    <div className="stat-card">
-                      <div className="stat-value">
-                        {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
-                      </div>
-                      <div className="stat-label">平均打点</div>
-                    </div>
-                    <div className="stat-card">
-                      <div className="stat-value">
-                        {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
-                      </div>
-                      <div className="stat-label">平均铳点</div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
               {/* 番种成就只在国标模式下显示(其他模式没有番种系统) */}
               {selectedMode === 'GUOBIAO' && (
                 <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -224,12 +224,22 @@ export interface PlayerGameEntry {
   totalScore: number
 }
 
+export interface PlayerModeStats {
+  roundsPlayed: number
+  handWins: number
+  tsumoWins: number
+  dealIns: number
+  avgWinPoints: number
+  avgDealInPoints: number
+}
+
 export interface PlayerDetail {
   playerId: number
   userName: string
   firstName: string
   lastName: string
   games: PlayerGameEntry[]
+  statsByMode: Partial<Record<GameModeKey, PlayerModeStats>>
 }
 export interface BestRound {
   sessionId: number


### PR DESCRIPTION
## 概要

把原先只在个人资料页(ProfilePage)立直模式下显示的"数据统计"(和牌率/放铳率/平均打点/平均铳点)移到玩家详情页(`/player/:id`), 并扩展为支持国标/立直/东北三种模式切换。数据改由 `/players/{id}/detail` 接口一次性返回、只聚合该玩家自己的对局, 避免复用全表扫描的 `getPlayerStats`。共 5 个文件, +169 / -42。

## 一、前端: 统计块迁移与多模式切换

- **移除**: ProfilePage 立直"数据统计"块。
- **新增**: PlayerDetailPage 数据统计卡片, 顶部 `select-inline` 切换国标/立直/东北, 复用现有 `.stats-grid` / `.stat-card` 样式。
- 各模式无对局数据时显示"本模式暂无数据统计。"空态。
- `player.statsByMode?.[statsMode]` 加可选链, 后端未返回该字段时降级为空态而非白屏。

## 二、前端: 和牌率显示自摸率

- 和牌率卡片在百分比后用小括号显示自摸率, 如 `20.0% (50%)`, 括号内为 自摸局数 / 和牌局数。
- 和牌数为 0 时不显示括号, 避免除零。

## 三、后端: 按玩家聚合、避免全表扫描

- `PlayerDetailResponse` 新增 `statsByMode`(按 `GameMode` 名索引), 字段含 `roundsPlayed` / `handWins` / `tsumoWins` / `dealIns` / `avgWinPoints` / `avgDealInPoints`。
- `getPlayerDetail` 只用该玩家自己的已完成对局聚合, 一次 `getRoundDetailsBySessions` 查询按模式分组, 不再触发返回全部玩家的 `getPlayerStats`。开页由多次全量聚合降为随详情一次返回。
- `accumulateRiichiRoundStats` 更名为 `accumulateRoundStats`(现通用于各模式), 同步更新 `getPlayerStats` 调用点, 逻辑不变。
- 自摸(`dealInPlayerId` 为 null)不计入放铳, 与雀魂口径一致。

## 四、工具: PMD 修复

- 修复 `pmdMain` 的 `UseEnumCollections` 违规: `rowsByMode` 由 `HashMap` 改为 `EnumMap`(该 map 以 `GameMode` 枚举为键)。

## 测试要点

- [ ] 玩家详情页(`/player/:id?from=players`)显示数据统计卡片, 模式切换正常
- [ ] 和牌率括号内自摸率 = 自摸 / 和牌, 数值正确; 和牌为 0 时不显示括号
- [ ] 东北麻将无点炮记录的玩家, 放铳率 0.0% 且平均铳点显示 `-`
- [ ] 个人资料页(ProfilePage)不再显示"数据统计"块
- [ ] 无对局数据的模式显示空态而非报错
- [ ] **重启后端**后接口返回 `statsByMode`; 未重启时页面不白屏(降级空态)
- [ ] 打开详情页仅一次 `/players/{id}/detail` 请求, 无额外 `/stats` 请求

## 文件改动

- `PlayerDetailResponse.java` — 新增 `statsByMode` 及内嵌 `ModeStats`
- `GameService.java` — 新增 `computeModeStats`; helper 更名; `EnumMap` 修复
- `PlayerDetailPage.tsx` — 数据统计卡片 + 模式切换 + 自摸率
- `ProfilePage.tsx` — 移除数据统计块
- `types/index.ts` — 新增 `PlayerModeStats`, `PlayerDetail` 加 `statsByMode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a game-mode selector to player detail statistics.
  * Player statistics now include rounds played, win and deal-in rates, average points, and applicable self-draw rates.
  * Added support for viewing mode-specific statistics, including empty states when no data is available.

* **Improvements**
  * Consolidated player statistics into the player detail page for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->