### PR TITLE
fix(ui): 统计页全部赛季门槛改为 5 + 赛季数

### DIFF
--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -130,8 +130,12 @@ export default function StatsPage() {
     return () => controller.abort()
   }, [tab, seasonKey, gameMode])
 
-  // 全部赛季需累计 ≥5 场才进排名/评选; 单个赛季不设门槛.
-  const activeStats = stats.filter((s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= 5))
+  // 全部赛季门槛随赛季数增长(5 + 赛季数): 抬高全时段榜的样本要求, 让持续活跃的玩家够线、
+  // 只打过几场就消失的旧玩家随时间被筛掉; 单个赛季不设门槛.
+  const allSeasonMinGames = 5 + seasons.length
+  const activeStats = stats.filter(
+    (s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= allSeasonMinGames)
+  )
   const selectedSeason = seasons.find((s) => `${s.year}-${s.month}` === seasonKey)
 
   // Sort by skillRating descending so top performers show first.


### PR DESCRIPTION
## 概要

统计页「全部赛季」进排名/评选的累计场次门槛,由固定 5 改成 **5 + 赛季数**(`seasons.length`)。单个赛季维持不设门槛。1 个文件。

## 改动

`ui/src/pages/StatsPage.tsx`:

```diff
- const activeStats = stats.filter((s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= 5))
+ const allSeasonMinGames = 5 + seasons.length
+ const activeStats = stats.filter(
+   (s) => s.gamesPlayed > 0 && (seasonKey !== 'all' || s.gamesPlayed >= allSeasonMinGames)
+ )
```

门槛随赛季数增长: 抬高全时段榜的样本要求,持续活跃(每赛季都加场)的玩家能一直够线,只打过几场就消失的旧玩家随时间被筛掉。`activeStats` 同时驱动排行榜、奖项卡、参与玩家/游戏场次计数。

## 说明 / 边界

- 这不是字面「每赛季至少 1 场就入选」——只打 1 场/赛季的玩家总场数 = 赛季数 N < 5+N,不会入选。它保证的是**持续活跃者留下、僵尸旧号被筛掉**。
- 单个赛季视图不受影响(无门槛)。

## 测试要点

- [ ] 全部赛季: 门槛 = 5 + 当前赛季数; 达标玩家进榜/评选, 不达标不出现
- [ ] 单个赛季: 无门槛(行为不变)
- [ ] 赛季数变化时门槛随之变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved player statistics filtering for specific season views.
  * Players must now meet a dynamic minimum games-played threshold based on the number of seasons, improving the accuracy of active statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->