### PR TITLE
feat(ui): 新增赛季奖项 阳寿打牌 + 小丑皇

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -14,6 +14,7 @@ public class PlayerStatsResponse {
   private double avgScore;
   private double avgRank;
   private int wins;
+  private int fourthPlaces;
   private double totalRP;
   private double baseRP;
   private double tieredBonus;

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -884,6 +884,7 @@ public class GameService {
     Map<Long, Integer> gamesPlayed = new HashMap<>();
     Map<Long, Integer> wins = new HashMap<>();
     Map<Long, Integer> totalRanks = new HashMap<>();
+    Map<Long, Integer> fourthPlaces = new HashMap<>();
     Map<Long, Double> totalRP = new HashMap<>();
     Map<Long, Double> tieredBonusPerPlayer = new HashMap<>();
     Map<Long, Double> adminBonusPerPlayer = new HashMap<>();
@@ -1011,6 +1012,7 @@ public class GameService {
         for (var entry : ranked) {
           totalRP.merge(entry.playerId(), entry.rp(), (a, b) -> a + b);
           totalRanks.merge(entry.playerId(), entry.rank(), Integer::sum);
+          if (entry.rank() == 4) fourthPlaces.merge(entry.playerId(), 1, Integer::sum);
         }
 
         int topScore = ((Number) sorted.get(0)[1]).intValue();
@@ -1037,6 +1039,7 @@ public class GameService {
               stat.setGamesPlayed(gamesPlayed.getOrDefault(p.getId(), 0));
               stat.setTotalScore(totalScores.getOrDefault(p.getId(), 0));
               stat.setWins(wins.getOrDefault(p.getId(), 0));
+              stat.setFourthPlaces(fourthPlaces.getOrDefault(p.getId(), 0));
               double baseRP = totalRP.getOrDefault(p.getId(), 0.0);
               double tieredBonus = tieredBonusPerPlayer.getOrDefault(p.getId(), 0.0);
               double adminBonus = adminBonusPerPlayer.getOrDefault(p.getId(), 0.0);

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -260,11 +260,11 @@ export default function StatsPage() {
           <div className="stats-grid">
             {awardCard('🧿 真•赤木', '最高胡牌率', topWinRate, topWinRate ? winRate(topWinRate) : undefined)}
             {awardCard('🪣 水缸坐穿', '最低胡牌率', lowWinRate, lowWinRate ? winRate(lowWinRate) : undefined)}
-            {awardCard('🐕 人是打不过狗的', '最高自摸率', topTsumo, topTsumo ? tsumoRate(topTsumo) : undefined)}
+            {awardCard('🐶 人是打不过狗的', '最高自摸率', topTsumo, topTsumo ? tsumoRate(topTsumo) : undefined)}
             {awardCard('⚰️ 我的牌去哪儿了', '最低自摸率', lowTsumo, lowTsumo ? tsumoRate(lowTsumo) : undefined)}
             {awardCard('💣 二营长', '最高铳率', topDealIn, topDealIn ? dealInRate(topDealIn) : undefined)}
             {awardCard('🐢 龟仙人', '最低铳率', lowDealIn, lowDealIn ? dealInRate(lowDealIn) : undefined)}
-            {awardCard('🔥 阳寿打牌', '最高1位率', topFirstRate, topFirstRate ? firstRate(topFirstRate) : undefined)}
+            {awardCard('☠️ 阳寿打牌', '最高1位率', topFirstRate, topFirstRate ? firstRate(topFirstRate) : undefined)}
             {awardCard('🤡 小丑皇', '最高4位率', topFourthRate, topFourthRate ? fourthRate(topFourthRate) : undefined)}
             {statCard(activeStats.length, '参与玩家')}
             {statCard(totalGames, '游戏场次')}

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -168,18 +168,23 @@ export default function StatsPage() {
 
   const totalGames = activeStats.length > 0 ? Math.max(...activeStats.map((s) => s.gamesPlayed)) : 0
 
-  // 赛季奖项. 单赛季无局数门槛; 全部赛季沿用 activeStats 的 ≥10 场门槛. 自摸率=自摸/和牌, 胡牌率=和牌/局数, 铳率=放铳/局数.
+  // 赛季奖项. 单赛季无局数门槛; 全部赛季沿用 activeStats 的 5+赛季数 门槛.
+  // 率: 自摸=自摸/和牌, 胡牌=和牌/局数, 铳=放铳/局数, 1位=1位/总场, 4位=4位/总场.
   const withRounds = activeStats.filter((s) => s.roundsPlayed > 0)
   const withWins = activeStats.filter((s) => s.handWins > 0)
   const winRate = (s: PlayerStats) => s.handWins / s.roundsPlayed
   const tsumoRate = (s: PlayerStats) => s.tsumoWins / s.handWins
   const dealInRate = (s: PlayerStats) => s.dealIns / s.roundsPlayed
+  const firstRate = (s: PlayerStats) => s.wins / s.gamesPlayed
+  const fourthRate = (s: PlayerStats) => s.fourthPlaces / s.gamesPlayed
   const pick = (arr: PlayerStats[], rate: (s: PlayerStats) => number, dir: 'max' | 'min') =>
     arr.length === 0 ? null : [...arr].sort((a, b) => (dir === 'max' ? rate(b) - rate(a) : rate(a) - rate(b)))[0]
   const topTsumo = pick(withWins, tsumoRate, 'max')
   const topWinRate = pick(withRounds, winRate, 'max')
   const topDealIn = pick(withRounds, dealInRate, 'max')
   const lowDealIn = pick(withRounds, dealInRate, 'min')
+  const topFirstRate = pick(activeStats, firstRate, 'max')
+  const topFourthRate = pick(activeStats, fourthRate, 'max')
   const lowWinRate = pick(withRounds, winRate, 'min')
   const lowTsumo = pick(withWins, tsumoRate, 'min')
 
@@ -259,6 +264,8 @@ export default function StatsPage() {
             {awardCard('⚰️ 我的牌去哪儿了', '最低自摸率', lowTsumo, lowTsumo ? tsumoRate(lowTsumo) : undefined)}
             {awardCard('💣 二营长', '最高铳率', topDealIn, topDealIn ? dealInRate(topDealIn) : undefined)}
             {awardCard('🐢 龟仙人', '最低铳率', lowDealIn, lowDealIn ? dealInRate(lowDealIn) : undefined)}
+            {awardCard('🔥 阳寿打牌', '最高1位率', topFirstRate, topFirstRate ? firstRate(topFirstRate) : undefined)}
+            {awardCard('🤡 小丑皇', '最高4位率', topFourthRate, topFourthRate ? fourthRate(topFourthRate) : undefined)}
             {statCard(activeStats.length, '参与玩家')}
             {statCard(totalGames, '游戏场次')}
           </div>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -166,6 +166,7 @@ export interface PlayerStats {
   avgScore: number
   avgRank: number
   wins: number
+  fourthPlaces: number
   roundsPlayed: number
   handWins: number
   tsumoWins: number


### PR DESCRIPTION
## 概要

统计页赛季奖项在 🐢 龟仙人后新增两张:
- 🔥 **阳寿打牌** — 最高 1 位率
- 🤡 **小丑皇** — 最高 4 位率

## 改动

**后端**:
- `PlayerStatsResponse` 新增 `fourthPlaces`。
- `getPlayerStats` 在按局排名时统计每位玩家 `rank == 4` 的次数(复用 `RpCalculator` 已算好的名次, 与并列口径一致)。

**前端**:
- `PlayerStats` 类型加 `fourthPlaces`。
- `StatsPage`: `1位率 = wins/总场`、`4位率 = fourthPlaces/总场`, 取最高值。跟随选中赛季+模式, 沿用 `activeStats` 门槛(单赛季无门槛, 全部赛季 5+赛季数)。
- 顺手修了 awards 注释里过期的门槛说明(≥10 → 5+赛季数)。

## 说明

- `1位` = 本局并列第一(top score, 含并列); `4位` = 本局名次为 4(仅 4 人局会出现, 与末位 🤡 口径一致, 并列第 3 时不产生第 4)。
- 分母都是总场次, 与已有奖项一致(单赛季无门槛, 样本小时可能出现"打几场就登顶率"的噪音)。

## 测试要点

- [ ] 阳寿打牌 = wins/gamesPlayed 最高者; 小丑皇 = fourthPlaces/gamesPlayed 最高者
- [ ] 切赛季/模式数值随之更新
- [ ] 4 人局第 4 名计入 4 位率; 并列第 3(无第 4)不计
- [ ] **重启后端** fourthPlaces 才生效; 未重启前端不崩(缺字段按 0 处理 → 显示 0% 或选不出)

🤖 Generated with [Claude Code](https://claude.com/claude-code)