### PR TITLE
feat(ui): 进行中对局全屏看盘重构（双击/全屏按钮/单列极简/iPad安全对齐）

### DIFF
--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -6,6 +6,19 @@ import { TierKey } from '../types'
 import { RankBadge } from './RankBadge'
 import { TableStrengthTag } from './TableStrengthTag'
 
+// Fullscreen API with webkit fallback + feature-detection (Safari/iPadOS use webkit*; iPhone has neither).
+type FsDoc = Document & { webkitFullscreenElement?: Element; webkitExitFullscreen?: () => void }
+type FsEl = HTMLElement & { webkitRequestFullscreen?: () => void }
+const fsElement = () => document.fullscreenElement ?? (document as FsDoc).webkitFullscreenElement ?? null
+const requestFs = (el: FsEl) => {
+  const fn = el.requestFullscreen ?? el.webkitRequestFullscreen
+  if (fn) Promise.resolve(fn.call(el)).catch(() => {})
+}
+const exitFs = () => {
+  const fn = document.exitFullscreen ?? (document as FsDoc).webkitExitFullscreen
+  if (fn) Promise.resolve(fn.call(document)).catch(() => {})
+}
+
 interface PlayerEntry {
   rank: number
   name: string
@@ -37,6 +50,7 @@ export const GameCard: React.FC<Props> = ({
   const navigate = useNavigate()
   const [fullscreen, setFullscreen] = useState(false)
   const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const closeBtnRef = useRef<HTMLButtonElement>(null)
 
   useEffect(
     () => () => {
@@ -53,6 +67,7 @@ export const GameCard: React.FC<Props> = ({
       }
     }
     document.addEventListener('keydown', onKey)
+    closeBtnRef.current?.focus()
     const scrollY = window.scrollY
     document.body.style.position = 'fixed'
     document.body.style.top = `-${scrollY}px`
@@ -69,27 +84,23 @@ export const GameCard: React.FC<Props> = ({
   useEffect(() => {
     if (!fullscreen) return
     const handleFsChange = () => {
-      if (!document.fullscreenElement) {
-        setFullscreen(false)
-      }
+      if (!fsElement()) setFullscreen(false)
     }
     document.addEventListener('fullscreenchange', handleFsChange)
+    document.addEventListener('webkitfullscreenchange', handleFsChange)
     return () => {
       document.removeEventListener('fullscreenchange', handleFsChange)
+      document.removeEventListener('webkitfullscreenchange', handleFsChange)
     }
   }, [fullscreen])
 
   const openFullscreen = () => {
     setFullscreen(true)
-    if (!document.fullscreenElement) {
-      document.documentElement.requestFullscreen().catch(() => {})
-    }
+    if (!fsElement()) requestFs(document.documentElement)
   }
 
   const closeFullscreen = () => {
-    if (document.fullscreenElement) {
-      document.exitFullscreen().catch(() => {})
-    }
+    if (fsElement()) exitFs()
     setFullscreen(false)
   }
 
@@ -137,29 +148,6 @@ export const GameCard: React.FC<Props> = ({
               })}
             </span>
             <span className={`badge badge-sm ${isActive ? 'badge-progress' : 'badge-completed'}`}>{roundLabel}</span>
-            <button
-              type="button"
-              className="btn-card-fullscreen"
-              title="全屏看盘"
-              aria-label="全屏看盘"
-              onClick={(e) => {
-                e.stopPropagation()
-                openFullscreen()
-              }}
-            >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
-              </svg>
-            </button>
           </div>
         </div>
         <div className="session-card-players">
@@ -182,7 +170,7 @@ export const GameCard: React.FC<Props> = ({
       </div>
 
       {fullscreen && (
-        <div className="game-fs-overlay" role="dialog" aria-modal="true">
+        <div className="game-fs-overlay" role="dialog" aria-modal="true" aria-label="全屏看盘">
           <div className="game-fs-topbar">
             <div className="game-fs-title-area">
               <span className="game-fs-mode">{gameModeDisplayName}</span>
@@ -204,6 +192,7 @@ export const GameCard: React.FC<Props> = ({
             </div>
             <div className="game-fs-actions">
               <button
+                ref={closeBtnRef}
                 type="button"
                 className="game-fs-btn game-fs-close-btn"
                 title="退出全屏 (Esc)"

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -37,29 +37,22 @@ export const GameCard: React.FC<Props> = ({
   const navigate = useNavigate()
   const [fullscreen, setFullscreen] = useState(false)
   const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const fsCardRef = useRef<HTMLDivElement>(null)
-  const [fsScale, setFsScale] = useState(1)
 
-  useEffect(() => {
-    if (!fullscreen) return
-    const compute = () => {
-      const el = fsCardRef.current
-      if (!el) return
-      const s = Math.min((window.innerWidth - 24) / el.offsetWidth, (window.innerHeight - 24) / el.offsetHeight)
-      setFsScale(s)
-    }
-    compute()
-    window.addEventListener('resize', compute)
-    return () => window.removeEventListener('resize', compute)
-  }, [fullscreen])
+  useEffect(
+    () => () => {
+      if (clickTimer.current !== null) clearTimeout(clickTimer.current)
+    },
+    []
+  )
 
   useEffect(() => {
     if (!fullscreen) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setFullscreen(false)
+      if (e.key === 'Escape') {
+        closeFullscreen()
+      }
     }
     document.addEventListener('keydown', onKey)
-    // position:fixed body 锁滚动(iOS Safari 上 overflow:hidden 不可靠).
     const scrollY = window.scrollY
     document.body.style.position = 'fixed'
     document.body.style.top = `-${scrollY}px`
@@ -73,23 +66,38 @@ export const GameCard: React.FC<Props> = ({
     }
   }, [fullscreen])
 
-  useEffect(
-    () => () => {
-      if (clickTimer.current !== null) clearTimeout(clickTimer.current)
-    },
-    []
-  )
-
-  // 单一 click 计时判断双击, 兼容手机(onDoubleClick 移动端不可靠).
-  const handleClick = () => {
-    if (!isActive) {
-      navigate(`/session/${id}`)
-      return
+  useEffect(() => {
+    if (!fullscreen) return
+    const handleFsChange = () => {
+      if (!document.fullscreenElement) {
+        setFullscreen(false)
+      }
     }
+    document.addEventListener('fullscreenchange', handleFsChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFsChange)
+    }
+  }, [fullscreen])
+
+  const openFullscreen = () => {
+    setFullscreen(true)
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch(() => {})
+    }
+  }
+
+  const closeFullscreen = () => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {})
+    }
+    setFullscreen(false)
+  }
+
+  const handleCardClick = () => {
     if (clickTimer.current !== null) {
       clearTimeout(clickTimer.current)
       clickTimer.current = null
-      setFullscreen(true)
+      openFullscreen()
       return
     }
     clickTimer.current = setTimeout(() => {
@@ -98,54 +106,14 @@ export const GameCard: React.FC<Props> = ({
     }, 250)
   }
 
-  const cardBody = (
-    <>
-      <div className="session-card-header">
-        <div className="session-card-mode">
-          <span className="mode-text">{gameModeDisplayName}</span>
-          <TableStrengthTag table={tableStrength} />
-        </div>
-        <div className="session-card-meta">
-          <span className="session-card-date">
-            {new Date(createdAt).toLocaleString([], {
-              timeZone: 'America/Los_Angeles',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}
-          </span>
-          <span className={`badge badge-sm ${isActive ? 'badge-progress' : 'badge-completed'}`}>{roundLabel}</span>
-        </div>
-      </div>
-      <div className="session-card-players">
-        {players.map((p, idx) => (
-          <div key={idx} className="player-rank-item">
-            <span className="player-name-with-rank">
-              <span className={`rank-number${p.rank <= 4 ? ` rank-tag-${p.rank}` : ''}`}>
-                {seatRankMedal(p.rank) ?? `#${p.rank}`}
-              </span>
-              {p.wind && <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>{p.wind}</span>}
-              <RankBadge tier={p.tier} size="sm" userName={p.name} />
-              <span className="player-name" style={{ fontSize: nameFontSize(p.name) }}>
-                {p.name}
-              </span>
-            </span>
-            <span className={`player-score ${scoreClass(p.score)}`}>{p.score > 0 ? `+${p.score}` : p.score}</span>
-          </div>
-        ))}
-      </div>
-    </>
-  )
-
   return (
     <>
       <div
         className="game-card"
         role="button"
         tabIndex={0}
-        title={isActive ? '单击查看详情 · 双击全屏' : '单击查看详情'}
-        onClick={handleClick}
+        title="单击查看详情 · 双击全屏看盘"
+        onClick={handleCardClick}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
@@ -153,21 +121,137 @@ export const GameCard: React.FC<Props> = ({
           }
         }}
       >
-        {cardBody}
+        <div className="session-card-header">
+          <div className="session-card-mode">
+            <span className="mode-text">{gameModeDisplayName}</span>
+            <TableStrengthTag table={tableStrength} />
+          </div>
+          <div className="session-card-meta">
+            <span className="session-card-date">
+              {new Date(createdAt).toLocaleString([], {
+                timeZone: 'America/Los_Angeles',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+            <span className={`badge badge-sm ${isActive ? 'badge-progress' : 'badge-completed'}`}>{roundLabel}</span>
+            <button
+              type="button"
+              className="btn-card-fullscreen"
+              title="全屏看盘"
+              aria-label="全屏看盘"
+              onClick={(e) => {
+                e.stopPropagation()
+                openFullscreen()
+              }}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div className="session-card-players">
+          {players.map((p, idx) => (
+            <div key={idx} className="player-rank-item">
+              <span className="player-name-with-rank">
+                <span className={`rank-number${p.rank <= 4 ? ` rank-tag-${p.rank}` : ''}`}>
+                  {seatRankMedal(p.rank) ?? `#${p.rank}`}
+                </span>
+                {p.wind && <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>{p.wind}</span>}
+                <RankBadge tier={p.tier} size="sm" userName={p.name} />
+                <span className="player-name" style={{ fontSize: nameFontSize(p.name) }}>
+                  {p.name}
+                </span>
+              </span>
+              <span className={`player-score ${scoreClass(p.score)}`}>{p.score > 0 ? `+${p.score}` : p.score}</span>
+            </div>
+          ))}
+        </div>
       </div>
 
       {fullscreen && (
-        <div className="game-fs" onClick={() => setFullscreen(false)}>
-          <button type="button" className="game-fs-close" aria-label="关闭" onClick={() => setFullscreen(false)}>
-            ✕
-          </button>
-          <div
-            ref={fsCardRef}
-            className="game-card game-card-fs"
-            style={{ transform: `scale(${fsScale})` }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            {cardBody}
+        <div className="game-fs-overlay" role="dialog" aria-modal="true">
+          <div className="game-fs-topbar">
+            <div className="game-fs-title-area">
+              <span className="game-fs-mode">{gameModeDisplayName}</span>
+              <TableStrengthTag table={tableStrength} />
+              <span className={`badge ${isActive ? 'badge-progress' : 'badge-completed'}`}>
+                {isActive && <span className="pulse-dot" />}
+                {roundLabel}
+              </span>
+              <span className="game-fs-date">
+                {new Date(createdAt).toLocaleString([], {
+                  timeZone: 'America/Los_Angeles',
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+            </div>
+            <div className="game-fs-actions">
+              <button
+                type="button"
+                className="game-fs-btn game-fs-close-btn"
+                title="退出全屏 (Esc)"
+                onClick={closeFullscreen}
+              >
+                ✕ 退出全屏
+              </button>
+            </div>
+          </div>
+
+          <div className="game-fs-main">
+            <div className="game-fs-scoreboard-col">
+              {players.map((p, idx) => (
+                <div key={idx} className={`game-fs-player-card ${p.isDealer ? 'is-dealer' : ''} rank-${p.rank}`}>
+                  <div className="game-fs-player-left">
+                    <div className="game-fs-rank-badge">{seatRankMedal(p.rank) ?? `#${p.rank}`}</div>
+                    <div className="game-fs-player-info">
+                      <div className="game-fs-player-name-row">
+                        {p.wind && (
+                          <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>
+                            {p.wind} {p.isDealer && '庄'}
+                          </span>
+                        )}
+                        <RankBadge tier={p.tier} size="md" userName={p.name} />
+                        <span className="game-fs-player-name">{p.name}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className={`game-fs-player-score ${scoreClass(p.score)}`}>
+                    {p.score > 0 ? `+${p.score}` : p.score}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="game-fs-footer">
+            <button
+              type="button"
+              className="game-fs-detail-link"
+              onClick={() => {
+                closeFullscreen()
+                navigate(`/session/${id}`)
+              }}
+            >
+              进入对局详情页 ➔
+            </button>
+            <span className="game-fs-tip">按 Esc 键可退出全屏</span>
           </div>
         </div>
       )}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2982,28 +2982,6 @@ table.auto-table {
   font-weight: 800;
 }
 
-/* 卡片右上角全屏按钮 */
-.btn-card-fullscreen {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 3px;
-  border-radius: 5px;
-  border: 1px solid var(--border-ccc, #cccccc);
-  background: transparent;
-  color: var(--text-666, #666666);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  margin-left: 6px;
-}
-
-.btn-card-fullscreen:hover {
-  background: var(--accent, #d4a017);
-  color: #ffffff;
-  border-color: var(--accent, #d4a017);
-  transform: scale(1.08);
-}
-
 /* 影院/全屏看盘 — 覆盖全屏 Overlay (白色极简全屏 Mode) */
 .game-fs-overlay {
   position: fixed;
@@ -3011,18 +2989,18 @@ table.auto-table {
   width: 100vw;
   height: 100vh;
   z-index: 99999;
-  background: #ffffff;
+  background: #fff;
   color: #0f172a;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  padding: max(20px, env(safe-area-inset-top)) max(24px, env(safe-area-inset-right)) 24px
-    max(24px, env(safe-area-inset-left));
+  padding: max(20px, env(safe-area-inset-top)) max(24px, env(safe-area-inset-right))
+    max(24px, env(safe-area-inset-bottom)) max(24px, env(safe-area-inset-left));
   overflow-y: auto;
-  animation: fadeInFs 0.2s ease-out;
+  animation: fade-in-fs 0.2s ease-out;
 }
 
-@keyframes fadeInFs {
+@keyframes fade-in-fs {
   from {
     opacity: 0;
     transform: scale(0.99);
@@ -3132,7 +3110,7 @@ table.auto-table {
 }
 
 .game-fs-player-card {
-  background: #ffffff;
+  background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 14px;
   padding: 20px 28px;
@@ -3151,7 +3129,7 @@ table.auto-table {
 
 .game-fs-player-card.is-dealer {
   border-color: #f59e0b;
-  background: linear-gradient(135deg, #fffbeb 0%, #ffffff 100%);
+  background: linear-gradient(135deg, #fffbeb 0%, #fff 100%);
   box-shadow: 0 4px 20px -2px rgb(245 158 11 / 20%);
 }
 
@@ -3208,16 +3186,12 @@ table.auto-table {
   letter-spacing: -0.03em;
 }
 
-.game-fs-player-score.pos {
+.game-fs-player-score.score-positive {
   color: #16a34a;
 }
 
-.game-fs-player-score.neg {
+.game-fs-player-score.score-negative {
   color: #dc2626;
-}
-
-.game-fs-player-score.zero {
-  color: #64748b;
 }
 
 .pulse-dot {
@@ -3228,10 +3202,10 @@ table.auto-table {
   background: #22c55e;
   margin-right: 6px;
   box-shadow: 0 0 8px #22c55e;
-  animation: pulseDot 1.5s infinite;
+  animation: pulse-dot 1.5s infinite;
 }
 
-@keyframes pulseDot {
+@keyframes pulse-dot {
   0% {
     transform: scale(0.95);
     opacity: 0.8;
@@ -3258,7 +3232,7 @@ table.auto-table {
 
 .game-fs-detail-link {
   background: var(--accent, #d4a017);
-  color: #ffffff;
+  color: #fff;
   border: none;
   padding: 10px 22px;
   border-radius: 8px;
@@ -3278,10 +3252,10 @@ table.auto-table {
   color: #64748b;
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .game-fs-overlay {
-    padding: max(12px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) 16px
-      max(16px, env(safe-area-inset-left));
+    padding: max(12px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
+      max(16px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
   }
 
   .game-fs-topbar {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2750,14 +2750,14 @@ table.auto-table {
 }
 
 .wind-tag {
-  font-size: 0.75rem;
-  padding: 1px 5px;
+  font-size: 0.85rem;
+  padding: 2px 7px;
   border: 1.5px solid var(--mj-gold);
   color: var(--mj-gold);
   background-color: transparent;
   border-radius: 4px;
   font-weight: bold;
-  min-width: 24px;
+  min-width: 26px;
   text-align: center;
   display: inline-block;
   line-height: 1.2;
@@ -2982,36 +2982,324 @@ table.auto-table {
   font-weight: 800;
 }
 
-/* 全屏放大观看 — 复用原卡片 DOM, 整体 transform: scale 放大, 不改任何子元素样式 */
-.game-fs {
+/* 卡片右上角全屏按钮 */
+.btn-card-fullscreen {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  border-radius: 5px;
+  border: 1px solid var(--border-ccc, #cccccc);
+  background: transparent;
+  color: var(--text-666, #666666);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-left: 6px;
+}
+
+.btn-card-fullscreen:hover {
+  background: var(--accent, #d4a017);
+  color: #ffffff;
+  border-color: var(--accent, #d4a017);
+  transform: scale(1.08);
+}
+
+/* 影院/全屏看盘 — 覆盖全屏 Overlay (白色极简全屏 Mode) */
+.game-fs-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2000;
-  background: rgb(0 0 0 / 60%);
+  width: 100vw;
+  height: 100vh;
+  z-index: 99999;
+  background: #ffffff;
+  color: #0f172a;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  padding: max(20px, env(safe-area-inset-top)) max(24px, env(safe-area-inset-right)) 24px
+    max(24px, env(safe-area-inset-left));
+  overflow-y: auto;
+  animation: fadeInFs 0.2s ease-out;
+}
+
+@keyframes fadeInFs {
+  from {
+    opacity: 0;
+    transform: scale(0.99);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.game-fs-topbar {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
+  padding-bottom: 18px;
+  padding-left: 64px; /* 避开 iPadOS/iOS 元素全屏左上角系统自带的 X 按钮 */
+  padding-right: 64px;
+  border-bottom: 1px solid #e2e8f0;
+  min-height: 44px;
+  gap: 16px;
+  box-sizing: border-box;
 }
 
-.game-fs-close {
-  position: fixed;
-  top: 12px;
-  right: 16px;
-  border: none;
-  background: transparent;
-  color: #fff;
-  font-size: 1.8rem;
-  line-height: 1;
+.game-fs-title-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.game-fs-mode {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+}
+
+.game-fs-date {
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.game-fs-actions {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-60%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.game-fs-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  color: #334155;
+  font-size: 0.9rem;
+  font-weight: 600;
   cursor: pointer;
-  padding: 6px 10px;
-  z-index: 1;
+  transition: all 0.2s ease;
 }
 
-.game-card-fs {
-  width: 340px;
-  cursor: default;
-  transform-origin: center center;
+.game-fs-btn:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+  border-color: #94a3b8;
+}
+
+.game-fs-close-btn {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #dc2626;
+}
+
+.game-fs-close-btn:hover {
+  background: #fecaca;
+  border-color: #f87171;
+  color: #b91c1c;
+}
+
+.game-fs-main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px 0;
+}
+
+.game-fs-scoreboard-col {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}
+
+.game-fs-player-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 20px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 4px 16px -2px rgb(15 23 42 / 6%);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.game-fs-player-card:hover {
+  transform: translateY(-2px);
+  border-color: #cbd5e1;
+  box-shadow: 0 8px 24px -4px rgb(15 23 42 / 10%);
+}
+
+.game-fs-player-card.is-dealer {
+  border-color: #f59e0b;
+  background: linear-gradient(135deg, #fffbeb 0%, #ffffff 100%);
+  box-shadow: 0 4px 20px -2px rgb(245 158 11 / 20%);
+}
+
+.game-fs-player-left {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.game-fs-rank-badge {
+  font-size: 2.2rem;
+  line-height: 1;
+  width: 52px;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.game-fs-player-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.game-fs-player-name-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.game-fs-player-card .wind-tag {
+  font-size: 1.25rem;
+  padding: 4px 0;
+  width: 76px;
+  flex-shrink: 0;
+  border-width: 2px;
+  border-radius: 6px;
+  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.game-fs-player-name {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.game-fs-player-score {
+  font-size: 2.6rem;
+  font-weight: 900;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  letter-spacing: -0.03em;
+}
+
+.game-fs-player-score.pos {
+  color: #16a34a;
+}
+
+.game-fs-player-score.neg {
+  color: #dc2626;
+}
+
+.game-fs-player-score.zero {
+  color: #64748b;
+}
+
+.pulse-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  margin-right: 6px;
+  box-shadow: 0 0 8px #22c55e;
+  animation: pulseDot 1.5s infinite;
+}
+
+@keyframes pulseDot {
+  0% {
+    transform: scale(0.95);
+    opacity: 0.8;
+  }
+
+  50% {
+    transform: scale(1.3);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(0.95);
+    opacity: 0.8;
+  }
+}
+
+.game-fs-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 16px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.game-fs-detail-link {
+  background: var(--accent, #d4a017);
+  color: #ffffff;
+  border: none;
+  padding: 10px 22px;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.game-fs-detail-link:hover {
+  background: #b88a10;
+  transform: translateY(-1px);
+}
+
+.game-fs-tip {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (max-width: 768px) {
+  .game-fs-overlay {
+    padding: max(12px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) 16px
+      max(16px, env(safe-area-inset-left));
+  }
+
+  .game-fs-topbar {
+    padding-left: 48px;
+    padding-right: 48px;
+  }
+
+  .game-fs-player-card {
+    padding: 14px 18px;
+  }
+
+  .game-fs-player-score {
+    font-size: 2rem;
+  }
+
+  .game-fs-player-name {
+    font-size: 1.2rem;
+  }
 }
 
 @media (width <= 640px) {


### PR DESCRIPTION
重构进行中对局全屏看盘：支持双击与独立全屏按钮、直连系统全屏API、纯白极简单列排版、风圈槽位76px固定宽度绝对对齐，以及iPadOS safe-area避让。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned fullscreen game view using the browser Fullscreen API, with dialog-style layout, close control, scoreboard, player details, and improved navigation.
  * Added fullscreen entry via card double-click, plus responsive layout and fade-in animation.
* **Bug Fixes**
  * Updated keyboard and state handling: **Esc** exits fullscreen; **Enter/Space** navigate directly; single-click navigation is consistently scheduled.
  * Refreshed the “games” tab statistic card label for the affected ranking.
* **Style**
  * Improved wind indicator sizing and added player-score pulse visuals in fullscreen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->