### PR TITLE
fix(ui): 修 session 页移动端 局 列 本场 溢出

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -898,7 +898,7 @@ table.auto-table {
 }
 
 .round-wind-tag {
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   background: var(--sol-base2);
   color: var(--sol-yellow);
   padding: 2px 6px;
@@ -906,6 +906,19 @@ table.auto-table {
   border: 1px solid var(--sol-base1);
   font-weight: 700;
   white-space: nowrap;
+
+  /* The 局 column is a fixed width, so clip rather than spill into the score columns.
+     With the （N）form this should not trigger; it is a backstop for a 2-digit 本场. */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (width <= 480px) {
+  .round-wind-tag {
+    font-size: 0.72rem;
+    padding: 2px 4px;
+  }
 }
 
 /* Best Hand Card */

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -17,6 +17,8 @@ import { Meld as GuobiaoMeld } from '../logic/guobiao/types'
 import { Meld as RiichiMeld } from '../logic/riichi/types'
 import { ImportedHand, toGuobiaoMelds, toRiichiMelds } from '../logic/shared/importedHand'
 
+const ROUND_COL_PX = 76
+
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>()
   const [session, setSession] = useState<SessionDetail | null>(null)
@@ -315,7 +317,7 @@ export default function SessionPage() {
     return state.displayName
   }
 
-  const fixedColPx = 60 + (session.status === 'IN_PROGRESS' ? 32 : 0)
+  const fixedColPx = ROUND_COL_PX + (session.status === 'IN_PROGRESS' ? 32 : 0)
   const playerColStyle = {
     textAlign: 'center' as const,
     verticalAlign: 'top' as const,
@@ -820,7 +822,7 @@ export default function SessionPage() {
           <table className="fixed-table">
             <thead>
               <tr>
-                <th style={{ textAlign: 'center', verticalAlign: 'top', width: '60px' }}>局</th>
+                <th style={{ textAlign: 'center', verticalAlign: 'top', width: `${ROUND_COL_PX}px` }}>局</th>
                 {session.players.map((p) => (
                   <th key={p.id} style={playerColStyle}>
                     <div className="player-header-cell">

--- a/ui/src/utils/__tests__/gameState.test.ts
+++ b/ui/src/utils/__tests__/gameState.test.ts
@@ -46,31 +46,31 @@ describe('deriveGameState: riichi ryuukyoku dealer rotation', () => {
   it('全员未听 → 流庄, 本场 +1', () => {
     const s = deriveGameState(session([draw([])]))
     expect(s.dealerPlayerId).toBe(2)
-    expect(s.displayName).toBe('东2 1本场')
+    expect(s.displayName).toBe('东2（1）')
   })
 
   it('全员听牌 → 连庄, 本场 +1', () => {
     const s = deriveGameState(session([draw([1, 2, 3, 4])]))
     expect(s.dealerPlayerId).toBe(1)
-    expect(s.displayName).toBe('东1 1本场')
+    expect(s.displayName).toBe('东1（1）')
   })
 
   it('庄家听牌 (部分听) → 连庄', () => {
     const s = deriveGameState(session([draw([1, 3])]))
     expect(s.dealerPlayerId).toBe(1)
-    expect(s.displayName).toBe('东1 1本场')
+    expect(s.displayName).toBe('东1（1）')
   })
 
   it('庄家未听 (部分听) → 流庄, 本场 +1', () => {
     const s = deriveGameState(session([draw([2, 3])]))
     expect(s.dealerPlayerId).toBe(2)
-    expect(s.displayName).toBe('东2 1本场')
+    expect(s.displayName).toBe('东2（1）')
   })
 
   it('连续流局本场累加, 庄家轮转', () => {
     const s = deriveGameState(session([draw([]), draw([]), draw([1, 2, 3, 4])]))
     expect(s.dealerPlayerId).toBe(3)
-    expect(s.displayName).toBe('东3 3本场')
+    expect(s.displayName).toBe('东3（3）')
   })
 
   it('legacy 流局 (无听牌名单) 沿用点数推断', () => {
@@ -80,7 +80,7 @@ describe('deriveGameState: riichi ryuukyoku dealer rotation', () => {
     }
     const s = deriveGameState(session([notenDealer]))
     expect(s.dealerPlayerId).toBe(2)
-    expect(s.displayName).toBe('东2 1本场')
+    expect(s.displayName).toBe('东2（1）')
   })
 
   it('闲家和牌 → 流庄, 本场清零', () => {
@@ -94,7 +94,7 @@ describe('deriveGameState: riichi ryuukyoku dealer rotation', () => {
     const win: RoundInfo = { roundNumber: 1, scores: { 1: 5800, 2: -5800, 3: 0, 4: 0 }, winnerId: 1 }
     const s = deriveGameState(session([win]))
     expect(s.dealerPlayerId).toBe(1)
-    expect(s.displayName).toBe('东1 1本场')
+    expect(s.displayName).toBe('东1（1）')
   })
 
   it('立直棒流局保留, 和牌清零', () => {

--- a/ui/src/utils/gameState.ts
+++ b/ui/src/utils/gameState.ts
@@ -97,7 +97,7 @@ export function deriveGameState(session: SessionDetail): GameState {
     handNumber,
     honba,
     kyoutaku,
-    displayName: honba > 0 ? `${windHand} ${honba}本场` : windHand,
+    displayName: honba > 0 ? `${windHand}（${honba}）` : windHand,
     playerCount,
   }
 }


### PR DESCRIPTION
## 问题

移动端 session 页，记分表 `局` 列显示 `东N M本场` 时内容显示不全。表格是 `table-layout: fixed`，列宽写死 60px，而单元格是 `white-space: nowrap`，所以文字直接溢出。

## 改动

**1. 本场 格式改为 `东N（M）`**（`gameState.ts`）
`东2 1本场` → `东2（1）`。

**2. `局` 列宽提取为 `ROUND_COL_PX` 常量**（`SessionPage.tsx`）
原来 `60` 分别写在表头 `width: "60px"` 和玩家列宽计算 `fixedColPx = 60 + ...` 两处，各自写死、改一处就会漂移。现在共用一个常量，取 76px。

**3. 字号与溢出兜底**（`index.css`）
`.round-wind-tag` 0.85rem → 0.78rem，≤480px 再降到 0.72rem；补 `max-width / overflow / text-overflow`，万一 本场 到两位数只会截断，不会溢出挤压分数列。

**4. 同步更新 `gameState.test.ts` 5 处断言**（原先断言 `"东2 1本场"` 这类字符串）。

## 关于宽度取值

原本想用 headless Chrome 实测文字宽度，但本机 Chrome 无法启动（`Failed to bind() SingletonSocket`），所以宽度是按字体度量推算的：PingFang 里全角括号 `（）` 各占 1em（与汉字同宽），`东2（10）` ≈ 4.65em，0.78rem 下约 58px，加 padding/border 约 72px，故列宽取 76px。

单个 本场 余量充足，两位数也在范围内；但**这是推算值，建议在真机上确认一次**。若仍偏紧，可改半角 `(N)`（省约 1.4em）或再加几 px。

## 影响面

`displayName` 全仓库只有 3 处渲染、无任何解析逻辑，后端不涉及：

- session 记分表 `局` 列（本次问题）
- session 记分表单标题 `添加 — 东1（1）`
- 首页对局卡片 `东1（1） 进行中`

后两处也一并变短。

## 验证

`tsc` / `stylelint` / 1344 个测试 / pre-commit 五项检查全部通过。