### PR TITLE
fix(ui): 统一对局名次算法, 修同分并列显示不一致

### DIFF
--- a/ui/src/logic/ranking.ts
+++ b/ui/src/logic/ranking.ts
@@ -35,9 +35,6 @@ export function rankByScore<T extends object>(items: T[], getScore: (t: T) => nu
   return result
 }
 
-/**
- * Calculates ranks and Ranking Points (RP) for a list of player scores.
- */
 export function calculateRanks(scores: PlayerScore[], config: RpConfig): PlayerRank[] {
   const { rpFactor: factor, umaDist } = config
   const ranked = rankByScore(scores, (s) => s.score)
@@ -45,7 +42,6 @@ export function calculateRanks(scores: PlayerScore[], config: RpConfig): PlayerR
   const results: PlayerRank[] = []
   let i = 0
   while (i < ranked.length) {
-    // Rank groups are contiguous (same score → same rank), so group by rank.
     let j = i
     while (j < ranked.length && ranked[j].rank === ranked[i].rank) j++
 

--- a/ui/src/logic/ranking.ts
+++ b/ui/src/logic/ranking.ts
@@ -15,37 +15,52 @@ export interface RpConfig {
 }
 
 /**
- * Calculates ranks and Ranking Points (RP) for a list of player scores.
+ * Standard competition ranking: sort by score descending, tied scores share the
+ * same rank, and the next distinct score skips (e.g. [100,50,30,30] → ranks
+ * [1,2,3,3]; [50,50,30,10] → [1,1,3,4]). Sort is stable, so tied items keep their
+ * input order. This is the single source of truth for per-game rank across the UI
+ * and matches the backend RpCalculator.
  */
-export function calculateRanks(scores: PlayerScore[], config: RpConfig): PlayerRank[] {
-  const sorted = [...scores].sort((a, b) => b.score - a.score)
-
-  const results: PlayerRank[] = []
-  const { rpFactor: factor, umaDist } = config
-
+export function rankByScore<T extends object>(items: T[], getScore: (t: T) => number): (T & { rank: number })[] {
+  const sorted = [...items].sort((a, b) => getScore(b) - getScore(a))
+  const result: (T & { rank: number })[] = []
   let i = 0
   while (i < sorted.length) {
     let j = i
-    while (j < sorted.length && sorted[j].score === sorted[i].score) {
-      j++
-    }
-
-    const groupSize = j - i
+    while (j < sorted.length && getScore(sorted[j]) === getScore(sorted[i])) j++
     const rank = i + 1
+    for (let k = i; k < j; k++) result.push({ ...sorted[k], rank })
+    i = j
+  }
+  return result
+}
+
+/**
+ * Calculates ranks and Ranking Points (RP) for a list of player scores.
+ */
+export function calculateRanks(scores: PlayerScore[], config: RpConfig): PlayerRank[] {
+  const { rpFactor: factor, umaDist } = config
+  const ranked = rankByScore(scores, (s) => s.score)
+
+  const results: PlayerRank[] = []
+  let i = 0
+  while (i < ranked.length) {
+    // Rank groups are contiguous (same score → same rank), so group by rank.
+    let j = i
+    while (j < ranked.length && ranked[j].rank === ranked[i].rank) j++
 
     let totalUma = 0
     for (let k = i; k < j; k++) {
       totalUma += umaDist[k] || 0
     }
-    const avgUma = totalUma / groupSize
+    const avgUma = totalUma / (j - i)
 
     for (let k = i; k < j; k++) {
-      const current = sorted[k]
-      const baseRP = current.score / factor
       results.push({
-        ...current,
-        rank,
-        rp: baseRP + avgUma,
+        playerId: ranked[k].playerId,
+        score: ranked[k].score,
+        rank: ranked[k].rank,
+        rp: ranked[k].score / factor + avgUma,
       })
     }
 

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -113,8 +113,8 @@ export default function DashboardPage() {
               tableStrength={s.tableStrength}
               players={
                 s.rankings
-                  ? s.rankings.map((p, idx) => ({
-                      rank: idx + 1,
+                  ? s.rankings.map((p) => ({
+                      rank: p.rank,
                       name: p.userName,
                       score: p.totalScore,
                       tier: p.tier ?? null,

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { GAME_MODES, SessionDetail, PlayerStats, BestRound, getCurrentSeason } f
 import { GameCard } from '../components/GameCard'
 import { RankBadge } from '../components/RankBadge'
 import { deriveGameState, getWindName } from '../utils/gameState'
+import { rankByScore } from '../logic/ranking'
 import { nameFontSize } from '../utils/fontSize'
 import { rankMedal } from '../utils/format'
 import { MSG } from '../constants'
@@ -80,10 +81,7 @@ export default function HomePage() {
           <div className="active-games-grid">
             {activeSessions.map((s) => {
               const state = deriveGameState(s)
-              const sortedPlayers = [...s.players].sort(
-                (a, b) => (s.totalScores[b.id] || 0) - (s.totalScores[a.id] || 0)
-              )
-              const sortedScores = sortedPlayers.map((p) => s.totalScores[p.id] || 0)
+              const ranked = rankByScore(s.players, (p) => s.totalScores[p.id] || 0)
               return (
                 <GameCard
                   key={s.id}
@@ -93,13 +91,12 @@ export default function HomePage() {
                   roundLabel={`${state.displayName} 进行中`}
                   isActive={true}
                   tableStrength={s.tableStrength}
-                  players={sortedPlayers.map((p) => {
+                  players={ranked.map((p) => {
                     const score = s.totalScores[p.id] || 0
-                    const rank = sortedScores.indexOf(score) + 1
                     const seat = p.seat ?? s.players.findIndex((op) => op.id === p.id) + 1
                     const menfeng = ((seat - state.dealerSeat + state.playerCount) % state.playerCount) + 1
                     return {
-                      rank,
+                      rank: p.rank,
                       name: p.userName,
                       score,
                       wind: getWindName(menfeng),


### PR DESCRIPTION
## 概要

修复同分并列时名次显示不一致的 bug, 并把前端三处「单局名次」算法统一到一个共享函数。

## Bug

两人同分并列第 3(4 人局)时:
- **已结束对局卡(DashboardPage)**: 一人被显示成第 4 → 🤡(错)
- **对局详情页(SessionPage)**: 两人都是 🥉(对)

## 根因: 三套不一致的算法

| 位置 | 原算法 | 并列 |
|------|--------|------|
| SessionPage | `calculateRanks`(竞赛排名) | ✅ |
| HomePage(进行中卡) | `sortedScores.indexOf(score)+1` | ✅(但临时写法) |
| DashboardPage(已结束卡) | `s.rankings.map((p, idx) => idx+1)` | ❌ 用数组下标, 丢掉了后端算好的 `p.rank` |

后端 `SessionSummaryResponse` 其实已用 `RpCalculator.rankPlayers` 给出并列名次(`p.rank`), DashboardPage 却改用下标 → 同分第 3 变成 3/4。

## 统一方案

竞赛排名: 按本局得分降序, 同分并列共享名次, 下一档跳号(`[100,50,30,30]→[1,2,3,3]`; `[50,50,30,10]→[1,1,3,4]`)。与后端 `RpCalculator` 口径一致。

- `logic/ranking.ts`: 抽出共享 `rankByScore(items, getScore)`; `calculateRanks` 改为复用它。
- **HomePage**: 进行中对局卡改用 `rankByScore`, 删掉 `indexOf` 临时写法。
- **DashboardPage**: 改用后端 `p.rank`(修 bug)。
- 后端 `RpCalculator`、赛季积分榜(按 RP 位次, 另一套语义)保持不变。

## 测试要点

- [ ] 4 人局同分并列第 3: 首页卡 / 已结束卡 / 详情页都显示两人 🥉, 无 🤡
- [ ] 真正垫底(如 [1,1,3,4])才显示 🤡
- [ ] 进行中对局卡名次随分数实时正确
- [ ] 已结束对局卡名次与详情页一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected player rankings so tied scores share the same rank and subsequent ranks skip appropriately.
  * Ensured dashboard and home views display calculated ranks consistently rather than relying on player position.
  * Preserved accurate ranking details for active sessions and game cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->