### PR TITLE
fix(riichi): 流局全员未听改为流庄, 流局必定加一本场

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -61,6 +61,7 @@ public class SessionDetailResponse {
     private String dealInPlayerName;
     private Integer prevalentWind;
     private List<Long> riichiPlayerIds;
+    private List<Long> tenpaiPlayerIds;
     private Boolean backfill;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/model/Round.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Round.java
@@ -44,5 +44,8 @@ public class Round {
   @Column(columnDefinition = "TEXT")
   private String riichiPlayerIds;
 
+  @Column(columnDefinition = "TEXT")
+  private String tenpaiPlayerIds;
+
   private Boolean backfill;
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -464,15 +464,15 @@ public class GameService {
                     dealInName = playerNameMap.getOrDefault(round.getDealInPlayerId(), "?");
                   }
 
-                  List<Long> riichiIds = null;
-                  if (round.getRiichiPlayerIds() != null && !round.getRiichiPlayerIds().isBlank()) {
-                    riichiIds =
-                        Arrays.stream(round.getRiichiPlayerIds().split(","))
-                            .map(String::trim)
-                            .filter(s -> !s.isEmpty())
-                            .map(Long::valueOf)
-                            .toList();
-                  }
+                  // null column = 历史对局没有该数据, 保持 null 让前端走兼容分支
+                  List<Long> riichiIds =
+                      round.getRiichiPlayerIds() == null
+                          ? null
+                          : parseIdList(round.getRiichiPlayerIds());
+                  List<Long> tenpaiIds =
+                      round.getTenpaiPlayerIds() == null
+                          ? null
+                          : parseIdList(round.getTenpaiPlayerIds());
 
                   return new SessionDetailResponse.RoundInfo(
                       round.getRoundNumber(),
@@ -485,6 +485,7 @@ public class GameService {
                       dealInName,
                       round.getPrevalentWind(),
                       riichiIds,
+                      tenpaiIds,
                       round.getBackfill());
                 })
             .collect(Collectors.toList()));
@@ -619,6 +620,7 @@ public class GameService {
         request.isSelfDraw() ? null : request.getDealInPlayerId(),
         request.getPrevalentWind(),
         request.getRiichiPlayerIds(),
+        request.getTenpaiPlayerIds(),
         request.getBackfill());
     evictAllCaches();
   }
@@ -1261,6 +1263,15 @@ public class GameService {
     return handler;
   }
 
+  /** Parses a comma-separated id column; "" → empty list (e.g. 流局全员未听). */
+  private static List<Long> parseIdList(String raw) {
+    return Arrays.stream(raw.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(Long::valueOf)
+        .toList();
+  }
+
   private void saveRoundScores(
       GameSession session,
       int roundNumber,
@@ -1272,6 +1283,7 @@ public class GameService {
       Long dealInId,
       Integer prevalentWind,
       List<Long> riichiPlayerIds,
+      List<Long> tenpaiPlayerIds,
       Boolean backfill) {
     Round round = new Round();
     round.setGameSession(session);
@@ -1286,6 +1298,11 @@ public class GameService {
     if (riichiPlayerIds != null && !riichiPlayerIds.isEmpty()) {
       round.setRiichiPlayerIds(
           riichiPlayerIds.stream().map(String::valueOf).collect(Collectors.joining(",")));
+    }
+    if (tenpaiPlayerIds != null) {
+      // Empty list is meaningful for draws (全员未听) — store "" to distinguish from legacy rounds
+      round.setTenpaiPlayerIds(
+          tenpaiPlayerIds.stream().map(String::valueOf).collect(Collectors.joining(",")));
     }
 
     round = roundRepo.save(round);

--- a/server/src/test/java/com/mahjong/omakase/model/RoundTenpaiPersistenceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/model/RoundTenpaiPersistenceTest.java
@@ -1,0 +1,42 @@
+package com.mahjong.omakase.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+/** 流局的听牌名单用 "" 表示「全员未听」, null 表示「历史对局无该数据」, 前端靠这个区别判断庄家连庄/流庄。 */
+@DataJpaTest
+class RoundTenpaiPersistenceTest {
+
+  @Autowired private EntityManager em;
+
+  private Round saveRound(String tenpaiPlayerIds) {
+    GameSession session = new GameSession();
+    session.setPlayerCount(4);
+    session.setGameMode(GameMode.RIICHI);
+    em.persist(session);
+
+    Round round = new Round();
+    round.setGameSession(session);
+    round.setRoundNumber(1);
+    round.setTenpaiPlayerIds(tenpaiPlayerIds);
+    em.persist(round);
+
+    em.flush();
+    em.clear();
+    return em.find(Round.class, round.getId());
+  }
+
+  @Test
+  void emptyTenpaiListRoundTripsAsEmptyString() {
+    assertThat(saveRound("").getTenpaiPlayerIds()).isEmpty();
+  }
+
+  @Test
+  void missingTenpaiListRoundTripsAsNull() {
+    assertThat(saveRound(null).getTenpaiPlayerIds()).isNull();
+  }
+}

--- a/server/src/test/java/com/mahjong/omakase/service/handler/RiichiModeHandlerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/handler/RiichiModeHandlerTest.java
@@ -38,6 +38,13 @@ public class RiichiModeHandlerTest {
     return request;
   }
 
+  private AddRoundRequest drawnGame(List<Long> tenpaiIds) {
+    AddRoundRequest request = new AddRoundRequest();
+    request.setRoundType("DRAWN_GAME");
+    request.setTenpaiPlayerIds(tenpaiIds);
+    return request;
+  }
+
   private void assertZeroSum(Map<Long, Integer> scores, int kyoutaku) {
     int sum = scores.values().stream().mapToInt(Integer::intValue).sum();
     assertEquals(kyoutaku, sum, "scores must sum to kyoutaku (carried-over riichi sticks)");
@@ -540,6 +547,48 @@ public class RiichiModeHandlerTest {
     assertEquals(7400, scores.get(1L));
     assertEquals(-4200, scores.get(2L));
     assertEquals(-3200, scores.get(3L));
+    assertZeroSum(scores, 0);
+  }
+
+  // ============================================================
+  // Drawn game (流局) — tenpai list validation and noten payments
+  // ============================================================
+
+  @Test
+  public void testDrawnGameRejectsMissingTenpaiList() {
+    AddRoundRequest request = drawnGame(null);
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> handler.calculateRoundScores(request, YONMA));
+    assertEquals("Tenpai player list is required for drawn game", e.getMessage());
+  }
+
+  @Test
+  public void testDrawnGameRejectsTenpaiPlayerOutsideSession() {
+    AddRoundRequest request = drawnGame(Arrays.asList(1L, 99L));
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> handler.calculateRoundScores(request, YONMA));
+    assertEquals("Player 99 is not in this session", e.getMessage());
+  }
+
+  @Test
+  public void testDrawnGameAllNotenIsValidWithNoPointMovement() {
+    Map<Long, Integer> scores = handler.calculateRoundScores(drawnGame(List.of()), YONMA);
+    for (Long id : YONMA) {
+      assertEquals(0, scores.get(id));
+    }
+    assertZeroSum(scores, 0);
+  }
+
+  @Test
+  public void testDrawnGameTwoTenpaiPayments() {
+    Map<Long, Integer> scores =
+        handler.calculateRoundScores(drawnGame(Arrays.asList(1L, 2L)), YONMA);
+    assertEquals(1500, scores.get(1L));
+    assertEquals(1500, scores.get(2L));
+    assertEquals(-1500, scores.get(3L));
+    assertEquals(-1500, scores.get(4L));
     assertZeroSum(scores, 0);
   }
 }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -110,6 +110,7 @@ export interface RoundInfo {
   dealInPlayerName?: string | null
   prevalentWind?: number
   riichiPlayerIds?: number[]
+  tenpaiPlayerIds?: number[] // for drawn games; undefined on legacy rounds
   backfill?: boolean
 }
 

--- a/ui/src/utils/__tests__/gameState.test.ts
+++ b/ui/src/utils/__tests__/gameState.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { deriveGameState } from '../gameState'
+import { PlayerInfo, RoundInfo, SessionDetail } from '../../types'
+
+const PLAYERS: PlayerInfo[] = [1, 2, 3, 4].map((n) => ({
+  id: n,
+  userName: `p${n}`,
+  firstName: 'P',
+  lastName: String(n),
+  displayName: `P ${n}`,
+  seat: n,
+}))
+
+function session(rounds: RoundInfo[]): SessionDetail {
+  return {
+    id: 1,
+    name: 'test',
+    gameMode: 'RIICHI',
+    gameModeDisplayName: '立直麻将',
+    playerCount: 4,
+    status: 'IN_PROGRESS',
+    createdAt: '2026-08-02T00:00:00',
+    players: PLAYERS,
+    rounds,
+    totalScores: {},
+    rpFactor: 1,
+    rpOrigin: 0,
+    umaDist: [],
+  }
+}
+
+function draw(tenpaiPlayerIds: number[]): RoundInfo {
+  const scores: Record<number, number> = {}
+  const noten = PLAYERS.filter((p) => !tenpaiPlayerIds.includes(p.id))
+  for (const p of PLAYERS) {
+    if (tenpaiPlayerIds.length === 0 || noten.length === 0) {
+      scores[p.id] = 0
+    } else {
+      scores[p.id] = tenpaiPlayerIds.includes(p.id) ? 3000 / tenpaiPlayerIds.length : -3000 / noten.length
+    }
+  }
+  return { roundNumber: 1, scores, tenpaiPlayerIds }
+}
+
+describe('deriveGameState: riichi ryuukyoku dealer rotation', () => {
+  it('全员未听 → 流庄, 本场 +1', () => {
+    const s = deriveGameState(session([draw([])]))
+    expect(s.dealerPlayerId).toBe(2)
+    expect(s.displayName).toBe('东2 1本场')
+  })
+
+  it('全员听牌 → 连庄, 本场 +1', () => {
+    const s = deriveGameState(session([draw([1, 2, 3, 4])]))
+    expect(s.dealerPlayerId).toBe(1)
+    expect(s.displayName).toBe('东1 1本场')
+  })
+
+  it('庄家听牌 (部分听) → 连庄', () => {
+    const s = deriveGameState(session([draw([1, 3])]))
+    expect(s.dealerPlayerId).toBe(1)
+    expect(s.displayName).toBe('东1 1本场')
+  })
+
+  it('庄家未听 (部分听) → 流庄, 本场 +1', () => {
+    const s = deriveGameState(session([draw([2, 3])]))
+    expect(s.dealerPlayerId).toBe(2)
+    expect(s.displayName).toBe('东2 1本场')
+  })
+
+  it('连续流局本场累加, 庄家轮转', () => {
+    const s = deriveGameState(session([draw([]), draw([]), draw([1, 2, 3, 4])]))
+    expect(s.dealerPlayerId).toBe(3)
+    expect(s.displayName).toBe('东3 3本场')
+  })
+
+  it('legacy 流局 (无听牌名单) 沿用点数推断', () => {
+    const notenDealer: RoundInfo = {
+      roundNumber: 1,
+      scores: { 1: -1500, 2: 1500, 3: 1500, 4: -1500 },
+    }
+    const s = deriveGameState(session([notenDealer]))
+    expect(s.dealerPlayerId).toBe(2)
+    expect(s.displayName).toBe('东2 1本场')
+  })
+
+  it('闲家和牌 → 流庄, 本场清零', () => {
+    const win: RoundInfo = { roundNumber: 1, scores: { 1: 0, 2: -3900, 3: 3900, 4: 0 }, winnerId: 3 }
+    const s = deriveGameState(session([draw([]), win]))
+    expect(s.dealerPlayerId).toBe(3)
+    expect(s.displayName).toBe('东3')
+  })
+
+  it('庄家和牌 → 连庄, 本场 +1', () => {
+    const win: RoundInfo = { roundNumber: 1, scores: { 1: 5800, 2: -5800, 3: 0, 4: 0 }, winnerId: 1 }
+    const s = deriveGameState(session([win]))
+    expect(s.dealerPlayerId).toBe(1)
+    expect(s.displayName).toBe('东1 1本场')
+  })
+
+  it('立直棒流局保留, 和牌清零', () => {
+    const drawWithRiichi: RoundInfo = { ...draw([2, 3]), riichiPlayerIds: [2, 3] }
+    expect(deriveGameState(session([drawWithRiichi])).kyoutaku).toBe(2000)
+    const win: RoundInfo = { roundNumber: 2, scores: { 1: -3900, 2: 3900, 3: 0, 4: 0 }, winnerId: 2 }
+    expect(deriveGameState(session([drawWithRiichi, win])).kyoutaku).toBe(0)
+  })
+})

--- a/ui/src/utils/gameState.ts
+++ b/ui/src/utils/gameState.ts
@@ -21,7 +21,12 @@ function dealerStaysAfterRound(gameMode: GameModeKey, round: RoundInfo, dealerPl
   if (round.winnerId === dealerPlayerId) return true
   if (round.winnerId == null) {
     if (gameMode === 'DONGBEI') return true
-    if (gameMode === 'RIICHI') return (round.scores[dealerPlayerId] ?? 0) >= 0
+    if (gameMode === 'RIICHI') {
+      // 庄家听牌才连庄, 未听则流庄
+      if (round.tenpaiPlayerIds) return round.tenpaiPlayerIds.includes(dealerPlayerId)
+      // Legacy rounds have no tenpai list: fall back to the point delta (全员未听 reads as 连庄)
+      return (round.scores[dealerPlayerId] ?? 0) >= 0
+    }
   }
   return false
 }
@@ -70,17 +75,17 @@ export function deriveGameState(session: SessionDetail): GameState {
     }
 
     const dealer = playersBySeat[seatIndex]
-    if (dealerStaysAfterRound(session.gameMode, round, dealer.id)) {
-      honba++
-    } else {
+    const dealerStays = dealerStaysAfterRound(session.gameMode, round, dealer.id)
+    if (!dealerStays) {
       seatIndex = (seatIndex + 1) % playerCount
       handNumber++
-      honba = 0
       if (handNumber > playerCount) {
         handNumber = 1
         prevalentWind++
       }
     }
+    // 流局必定加一本场, 即使流庄
+    honba = dealerStays || round.winnerId == null ? honba + 1 : 0
   }
 
   const dealer = playersBySeat[seatIndex]


### PR DESCRIPTION
## 问题

立直麻将流局时, 判断庄家连庄/流庄用的是**庄家点数变动** (`gameState.ts`):

```ts
if (gameMode === 'RIICHI') return (round.scores[dealerPlayerId] ?? 0) >= 0
```

但「全员听牌」和「全员未听」的点数变动**都是全 0**, 从分数上根本区分不了, 于是全员未听被判成连庄 —— 应该流庄到下一家。

| 场景 | 庄家点数变动 | 原判定 | 正确规则 |
|---|---|---|---|
| 庄家听牌 (部分听) | +1000 ~ +3000 | 连庄 ✅ | 连庄 |
| 庄家未听 (部分听) | −1000 ~ −3000 | 过庄 ✅ | 过庄 |
| 全员听牌 | 0 | 连庄 ✅ | 连庄 |
| **全员未听** | **0** | **连庄 ❌** | **流庄** |

根因是信息丢失: 听牌名单在 `RiichiModeHandler.calculateDrawnGame` 里算完点数就丢了, `Round` 实体存了 `riichiPlayerIds` 却没存 `tenpaiPlayerIds`。

顺带修同一段代码的第二个问题: 流局时若庄家流庄, `honba` 被重置为 0。立直规则是**流局必定 +1 本场**, 所以「东1 全员未听」应进「东2 一本场」, 原来会变成「东2 零本场」。

## 改动

**后端 —— 持久化听牌名单**
- `Round` 新增 `tenpaiPlayerIds` TEXT 列 (`ddl-auto: update` 自动加, 无需迁移)
- 落库时**空名单存 `""` 而不是不存**, 用来区分「全员未听」与「历史对局没有该字段」(`null`)
- 经 `SessionDetailResponse.RoundInfo` 回传前端; riichi 的解析逻辑一并收敛到 `parseIdList` 复用

**前端 —— 连庄判定改用听牌名单**
- `RIICHI` 流局: 庄家在听牌名单内才连庄; 名单为 `undefined` (老对局) 时保留原点数启发式兜底
- 本场与庄家轮转解耦: 流局一律 `honba + 1`, 即使流庄

## 验证

`./gradlew spotlessCheck pmdMain test` 全绿; ui 1320 个测试通过。

`ui/src/utils/__tests__/gameState.test.ts` (新建, 此前 `utils/` 无测试) 9 例:

- 全员未听 → 东2 1本场 (庄家换人) ← **本次修复点**
- 全员听牌 → 东1 1本场 (连庄)
- 庄家听牌 / 庄家未听 (部分听)
- 连续两次全员未听 + 一次全员听牌 → 东3 3本场
- 老数据无名单 → 沿用点数推断
- 闲家和牌本场清零 / 庄家和牌 +1本场
- 立直棒流局保留、和牌清零

`server/.../RoundTenpaiPersistenceTest.java` (新建, `@DataJpaTest`) 2 例: 专门验证 `""` vs `null` 的存取语义在 H2 上真的能区分 —— 这是本次唯一有风险的机制。

## 已知遗留

已录入的历史流局没有听牌名单, 回放时仍走点数兜底, 因此过去那些「全员未听」的对局在历史视图里依然显示连庄 —— 数据本身没存, 补不回来。只影响历史显示, 不影响任何积分/RP (点数变动本来就是对的)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenpai player information to round details, including support for drawn rounds.
  * Improved riichi game-state handling using tenpai data when available, while supporting legacy rounds.

* **Bug Fixes**
  * Corrected dealer continuation and honba progression after exhaustive and partial draws.
  * Preserved accurate riichi-stick behavior across wins and draws.

* **Tests**
  * Added coverage for draw outcomes, dealer rotation, legacy data, and scoring transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->