### PR TITLE
fix(ui): 对局记分板勋章对齐 + 末位 🤡 标记

### DIFF
--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { scoreClass, rankMedal } from '../utils/format'
+import { scoreClass, seatRankMedal } from '../utils/format'
 import { nameFontSize } from '../utils/fontSize'
 import { TierKey } from '../types'
 import { RankBadge } from './RankBadge'
@@ -59,7 +59,7 @@ export const GameCard: React.FC<Props> = ({
           <div key={idx} className="player-rank-item">
             <span className="player-name-with-rank">
               <span className={`rank-number${p.rank <= 3 ? ` rank-tag-${p.rank}` : ''}`}>
-                {rankMedal(p.rank) ?? `#${p.rank}`}
+                {seatRankMedal(p.rank) ?? `#${p.rank}`}
               </span>
               {p.wind && <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>{p.wind}</span>}
               <RankBadge tier={p.tier} size="sm" userName={p.name} />

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -58,7 +58,7 @@ export const GameCard: React.FC<Props> = ({
         {players.map((p, idx) => (
           <div key={idx} className="player-rank-item">
             <span className="player-name-with-rank">
-              <span className={`rank-number${p.rank <= 3 ? ` rank-tag-${p.rank}` : ''}`}>
+              <span className={`rank-number${p.rank <= 4 ? ` rank-tag-${p.rank}` : ''}`}>
                 {seatRankMedal(p.rank) ?? `#${p.rank}`}
               </span>
               {p.wind && <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>{p.wind}</span>}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -403,6 +403,7 @@ table.fixed-table th,
 table.fixed-table td {
   padding-left: 6px;
   padding-right: 6px;
+  vertical-align: middle;
 }
 
 table.fixed-table .col-rank {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2961,7 +2961,8 @@ table.auto-table {
 
 .game-card .rank-number.rank-tag-1,
 .game-card .rank-number.rank-tag-2,
-.game-card .rank-number.rank-tag-3 {
+.game-card .rank-number.rank-tag-3,
+.game-card .rank-number.rank-tag-4 {
   opacity: 1;
 }
 

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -8,7 +8,7 @@ import { RiichiCalculator } from '../components/RiichiCalculator'
 import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
 import { deriveGameState, deriveRoundState, getWindName } from '../utils/gameState'
-import { scoreClass, parseError, rankMedal } from '../utils/format'
+import { scoreClass, parseError, seatRankMedal } from '../utils/format'
 import { MSG } from '../constants'
 import { RankBadge } from '../components/RankBadge'
 import { TableStrengthTag } from '../components/TableStrengthTag'
@@ -303,6 +303,7 @@ export default function SessionPage() {
   const fixedColPx = 60 + (session.status === 'IN_PROGRESS' ? 32 : 0)
   const playerColStyle = {
     textAlign: 'center' as const,
+    verticalAlign: 'top' as const,
     width: `calc((100% - ${fixedColPx}px) / ${session.players.length})`,
   }
 
@@ -770,12 +771,12 @@ export default function SessionPage() {
           <table className="fixed-table">
             <thead>
               <tr>
-                <th style={{ textAlign: 'center', width: '60px' }}>局</th>
+                <th style={{ textAlign: 'center', verticalAlign: 'top', width: '60px' }}>局</th>
                 {session.players.map((p) => (
                   <th key={p.id} style={playerColStyle}>
                     <div className="player-header-cell">
                       <span className={`rank-tag rank-tag-${rankMap[p.id]?.rank}`}>
-                        {rankMedal(rankMap[p.id]?.rank ?? 0) ?? `#${rankMap[p.id]?.rank ?? 0}`}
+                        {seatRankMedal(rankMap[p.id]?.rank ?? 0) ?? `#${rankMap[p.id]?.rank ?? 0}`}
                       </span>
                       <RankBadge tier={p.tier} size="sm" userName={p.userName} />
                       <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
@@ -922,7 +923,7 @@ export default function SessionPage() {
                   return (
                     <tr key={p.id}>
                       <td className="col-rank">
-                        <span className={`rank-tag rank-tag-${rank}`}>{rankMedal(rank) ?? `#${rank}`}</span>
+                        <span className={`rank-tag rank-tag-${rank}`}>{seatRankMedal(rank) ?? `#${rank}`}</span>
                       </td>
                       <td>
                         <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -47,3 +47,11 @@ export function parseError(e: unknown): string {
 export function rankMedal(rank: number): string | null {
   return { 1: '🥇', 2: '🥈', 3: '🥉' }[rank] ?? null
 }
+
+/**
+ * In-game seat ranking (fixed 3–4 seats): podium + 🤡 for the 4th (last) seat.
+ * Use in per-game views (对局内); NOT the global leaderboard where 4th isn't "last".
+ */
+export function seatRankMedal(rank: number): string | null {
+  return { 1: '🥇', 2: '🥈', 3: '🥉', 4: '🤡' }[rank] ?? null
+}


### PR DESCRIPTION
## 概要

修对局记分板名次勋章 🥇🥈🥉 高度对不齐的问题, 并给末位(4 名)加 🤡 标记。4 个文件。

## 一、勋章对齐

**现象**: /session/:id 记分板表头,不同玩家的 🥇🥈🥉 高度不一致。

**根因**: 表头每列是竖排「勋章 → 段位头像 → 名字」。头像尺寸其实已统一(sm 都是 52/38px),真正原因是**名字用按长度缩放的字号**(`nameFontSize`),各列这一竖排总高度不同;单元格默认非顶端对齐 → 竖排居中摆放 → 顶部勋章被推到不同高度。

**修复**:
- 表头 `<th>` 加 `vertical-align: top`(`playerColStyle` + 「局」列): 各列内容顶端对齐, 勋章必然齐平, 与名字长短/段位无关。
- `.fixed-table th,td` 默认 `baseline` 改 `vertical-align: middle`: 让勋章格与段位徽章格在同一行居中对齐(StatsPage 等表同样受益)。表头的 `top` 是内联样式, 优先级更高, 不受影响。

## 二、末位 🤡 标记

- 新增 `seatRankMedal(rank)` = `🥇🥈🥉` + **4 → 🤡**(一局末位)。
- 对局内视图(`GameCard`、`SessionPage` 表头 + 排名结果表)改用它, 现在 1/2/3/4 = 🥇🥈🥉🤡, 四人齐整。
- **统计页排行榜、首页荣誉殿堂仍用 `rankMedal`(仅 1/2/3)** —— 那里第 4 名不是"末位", 不加 🤡。

## 测试要点

- [ ] /session/:id 记分板: 斗战圣佛 + 新玩家同桌时, 🥇🥈🥉🤡 高度一致
- [ ] 4 人对局末位显示 🤡; 3 人对局末位是 🥉(第 3)无 🤡
- [ ] 首页进行中对局卡(GameCard)末位显示 🤡
- [ ] 统计页排行榜第 4 名仍是 `#4`(无 🤡), 5 名及以后 `#N`
- [ ] 移动端各表勋章/徽章对齐正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added medal indicators for in-game player rankings, including a fourth-place marker.
* **Style**
  * Improved vertical alignment in fixed-layout tables.
  * Adjusted player ranking table headers for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->