### PR TITLE
fix(ui): 统计页全部赛季排名门槛 10 场改成 5 场

### DIFF
--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -130,8 +130,8 @@ export default function StatsPage() {
     return () => controller.abort()
   }, [tab, seasonKey, gameMode])
 
-  // 全部赛季需累计 ≥10 场才进排名/评选; 单个赛季不设门槛.
-  const activeStats = stats.filter((s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= 10))
+  // 全部赛季需累计 ≥5 场才进排名/评选; 单个赛季不设门槛.
+  const activeStats = stats.filter((s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= 5))
   const selectedSeason = seasons.find((s) => `${s.year}-${s.month}` === seasonKey)
 
   // Sort by skillRating descending so top performers show first.


### PR DESCRIPTION
## 概要

统计页「全部赛季」视图进排名/评选的累计场次门槛由 ≥10 场降到 ≥5 场。单个赛季维持不设门槛。1 个文件, 1 行改动。

## 改动

`ui/src/pages/StatsPage.tsx` 的 `activeStats` 过滤:

```diff
- const activeStats = stats.filter((s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= 10))
+ const activeStats = stats.filter((s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= 5))
```

`activeStats` 同时驱动排行榜、6 个奖项卡、参与玩家/游戏场次计数, 所以全部赛季下的门槛统一降到 5 场。

## 测试要点

- [ ] 全部赛季: 累计打满 5 场的玩家进入排行榜和奖项评选; <5 场的不出现
- [ ] 单个赛季: 无门槛(行为不变)

🤖 Generated with [Claude Code](https://claude.com/claude-code)