### PR TITLE
feat: 统计页赛季奖项 + 桌力重做 + 前3名奖牌 + 首页实时刷新

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -21,6 +21,7 @@ public class PlayerStatsResponse {
   private double fanDiscoveryBonus;
   private int roundsPlayed;
   private int handWins;
+  private int tsumoWins;
   private int dealIns;
   private double avgWinPoints;
   private double avgDealInPoints;

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionSummaryResponse.java
@@ -22,7 +22,7 @@ public class SessionSummaryResponse {
   private int roundCount;
   private List<PlayerPerformanceDTO> rankings;
 
-  /** "凤凰台" / "麒麟阁" / "太极殿" / "困龙阙" / "百雀林" — null if mode doesn't track ratings. */
+  /** "铳之间" / "狠之间" / "贪之间" / "狱之间" / "大圣之间" — null if mode doesn't track ratings. */
   private String tableStrength;
 
   public static SessionSummaryResponse from(GameSession session) {

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -308,8 +308,7 @@ public class GameService {
   public List<SessionSummaryResponse> getAllSessionSummaries() {
     List<GameSession> sessions = sessionRepo.findAllByOrderByCreatedAtDesc();
     Map<String, Map<Long, Tier>> tiersCache = new HashMap<>();
-    Map<String, Map<Long, Integer>> monthlyGamesCache = new HashMap<>();
-    return sessions.stream().map(s -> toSummary(s, tiersCache, monthlyGamesCache)).toList();
+    return sessions.stream().map(s -> toSummary(s, tiersCache)).toList();
   }
 
   private String monthCacheKey(GameMode mode, LocalDateTime sessionUtc) {
@@ -318,10 +317,7 @@ public class GameService {
     return mode.name() + ":" + pt.getYear() + "-" + pt.getMonthValue();
   }
 
-  private SessionSummaryResponse toSummary(
-      GameSession s,
-      Map<String, Map<Long, Tier>> tiersCache,
-      Map<String, Map<Long, Integer>> monthlyGamesCache) {
+  private SessionSummaryResponse toSummary(GameSession s, Map<String, Map<Long, Tier>> tiersCache) {
     SessionSummaryResponse r = SessionSummaryResponse.from(s);
     GameMode mode = s.getGameMode();
     if (mode != GameMode.GUOBIAO && mode != GameMode.RIICHI) return r;
@@ -332,12 +328,8 @@ public class GameService {
     Map<Long, Tier> tiers =
         tiersCache.computeIfAbsent(
             key, k -> tierService.resolveTiersForDate(mode, s.getCreatedAt()));
-    Map<Long, Integer> monthly =
-        monthlyGamesCache.computeIfAbsent(
-            key, k -> tierService.monthlyGamesByPlayerForReferenceDate(mode, s.getCreatedAt()));
 
-    r.setTableStrength(
-        tableStrengthService.compute(players, mode, tiers, monthly).getDisplayName());
+    r.setTableStrength(tableStrengthService.compute(players, mode, tiers).getDisplayName());
     annotateRankingsTier(r.getRankings(), players, tiers, mode);
     return r;
   }
@@ -898,6 +890,7 @@ public class GameService {
     Map<Long, Double> fanBonusPerPlayer = new HashMap<>();
     Map<Long, Integer> roundsPlayed = new HashMap<>();
     Map<Long, Integer> handWins = new HashMap<>();
+    Map<Long, Integer> tsumoWins = new HashMap<>();
     Map<Long, Integer> dealIns = new HashMap<>();
     Map<Long, Integer> winPointsSum = new HashMap<>();
     Map<Long, Integer> dealInPointsSum = new HashMap<>();
@@ -952,18 +945,15 @@ public class GameService {
       }
     }
 
-    // Bulk-load Riichi round details — one SQL for all Riichi sessions in scope.
-    Map<Long, List<Object[]>> riichiRoundsBySessionId = new HashMap<>();
-    List<Long> riichiSessionIds =
-        completedSessions.stream()
-            .filter(s -> s.getGameMode() == GameMode.RIICHI)
-            .map(GameSession::getId)
-            .toList();
-    if (!riichiSessionIds.isEmpty()) {
-      for (Object[] row : roundScoreRepo.getRoundDetailsBySessions(riichiSessionIds)) {
+    // Bulk-load round details for ALL completed sessions in scope — one SQL — feeds the round-level
+    // metrics (和牌率/放铳率/自摸率/平均打点/平均铳点).
+    Map<Long, List<Object[]>> roundsBySessionId = new HashMap<>();
+    List<Long> allSessionIds = completedSessions.stream().map(GameSession::getId).toList();
+    if (!allSessionIds.isEmpty()) {
+      for (Object[] row : roundScoreRepo.getRoundDetailsBySessions(allSessionIds)) {
         Long sid = (Long) row[0];
-        // Drop the leading sessionId so the per-session shape matches getRoundDetailsBySession.
-        riichiRoundsBySessionId
+        // Drop the leading sessionId so the per-session shape matches accumulateRoundStats.
+        roundsBySessionId
             .computeIfAbsent(sid, k -> new ArrayList<>())
             .add(new Object[] {row[1], row[2], row[3], row[4], row[5]});
       }
@@ -1029,13 +1019,10 @@ public class GameService {
           if (row[0] != null) wins.merge((Long) row[0], 1, (a, b) -> a + b);
         }
 
-        // Round-level metrics only collected for Riichi (和牌率/放铳率/平均打点/平均铳点).
-        // Other modes have different scoring semantics where these don't translate cleanly.
-        if (session.getGameMode() == GameMode.RIICHI) {
-          List<Object[]> rows = riichiRoundsBySessionId.getOrDefault(session.getId(), List.of());
-          accumulateRoundStats(
-              rows, roundsPlayed, handWins, dealIns, winPointsSum, dealInPointsSum);
-        }
+        // Round-level metrics (和牌率/放铳率/自摸率/平均打点/平均铳点) collected for all modes.
+        List<Object[]> rows = roundsBySessionId.getOrDefault(session.getId(), List.of());
+        accumulateRoundStats(
+            rows, roundsPlayed, handWins, tsumoWins, dealIns, winPointsSum, dealInPointsSum);
       }
     }
 
@@ -1070,6 +1057,7 @@ public class GameService {
               int di = dealIns.getOrDefault(p.getId(), 0);
               stat.setRoundsPlayed(rounds);
               stat.setHandWins(hw);
+              stat.setTsumoWins(tsumoWins.getOrDefault(p.getId(), 0));
               stat.setDealIns(di);
               stat.setAvgWinPoints(
                   hw > 0 ? (double) winPointsSum.getOrDefault(p.getId(), 0) / hw : 0);
@@ -1121,6 +1109,7 @@ public class GameService {
       List<Object[]> rows,
       Map<Long, Integer> roundsPlayed,
       Map<Long, Integer> handWins,
+      Map<Long, Integer> tsumoWins,
       Map<Long, Integer> dealIns,
       Map<Long, Integer> winPointsSum,
       Map<Long, Integer> dealInPointsSum) {
@@ -1137,6 +1126,10 @@ public class GameService {
       if (seenRounds.add(roundId)) {
         if (winnerId != null) {
           handWins.merge(winnerId, 1, Integer::sum);
+          // 自摸 (self-draw): win with no deal-in player. 荣和 = handWins - tsumoWins.
+          if (dealInPlayerId == null) {
+            tsumoWins.merge(winnerId, 1, Integer::sum);
+          }
         }
         if (dealInPlayerId != null) {
           dealIns.merge(dealInPlayerId, 1, Integer::sum);
@@ -1227,33 +1220,28 @@ public class GameService {
     for (var entry : rowsByMode.entrySet()) {
       Map<Long, Integer> roundsPlayed = new HashMap<>();
       Map<Long, Integer> handWins = new HashMap<>();
+      Map<Long, Integer> tsumoWins = new HashMap<>();
       Map<Long, Integer> dealIns = new HashMap<>();
       Map<Long, Integer> winPointsSum = new HashMap<>();
       Map<Long, Integer> dealInPointsSum = new HashMap<>();
       accumulateRoundStats(
-          entry.getValue(), roundsPlayed, handWins, dealIns, winPointsSum, dealInPointsSum);
+          entry.getValue(),
+          roundsPlayed,
+          handWins,
+          tsumoWins,
+          dealIns,
+          winPointsSum,
+          dealInPointsSum);
 
       int rounds = roundsPlayed.getOrDefault(playerId, 0);
       if (rounds == 0) continue;
       int hw = handWins.getOrDefault(playerId, 0);
       int di = dealIns.getOrDefault(playerId, 0);
 
-      // 自摸 (self-draw) wins for this player — 荣和 count is derivable as handWins - tsumoWins.
-      Set<Long> seenWinRounds = new HashSet<>();
-      int tsumo = 0;
-      for (Object[] row : entry.getValue()) {
-        Long roundId = (Long) row[0];
-        Long winnerId = (Long) row[1];
-        Long dealInPlayerId = (Long) row[2];
-        if (playerId.equals(winnerId) && dealInPlayerId == null && seenWinRounds.add(roundId)) {
-          tsumo++;
-        }
-      }
-
       PlayerDetailResponse.ModeStats ms = new PlayerDetailResponse.ModeStats();
       ms.setRoundsPlayed(rounds);
       ms.setHandWins(hw);
-      ms.setTsumoWins(tsumo);
+      ms.setTsumoWins(tsumoWins.getOrDefault(playerId, 0));
       ms.setDealIns(di);
       ms.setAvgWinPoints(hw > 0 ? (double) winPointsSum.getOrDefault(playerId, 0) / hw : 0);
       ms.setAvgDealInPoints(di > 0 ? (double) dealInPointsSum.getOrDefault(playerId, 0) / di : 0);

--- a/server/src/main/java/com/mahjong/omakase/service/TableStrengthService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TableStrengthService.java
@@ -15,28 +15,27 @@ import org.springframework.stereotype.Service;
  * <p>Rules (priority top-down):
  *
  * <ol>
- *   <li>FENG_HUANG_TAI 凤凰台 — ≥ 2 stable顶尖 (LV3+ AND 当月 ≥ 5 场) AND 0 LV1
- *   <li>KUN_LONG_QUE 困龙阙 — ≥ 2 LV3+ AND ≥ 1 LV1 (高低混战)
- *   <li>QI_LIN_GE 麒麟阁 — ≥ 1 LV3+ (含未达月度门槛的)
- *   <li>BAI_QUE_LIN 百雀林 — 全员 LV1 / 未定段
- *   <li>TAI_JI_DIAN 太极殿 — 其他 (LV2 居多)
+ *   <li>DA_SHENG 大圣之间 — 有斗战胜佛 (LV4_THRONE) 在桌
+ *   <li>YU 狱之间 — ≥ 3 名齐天大圣 (LV3)
+ *   <li>TAN 贪之间 — 2 名 LV3
+ *   <li>HEN 狠之间 — 1 名 LV3
+ *   <li>CHONG 铳之间 — 0 名 LV3
  * </ol>
  *
- * <p>Note: only GUOBIAO and RIICHI modes get a label. DONGBEI returns null (no tag in UI).
+ * <p>Note: only GUOBIAO and RIICHI modes get a label. DONGBEI returns null (no tag in UI). The 斗战胜佛
+ * tier already encodes the "top player, active ≥ 5 games this month" rule, so early each month
+ * (before anyone qualifies) tables fall back to the LV3-count ladder.
  */
 @Service
 @RequiredArgsConstructor
 public class TableStrengthService {
 
-  /** "顶尖" 月度场数门槛 — 防止"少场高分"瞎冲凤凰台. */
-  public static final int STABLE_TOP_MONTHLY_GAMES = 5;
-
   public enum TableStrength {
-    FENG_HUANG_TAI("凤凰台"),
-    QI_LIN_GE("麒麟阁"),
-    TAI_JI_DIAN("太极殿"),
-    KUN_LONG_QUE("困龙阙"),
-    BAI_QUE_LIN("百雀林");
+    CHONG("铳之间"),
+    HEN("狠之间"),
+    TAN("贪之间"),
+    YU("狱之间"),
+    DA_SHENG("大圣之间");
 
     private final String displayName;
 
@@ -54,62 +53,46 @@ public class TableStrengthService {
   /**
    * Compute the table strength label for a session's seated players. Returns null for DONGBEI.
    *
-   * @param sessionDate session's createdAt (UTC) — monthly game count is taken from THAT month, so
-   *     historical sessions get the label they should have had at the time, not what they'd be
-   *     under today's monthly count.
+   * @param sessionDate session's createdAt (UTC) — tier is resolved for THAT month, so historical
+   *     sessions get the label they should have had at the time, not what they'd be under today's
+   *     ratings.
    */
   public TableStrength compute(List<Player> players, GameMode mode, LocalDateTime sessionDate) {
     if (mode != GameMode.GUOBIAO && mode != GameMode.RIICHI) return null;
     Map<Long, Tier> tierByPlayer =
         sessionDate != null ? tierService.resolveTiersForDate(mode, sessionDate) : Map.of();
-    Map<Long, Integer> monthlyByPlayer =
-        sessionDate != null
-            ? tierService.monthlyGamesByPlayerForReferenceDate(mode, sessionDate)
-            : Map.of();
-    return compute(players, mode, tierByPlayer, monthlyByPlayer);
+    return compute(players, mode, tierByPlayer);
   }
 
   /**
-   * Precomputed-map overload — caller provides the per-(mode, month) tier and monthly-games maps so
-   * a request that summarizes 150 sessions doesn't redo {@code resolveTiersForDate} + {@code
-   * monthlyGamesByPlayer} 150 times. {@link GameService#getAllSessionSummaries} groups sessions by
-   * (mode, PT year-month) and reuses one map per group.
+   * Precomputed-map overload — caller provides the per-(mode, month) tier map so a request that
+   * summarizes many sessions doesn't redo {@code resolveTiersForDate} per session. {@link
+   * GameService#getAllSessionSummaries} groups sessions by (mode, PT year-month) and reuses one map
+   * per group.
    */
-  public TableStrength compute(
-      List<Player> players,
-      GameMode mode,
-      Map<Long, Tier> tierByPlayer,
-      Map<Long, Integer> monthlyByPlayer) {
+  public TableStrength compute(List<Player> players, GameMode mode, Map<Long, Tier> tierByPlayer) {
     if (mode != GameMode.GUOBIAO && mode != GameMode.RIICHI) return null;
-    if (players == null) return TableStrength.BAI_QUE_LIN;
+    if (players == null) return TableStrength.CHONG;
     Map<Long, Tier> safeTiers = tierByPlayer != null ? tierByPlayer : Map.of();
-    Map<Long, Integer> safeMonthly = monthlyByPlayer != null ? monthlyByPlayer : Map.of();
 
     List<Player> humans = players.stream().filter(p -> p != null && !p.isBot()).toList();
-    if (humans.size() < 2) return TableStrength.BAI_QUE_LIN;
+    if (humans.size() < 2) return TableStrength.CHONG;
 
-    int stableTop = 0;
+    boolean hasThrone = false;
     int lv3Count = 0;
-    int lv1Count = 0;
-
     for (Player p : humans) {
       Tier t = safeTiers.getOrDefault(p.getId(), tierService.computeTier(p, mode));
-      if (t == Tier.LV3 || t == Tier.LV4_THRONE) {
+      if (t == Tier.LV4_THRONE) {
+        hasThrone = true;
+      } else if (t == Tier.LV3) {
         lv3Count++;
-        int monthlyGames = safeMonthly.getOrDefault(p.getId(), 0);
-        if (monthlyGames >= STABLE_TOP_MONTHLY_GAMES) {
-          stableTop++;
-        }
-      }
-      if (t == Tier.LV1 || t == Tier.UNRANKED) {
-        lv1Count++;
       }
     }
 
-    if (stableTop >= 2 && lv1Count == 0) return TableStrength.FENG_HUANG_TAI;
-    if (lv3Count >= 2 && lv1Count >= 1) return TableStrength.KUN_LONG_QUE;
-    if (lv3Count >= 1) return TableStrength.QI_LIN_GE;
-    if (lv1Count == humans.size()) return TableStrength.BAI_QUE_LIN;
-    return TableStrength.TAI_JI_DIAN;
+    if (hasThrone) return TableStrength.DA_SHENG;
+    if (lv3Count >= 3) return TableStrength.YU;
+    if (lv3Count == 2) return TableStrength.TAN;
+    if (lv3Count == 1) return TableStrength.HEN;
+    return TableStrength.CHONG;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/service/TierService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TierService.java
@@ -357,15 +357,6 @@ public class TierService {
     return out;
   }
 
-  /** Convenience: bulk monthly games for the PT month containing the given UTC reference date. */
-  public Map<Long, Integer> monthlyGamesByPlayerForReferenceDate(
-      GameMode mode, LocalDateTime referenceUtc) {
-    java.time.LocalDate pacificDate =
-        referenceUtc.atZone(ZONE_UTC).withZoneSameInstant(ZONE_PACIFIC).toLocalDate();
-    LocalDateTime[] r = monthUtcRangeFor(pacificDate);
-    return monthlyGamesByPlayer(mode, r[0], r[1]);
-  }
-
   private int monthlyGames(Player p, GameMode mode, LocalDateTime startUtc, LocalDateTime endUtc) {
     return monthlyGamesByPlayer(mode, startUtc, endUtc).getOrDefault(p.getId(), 0);
   }

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { scoreClass } from '../utils/format'
+import { scoreClass, rankMedal } from '../utils/format'
 import { nameFontSize } from '../utils/fontSize'
 import { TierKey } from '../types'
 import { RankBadge } from './RankBadge'
@@ -58,7 +58,9 @@ export const GameCard: React.FC<Props> = ({
         {players.map((p, idx) => (
           <div key={idx} className="player-rank-item">
             <span className="player-name-with-rank">
-              <span className={`rank-number${p.rank <= 3 ? ` rank-tag-${p.rank}` : ''}`}>#{p.rank}</span>
+              <span className={`rank-number${p.rank <= 3 ? ` rank-tag-${p.rank}` : ''}`}>
+                {rankMedal(p.rank) ?? `#${p.rank}`}
+              </span>
               {p.wind && <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>{p.wind}</span>}
               <RankBadge tier={p.tier} size="sm" userName={p.name} />
               <span className="player-name" style={{ fontSize: nameFontSize(p.name) }}>

--- a/ui/src/components/TableStrengthTag.tsx
+++ b/ui/src/components/TableStrengthTag.tsx
@@ -1,23 +1,24 @@
 import React from 'react'
 
 interface Props {
-  /** "凤凰台" / "麒麟阁" / "太极殿" / "困龙阙" / "百雀林" or null/undefined */
+  /** "铳之间" / "狠之间" / "贪之间" / "狱之间" / "大圣之间" or null/undefined */
   table?: string | null
   size?: 'sm' | 'md'
   className?: string
 }
 
+// theme 皮肤按档位由低到高: chong→hen→tan→yu→dasheng, dasheng 最华丽(火焰).
 const TABLE_META: Record<string, { emoji: string; theme: string }> = {
-  凤凰台: { emoji: '⚜️', theme: 'phoenix' },
-  麒麟阁: { emoji: '🦄', theme: 'qilin' },
-  太极殿: { emoji: '☯️', theme: 'taiji' },
-  困龙阙: { emoji: '🐉', theme: 'dragon' },
-  百雀林: { emoji: '🐦', theme: 'sparrow' },
+  铳之间: { emoji: '💥', theme: 'chong' },
+  狠之间: { emoji: '🥊', theme: 'hen' },
+  贪之间: { emoji: '🤑', theme: 'tan' },
+  狱之间: { emoji: '🏴‍☠️', theme: 'yu' },
+  大圣之间: { emoji: '🇨🇳', theme: 'dasheng' },
 }
 
 export const TableStrengthTag: React.FC<Props> = ({ table, size = 'sm', className }) => {
   if (!table) return null
-  const meta = TABLE_META[table] ?? { emoji: '·', theme: 'taiji' }
+  const meta = TABLE_META[table] ?? { emoji: '·', theme: 'hen' }
   return (
     <span className={`table-strength table-strength-${meta.theme} table-strength-${size} ${className ?? ''}`}>
       <span className="table-strength-emoji" aria-hidden>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -731,6 +731,12 @@ table.auto-table {
   margin-top: 4px;
 }
 
+.stat-card .stat-sublabel {
+  font-size: 0.7rem;
+  color: var(--text-light);
+  margin-top: 2px;
+}
+
 .empty-state {
   text-align: center;
   padding: 48px 24px;
@@ -1306,8 +1312,8 @@ table.auto-table {
   font-size: 1.1em;
 }
 
-/* 凤凰台 — 顶配, 烈焰红金 + 动态火焰外圈 */
-@keyframes phoenix-flame {
+/* 大圣之间 — 顶配, 烈焰红金 + 动态火焰外圈 */
+@keyframes dasheng-flame {
   0%,
   100% {
     box-shadow: inset 0 0 0 2px rgb(120 30 0 / 60%), inset 0 1px 0 rgb(255 255 255 / 35%),
@@ -1320,50 +1326,46 @@ table.auto-table {
   }
 }
 
-.table-strength-phoenix {
+.table-strength-dasheng {
   background: linear-gradient(135deg, #d4351c 0%, #f0a429 100%);
   color: #fff;
   text-shadow: 0 1px 2px rgb(0 0 0 / 30%);
-  animation: phoenix-flame 1.8s ease-in-out infinite;
+  animation: dasheng-flame 1.8s ease-in-out infinite;
 }
 
-.table-strength-phoenix .table-strength-emoji {
-  filter: brightness(0) invert(1) drop-shadow(0 1px 2px rgb(120 30 0 / 60%));
-}
-
-/* 麒麟阁 — 第二尊位, 墨青底 + 金字金边, 矜贵不张扬 */
-.table-strength-qilin {
+/* 贪之间 — 墨青底 + 金字金边, 矜贵不张扬 */
+.table-strength-tan {
   background: linear-gradient(135deg, #1a3a3a 0%, #0d2828 100%);
   color: #f4d03f;
   box-shadow: 0 1px 4px rgb(0 0 0 / 30%), inset 0 0 0 2px rgb(244 208 63 / 35%), inset 0 1px 0 rgb(244 208 63 / 30%);
   text-shadow: 0 1px 2px rgb(0 0 0 / 50%);
 }
 
-.table-strength-qilin .table-strength-emoji {
+.table-strength-tan .table-strength-emoji {
   filter: drop-shadow(0 0 3px rgb(244 208 63 / 70%));
 }
 
-/* 太极殿 — 玉石青绿, 阴阳渐变 */
-.table-strength-taiji {
+/* 狠之间 — 玉石青绿, 阴阳渐变 */
+.table-strength-hen {
   background: linear-gradient(135deg, #4a9b94 0%, #2c5f5b 100%);
   color: #fff;
   box-shadow: 0 1px 3px rgb(44 95 91 / 35%), inset 0 0 0 2px rgb(15 50 47 / 50%), inset 0 1px 0 rgb(255 255 255 / 25%);
   text-shadow: 0 1px 2px rgb(0 0 0 / 25%);
 }
 
-.table-strength-taiji .table-strength-emoji {
+.table-strength-hen .table-strength-emoji {
   filter: drop-shadow(0 0 2px rgb(255 255 255 / 50%));
 }
 
-/* 困龙阙 — 风云紫蓝 */
-.table-strength-dragon {
+/* 狱之间 — 风云紫蓝 */
+.table-strength-yu {
   background: linear-gradient(135deg, #4f3eb3 0%, #6c5ce7 100%);
   color: #fff;
   box-shadow: 0 2px 6px rgb(76 60 179 / 30%), inset 0 0 0 2px rgb(40 28 110 / 55%), inset 0 1px 0 rgb(255 255 255 / 20%);
 }
 
-/* 百雀林 — 朴素米绿 */
-.table-strength-sparrow {
+/* 铳之间 — 朴素米绿 */
+.table-strength-chong {
   background: linear-gradient(135deg, #e8ecdf 0%, #c4cfa8 100%);
   color: #4a5a30;
   box-shadow: inset 0 0 0 2px rgb(120 140 80 / 35%), inset 0 1px 0 rgb(255 255 255 / 40%);

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -35,15 +35,21 @@ export default function HomePage() {
 
     loadSummary(false)
 
-    // 轮询静默刷新, 让"正在进行的对局"随每局结束自动更新.
+    // 轮询静默刷新(仅前台), 让"正在进行的对局"随每局结束自动更新.
     const timer = setInterval(() => {
-      if (!document.hidden) loadSummary(true)
-    }, 10000)
+      if (!document.hidden) void loadSummary(true)
+    }, 5000)
+    // 切回该窗口/标签时立即刷新一次, 不用等下个轮询周期.
+    const onVisible = () => {
+      if (!document.hidden) void loadSummary(true)
+    }
+    document.addEventListener('visibilitychange', onVisible)
 
     return () => {
       isActive = false
       controller.abort()
       clearInterval(timer)
+      document.removeEventListener('visibilitychange', onVisible)
     }
   }, [currentSeason.year, currentSeason.month])
 

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -20,7 +20,7 @@ export default function HomePage() {
     let isActive = true
     const controller = new AbortController()
 
-    async function loadSummary() {
+    async function loadSummary(silent: boolean) {
       try {
         const summary = await fetchHomeSummary(currentSeason.year, currentSeason.month, controller.signal)
         if (!isActive) return
@@ -29,15 +29,21 @@ export default function HomePage() {
       } catch (e: unknown) {
         if (e instanceof Error && e.name !== 'AbortError') console.error('Failed to load home summary:', e)
       } finally {
-        if (isActive) setLoading(false)
+        if (isActive && !silent) setLoading(false)
       }
     }
 
-    loadSummary()
+    loadSummary(false)
+
+    // 轮询静默刷新, 让"正在进行的对局"随每局结束自动更新.
+    const timer = setInterval(() => {
+      if (!document.hidden) loadSummary(true)
+    }, 10000)
 
     return () => {
       isActive = false
       controller.abort()
+      clearInterval(timer)
     }
   }, [currentSeason.year, currentSeason.month])
 

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import { GameCard } from '../components/GameCard'
 import { RankBadge } from '../components/RankBadge'
 import { deriveGameState, getWindName } from '../utils/gameState'
 import { nameFontSize } from '../utils/fontSize'
+import { rankMedal } from '../utils/format'
 import { MSG } from '../constants'
 
 export default function HomePage() {
@@ -122,7 +123,7 @@ export default function HomePage() {
                     ) : (
                       data.top.map((player, idx) => (
                         <div key={player.playerId} className="rank-item">
-                          <span className={`rank-tag rank-tag-${idx + 1}`}>#{idx + 1}</span>
+                          <span className={`rank-tag rank-tag-${idx + 1}`}>{rankMedal(idx + 1) ?? `#${idx + 1}`}</span>
                           <div className="rank-info">
                             <span className="player-name-with-rank">
                               <RankBadge

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -775,7 +775,7 @@ export default function SessionPage() {
                   <th key={p.id} style={playerColStyle}>
                     <div className="player-header-cell">
                       <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>
-                        {rankMedal(rankMap[p.id]?.rank ?? 0) ?? `#${rankMap[p.id]?.rank}`}
+                        {rankMedal(rankMap[p.id]?.rank ?? 0) ?? `#${rankMap[p.id]?.rank ?? 0}`}
                       </span>
                       <RankBadge tier={p.tier} size="sm" userName={p.userName} />
                       <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -8,7 +8,7 @@ import { RiichiCalculator } from '../components/RiichiCalculator'
 import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
 import { deriveGameState, deriveRoundState, getWindName } from '../utils/gameState'
-import { scoreClass, parseError } from '../utils/format'
+import { scoreClass, parseError, rankMedal } from '../utils/format'
 import { MSG } from '../constants'
 import { RankBadge } from '../components/RankBadge'
 import { TableStrengthTag } from '../components/TableStrengthTag'
@@ -774,7 +774,9 @@ export default function SessionPage() {
                 {session.players.map((p) => (
                   <th key={p.id} style={playerColStyle}>
                     <div className="player-header-cell">
-                      <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>#{rankMap[p.id]?.rank}</span>
+                      <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>
+                        {rankMedal(rankMap[p.id]?.rank ?? 0) ?? `#${rankMap[p.id]?.rank}`}
+                      </span>
                       <RankBadge tier={p.tier} size="sm" userName={p.userName} />
                       <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
                         {p.userName}
@@ -920,7 +922,7 @@ export default function SessionPage() {
                   return (
                     <tr key={p.id}>
                       <td className="col-rank">
-                        <span className={`rank-tag rank-tag-${rank}`}>#{rank}</span>
+                        <span className={`rank-tag rank-tag-${rank}`}>{rankMedal(rank) ?? `#${rank}`}</span>
                       </td>
                       <td>
                         <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -176,6 +176,8 @@ export default function StatsPage() {
   const topWinRate = pick(withRounds, winRate, 'max')
   const topDealIn = pick(withRounds, dealInRate, 'max')
   const lowDealIn = pick(withRounds, dealInRate, 'min')
+  const lowWinRate = pick(withRounds, winRate, 'min')
+  const lowTsumo = pick(withWins, tsumoRate, 'min')
 
   const statCard = (value: number | string, label: string) => (
     <div className="stat-card">
@@ -188,14 +190,12 @@ export default function StatsPage() {
     <div className="stat-card">
       <div className="stat-value" style={{ fontSize: statFontSize(winner?.userName || '-') }}>
         {winner?.userName || '-'}
-        {winner && rate != null && (
-          <span style={{ fontSize: '0.6rem', color: 'var(--text-light)', verticalAlign: 'bottom', marginLeft: 2 }}>
-            ({(rate * 100).toFixed(0)}%)
-          </span>
-        )}
       </div>
       <div className="stat-label">{name}</div>
-      <div className="stat-sublabel">{sub}</div>
+      <div className="stat-sublabel">
+        {sub}
+        {winner && rate != null ? ` · ${(rate * 100).toFixed(0)}%` : ''}
+      </div>
     </div>
   )
 
@@ -250,7 +250,9 @@ export default function StatsPage() {
         <>
           <div className="stats-grid">
             {awardCard('🧿 真•赤木', '最高胡牌率', topWinRate, topWinRate ? winRate(topWinRate) : undefined)}
+            {awardCard('🪣 水缸坐穿', '最低胡牌率', lowWinRate, lowWinRate ? winRate(lowWinRate) : undefined)}
             {awardCard('🐕 人是打不过狗的', '最高自摸率', topTsumo, topTsumo ? tsumoRate(topTsumo) : undefined)}
+            {awardCard('⚰️ 我的牌去哪儿了', '最低自摸率', lowTsumo, lowTsumo ? tsumoRate(lowTsumo) : undefined)}
             {awardCard('💣 二营长', '最高铳率', topDealIn, topDealIn ? dealInRate(topDealIn) : undefined)}
             {awardCard('🐢 龟仙人', '最低铳率', lowDealIn, lowDealIn ? dealInRate(lowDealIn) : undefined)}
             {statCard(activeStats.length, '参与玩家')}

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -163,14 +163,12 @@ export default function StatsPage() {
     )
 
   const totalGames = activeStats.length > 0 ? Math.max(...activeStats.map((s) => s.gamesPlayed)) : 0
-  const topScorer = activeStats[0]
-  const topWinner = activeStats.length > 0 ? [...activeStats].sort((a, b) => b.wins - a.wins)[0] : null
 
   // 赛季奖项. 单赛季无局数门槛; 全部赛季沿用 activeStats 的 ≥10 场门槛. 自摸率=自摸/和牌, 胡牌率=和牌/局数, 铳率=放铳/局数.
   const withRounds = activeStats.filter((s) => s.roundsPlayed > 0)
   const withWins = activeStats.filter((s) => s.handWins > 0)
-  const tsumoRate = (s: PlayerStats) => s.tsumoWins / s.handWins
   const winRate = (s: PlayerStats) => s.handWins / s.roundsPlayed
+  const tsumoRate = (s: PlayerStats) => s.tsumoWins / s.handWins
   const dealInRate = (s: PlayerStats) => s.dealIns / s.roundsPlayed
   const pick = (arr: PlayerStats[], rate: (s: PlayerStats) => number, dir: 'max' | 'min') =>
     arr.length === 0 ? null : [...arr].sort((a, b) => (dir === 'max' ? rate(b) - rate(a) : rate(a) - rate(b)))[0]
@@ -178,6 +176,13 @@ export default function StatsPage() {
   const topWinRate = pick(withRounds, winRate, 'max')
   const topDealIn = pick(withRounds, dealInRate, 'max')
   const lowDealIn = pick(withRounds, dealInRate, 'min')
+
+  const statCard = (value: number | string, label: string) => (
+    <div className="stat-card">
+      <div className="stat-value">{value}</div>
+      <div className="stat-label">{label}</div>
+    </div>
+  )
 
   const awardCard = (name: string, sub: string, winner: PlayerStats | null, rate?: number) => (
     <div className="stat-card">
@@ -244,30 +249,12 @@ export default function StatsPage() {
       {tab === 'games' && (
         <>
           <div className="stats-grid">
-            <div className="stat-card">
-              <div className="stat-value">{activeStats.length}</div>
-              <div className="stat-label">参与玩家</div>
-            </div>
-            <div className="stat-card">
-              <div className="stat-value">{totalGames}</div>
-              <div className="stat-label">游戏场次</div>
-            </div>
-            <div className="stat-card">
-              <div className="stat-value" style={{ fontSize: statFontSize(topScorer?.userName || '-') }}>
-                {topScorer?.userName || '-'}
-              </div>
-              <div className="stat-label">🏆 积分冠军</div>
-            </div>
-            <div className="stat-card">
-              <div className="stat-value" style={{ fontSize: statFontSize(topWinner?.userName || '-') }}>
-                {topWinner?.userName || '-'}
-              </div>
-              <div className="stat-label">👑 最多胜场</div>
-            </div>
-            {awardCard('🐕 人是打不过狗的', '最高自摸率', topTsumo, topTsumo ? tsumoRate(topTsumo) : undefined)}
             {awardCard('🧿 真•赤木', '最高胡牌率', topWinRate, topWinRate ? winRate(topWinRate) : undefined)}
+            {awardCard('🐕 人是打不过狗的', '最高自摸率', topTsumo, topTsumo ? tsumoRate(topTsumo) : undefined)}
             {awardCard('💣 二营长', '最高铳率', topDealIn, topDealIn ? dealInRate(topDealIn) : undefined)}
             {awardCard('🐢 龟仙人', '最低铳率', lowDealIn, lowDealIn ? dealInRate(lowDealIn) : undefined)}
+            {statCard(activeStats.length, '参与玩家')}
+            {statCard(totalGames, '游戏场次')}
           </div>
 
           {activeStats.length === 0 ? (

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -10,7 +10,7 @@ type Tab = 'games' | 'players'
 const currentSeason = getCurrentSeason()
 
 import { statFontSize, nameFontSize } from '../utils/fontSize'
-import { parseError } from '../utils/format'
+import { parseError, rankMedal } from '../utils/format'
 import { MSG } from '../constants'
 import { useActiveSeasons } from '../hooks/useActiveSeasons'
 
@@ -130,7 +130,8 @@ export default function StatsPage() {
     return () => controller.abort()
   }, [tab, seasonKey, gameMode])
 
-  const activeStats = stats.filter((s) => s.gamesPlayed > 0)
+  // 全部赛季需累计 ≥10 场才进排名/评选; 单个赛季不设门槛.
+  const activeStats = stats.filter((s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= 10))
   const selectedSeason = seasons.find((s) => `${s.year}-${s.month}` === seasonKey)
 
   // Sort by skillRating descending so top performers show first.
@@ -164,6 +165,34 @@ export default function StatsPage() {
   const totalGames = activeStats.length > 0 ? Math.max(...activeStats.map((s) => s.gamesPlayed)) : 0
   const topScorer = activeStats[0]
   const topWinner = activeStats.length > 0 ? [...activeStats].sort((a, b) => b.wins - a.wins)[0] : null
+
+  // 赛季奖项. 单赛季无局数门槛; 全部赛季沿用 activeStats 的 ≥10 场门槛. 自摸率=自摸/和牌, 胡牌率=和牌/局数, 铳率=放铳/局数.
+  const withRounds = activeStats.filter((s) => s.roundsPlayed > 0)
+  const withWins = activeStats.filter((s) => s.handWins > 0)
+  const tsumoRate = (s: PlayerStats) => s.tsumoWins / s.handWins
+  const winRate = (s: PlayerStats) => s.handWins / s.roundsPlayed
+  const dealInRate = (s: PlayerStats) => s.dealIns / s.roundsPlayed
+  const pick = (arr: PlayerStats[], rate: (s: PlayerStats) => number, dir: 'max' | 'min') =>
+    arr.length === 0 ? null : [...arr].sort((a, b) => (dir === 'max' ? rate(b) - rate(a) : rate(a) - rate(b)))[0]
+  const topTsumo = pick(withWins, tsumoRate, 'max')
+  const topWinRate = pick(withRounds, winRate, 'max')
+  const topDealIn = pick(withRounds, dealInRate, 'max')
+  const lowDealIn = pick(withRounds, dealInRate, 'min')
+
+  const awardCard = (name: string, sub: string, winner: PlayerStats | null, rate?: number) => (
+    <div className="stat-card">
+      <div className="stat-value" style={{ fontSize: statFontSize(winner?.userName || '-') }}>
+        {winner?.userName || '-'}
+        {winner && rate != null && (
+          <span style={{ fontSize: '0.6rem', color: 'var(--text-light)', verticalAlign: 'bottom', marginLeft: 2 }}>
+            ({(rate * 100).toFixed(0)}%)
+          </span>
+        )}
+      </div>
+      <div className="stat-label">{name}</div>
+      <div className="stat-sublabel">{sub}</div>
+    </div>
+  )
 
   return (
     <>
@@ -235,6 +264,10 @@ export default function StatsPage() {
               </div>
               <div className="stat-label">👑 最多胜场</div>
             </div>
+            {awardCard('🐕 人是打不过狗的', '最高自摸率', topTsumo, topTsumo ? tsumoRate(topTsumo) : undefined)}
+            {awardCard('🧿 真•赤木', '最高胡牌率', topWinRate, topWinRate ? winRate(topWinRate) : undefined)}
+            {awardCard('💣 二营长', '最高铳率', topDealIn, topDealIn ? dealInRate(topDealIn) : undefined)}
+            {awardCard('🐢 龟仙人', '最低铳率', lowDealIn, lowDealIn ? dealInRate(lowDealIn) : undefined)}
           </div>
 
           {activeStats.length === 0 ? (
@@ -267,9 +300,7 @@ export default function StatsPage() {
                         onClick={() => navigate(`/player/${s.playerId}?from=games`)}
                         style={{ cursor: 'pointer' }}
                       >
-                        <td>
-                          {i < 3 ? <span className={`rank-tag rank-tag-${i + 1}`}>#{i + 1}</span> : <>#{i + 1}</>}
-                        </td>
+                        <td>{rankMedal(i + 1) ?? <>#{i + 1}</>}</td>
                         <td>
                           <span className="player-name-with-rank">
                             <RankBadge
@@ -401,7 +432,7 @@ export default function StatsPage() {
                       onClick={() => navigate(`/player/${p.id}?from=players`)}
                       style={{ cursor: 'pointer' }}
                     >
-                      <td>{i < 3 ? <span className={`rank-tag rank-tag-${i + 1}`}>#{i + 1}</span> : <>#{i + 1}</>}</td>
+                      <td>{rankMedal(i + 1) ?? <>#{i + 1}</>}</td>
                       <td>
                         <span className="player-name-with-rank">
                           <RankBadge

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -168,6 +168,7 @@ export interface PlayerStats {
   wins: number
   roundsPlayed: number
   handWins: number
+  tsumoWins: number
   dealIns: number
   avgWinPoints: number
   avgDealInPoints: number

--- a/ui/src/utils/fontSize.ts
+++ b/ui/src/utils/fontSize.ts
@@ -22,8 +22,10 @@ export function statFontSize(text: string) {
       { maxLen: 6, desktop: '2rem', mobile: '1.4rem' },
       { maxLen: 8, desktop: '2rem', mobile: '1.1rem' },
       { maxLen: 12, desktop: '1.5rem', mobile: '0.9rem' },
+      { maxLen: 16, desktop: '1.2rem', mobile: '0.8rem' },
+      { maxLen: 22, desktop: '0.9rem', mobile: '0.6rem' },
     ],
-    { desktop: '1.2rem', mobile: '0.9rem' }
+    { desktop: '0.75rem', mobile: '0.5rem' }
   )
 }
 

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -42,3 +42,8 @@ export function scoreClass(score: number): string {
 export function parseError(e: unknown): string {
   return e instanceof Error ? e.message : MSG.ERROR
 }
+
+/** Medal emoji for the top 3 ranks (🥇🥈🥉), null for 4th and beyond. */
+export function rankMedal(rank: number): string | null {
+  return { 1: '🥇', 2: '🥈', 3: '🥉' }[rank] ?? null
+}


### PR DESCRIPTION
## 概要

一组统计/首页相关改动: 统计页新增 6 个赛季趣味奖项卡(复用 `/api/stats`, 无新增接口), 桌力档位按「斗战胜佛 + 齐天大圣人数」重做并换新名, 全站前 3 名改用 🥇🥈🥉 奖牌, 首页「正在进行的对局」加实时轮询刷新。共 6 个 commit。

## 一、统计页赛季奖项(前端)

跟随选中赛季 + 游戏模式实时计算, 冠军名下小字标注「指标 · 百分比」:
- 🧿 真•赤木 — 最高胡牌率 / 🪣 水缸坐穿 — 最低胡牌率
- 🐕 人是打不过狗的 — 最高自摸率 / ⛰️ 山吞九枚 — 最低自摸率
- 💣 二营长 — 最高铳率 / 🐢 龟仙人 — 最低铳率

口径: 自摸率=自摸/和牌, 胡牌率=和牌/局数, 铳率=放铳/局数。**全部赛季**需累计 ≥10 场才进排名/评选, 单个赛季不设门槛。

删除了旧的 🏆 积分冠军 / 👑 最多胜场 两张卡; 抽出 `statCard(value, label)` 与 `awardCard(...)` 辅助函数, 不再手写重复的 `stat-card` 结构。

## 二、round 级指标扩展(后端, 复用而非新增接口)

- `PlayerStatsResponse` 新增 `tsumoWins`。
- `getPlayerStats` 的 round 级指标(和牌/放铳/自摸/打点/铳点)从「仅立直」改为**所有模式**累积, 复用同一个 `accumulateRoundStats` helper(新增 tsumoWins 产出)。奖项直接用这份已按赛季+模式过滤的数据算。
- `computeModeStats`(玩家详情页)改为复用 helper 的 tsumoWins, 删掉重复自摸循环。

## 三、桌力(国标/立直)重做

- 判定: **有斗战胜佛(LV4_THRONE)在桌 → 大圣之间**; 否则按齐天大圣(LV3)人数 `0→铳之间 / 1→狠之间 / 2→贪之间 / 3+→狱之间`。
- 王座的「当月 ≥5 场」门槛由 tier 系统(`resolveTiersForDate`/`LV4_THRONE`)天然携带, 每月月初冠军没打够 5 场时自动降级到 LV3 数量档。
- 清理: 桌力不再需要月度场次, 删掉 `toSummary`/`getAllSessionSummaries` 的 monthly 缓存和 `TierService.monthlyGamesByPlayerForReferenceDate`。
- 前端 `TableStrengthTag` 换 5 个新名 + theme key 改拼音(`chong/hen/tan/yu/dasheng`), CSS 类名/keyframe/注释同步; 去掉大圣之间 emoji 被强制反白的特殊处理。

## 四、前 3 名奖牌 + 小清理

- 新增共享 `rankMedal()`(🥇🥈🥉), 应用到统计页排行榜/玩家表、SessionPage、GameCard、HomePage; 第 4 名起仍 `#N`。
- 修 `SessionPage` 桌力表头: 缺排名时回退串也用 `?? 0`, 避免 `#undefined`。
- 奖项副标题抽出 `.stat-sublabel` 类。
- 长用户名自适应: `statFontSize` 增加长名档位(≤16/≤22/更长), 奖项卡名值行只放用户名(百分比进副标题), 修桌面穿模 + 移动端横向溢出。

## 五、首页「正在进行的对局」实时刷新

- 静默轮询(前台每 5s)重拉 `home-summary`, 游戏中每局结束后首页自动更新, 免手动刷新。
- 加 `visibilitychange` 监听: 切回该窗口/标签时立即刷新一次。
- 后端 `home-summary` 有缓存且写入时 evict, 两局之间轮询命中缓存廉价; 卸载清 interval + 移除监听。

## 测试要点

- [ ] 统计页切赛季/模式, 6 个奖项卡数值正确; 单赛季无门槛, 全部赛季 <10 场玩家不参与
- [ ] 长用户名(如 MonkeyAlwaysKing)在桌面不穿模、移动端(iPhone)不横向滚动
- [ ] 桌力: 有王座→大圣之间; 无王座按 LV3 人数→铳/狠/贪/狱; 东北不显示; 新皮肤(大圣火焰动画, emoji 不反白)正常
- [ ] 各页面前 3 名显示 🥇🥈🥉, 第 4 名起 #N; 桌力表头缺排名不显示 #undefined
- [ ] 首页游戏中每局结束约 5s 内自动更新; 切回窗口即刷新
- [ ] 移动端 ≤640px 统计卡 2 列、≤380px 1 列
- [ ] **重启后端**后 tsumoWins 与新桌力生效; 未重启前端不崩

🤖 Generated with [Claude Code](https://claude.com/claude-code)