### PR TITLE
fix(ui): 移动端截断修复 + 记分表单精简 + 和牌者选择改为点击循环

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/AddRoundRequest.java
@@ -38,8 +38,6 @@ public class AddRoundRequest {
 
   private List<Long> riichiPlayerIds; // players who declared riichi
 
-  private Boolean backfill;
-
   private String winHand;
 
   private String fanDetails;

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -62,6 +62,5 @@ public class SessionDetailResponse {
     private Integer prevalentWind;
     private List<Long> riichiPlayerIds;
     private List<Long> tenpaiPlayerIds;
-    private Boolean backfill;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/model/Round.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Round.java
@@ -46,6 +46,4 @@ public class Round {
 
   @Column(columnDefinition = "TEXT")
   private String tenpaiPlayerIds;
-
-  private Boolean backfill;
 }

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -451,8 +451,7 @@ public class GameService {
                       dealInName,
                       round.getPrevalentWind(),
                       riichiIds,
-                      tenpaiIds,
-                      round.getBackfill());
+                      tenpaiIds);
                 })
             .collect(Collectors.toList()));
 
@@ -540,8 +539,7 @@ public class GameService {
         request.isSelfDraw() ? null : request.getDealInPlayerId(),
         request.getPrevalentWind(),
         request.getRiichiPlayerIds(),
-        request.getTenpaiPlayerIds(),
-        request.getBackfill());
+        request.getTenpaiPlayerIds());
     evictAllCaches();
   }
 
@@ -1135,8 +1133,7 @@ public class GameService {
       Long dealInId,
       Integer prevalentWind,
       List<Long> riichiPlayerIds,
-      List<Long> tenpaiPlayerIds,
-      Boolean backfill) {
+      List<Long> tenpaiPlayerIds) {
     Round round = new Round();
     round.setGameSession(session);
     round.setRoundNumber(roundNumber);
@@ -1146,7 +1143,6 @@ public class GameService {
     round.setFanCount(fanCount);
     round.setDealInPlayerId(dealInId);
     round.setPrevalentWind(prevalentWind);
-    round.setBackfill(Boolean.TRUE.equals(backfill) ? true : null);
     if (riichiPlayerIds != null && !riichiPlayerIds.isEmpty()) {
       round.setRiichiPlayerIds(
           riichiPlayerIds.stream().map(String::valueOf).collect(Collectors.joining(",")));

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { scoreClass, seatRankMedal } from '../utils/format'
-import { nameFontSize } from '../utils/fontSize'
+import { tableNameFontSize } from '../utils/fontSize'
+import { useIsMobile } from '../hooks/useIsMobile'
 import { TierKey } from '../types'
 import { RankBadge } from './RankBadge'
 import { TableStrengthTag } from './TableStrengthTag'
@@ -48,6 +49,7 @@ export const GameCard: React.FC<Props> = ({
   tableStrength,
 }) => {
   const navigate = useNavigate()
+  const isMobile = useIsMobile()
   const [fullscreen, setFullscreen] = useState(false)
   const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const closeBtnRef = useRef<HTMLButtonElement>(null)
@@ -185,7 +187,7 @@ export const GameCard: React.FC<Props> = ({
                 </span>
                 {p.wind && <span className={`wind-tag ${p.isDealer ? 'wind-tag-dealer' : ''}`}>{p.wind}</span>}
                 <RankBadge tier={p.tier} size="sm" userName={p.name} />
-                <span className="player-name" style={{ fontSize: nameFontSize(p.name) }}>
+                <span className="player-name" style={{ fontSize: tableNameFontSize(p.name, isMobile) }}>
                   {p.name}
                 </span>
               </span>

--- a/ui/src/hooks/useIsMobile.ts
+++ b/ui/src/hooks/useIsMobile.ts
@@ -4,13 +4,23 @@ import { MOBILE_BREAKPOINT } from '../utils/fontSize'
 const QUERY = `(max-width: ${MOBILE_BREAKPOINT}px)`
 
 /**
+ * matchMedia 在浏览器里一定存在, 但 vitest 默认跑在 node 环境 —— 一旦有组件测试渲染用了本 hook
+ * 的组件, 不做判断会在任何断言之前就抛错. 取不到时按桌面处理.
+ */
+function queryMatches(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(QUERY).matches
+}
+
+/**
  * 订阅式的移动端断点判断. 直接读 window.innerWidth 不会触发 React 重渲染, 所以旋转屏幕或缩放窗口
  * 跨过断点后, 内联算出来的字号会一直停在旧值 —— 用 matchMedia 的 change 事件把它变成状态.
  */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(() => window.matchMedia(QUERY).matches)
+  const [isMobile, setIsMobile] = useState(queryMatches)
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
     const mql = window.matchMedia(QUERY)
     // 挂载时同步一次: 首次 render 到 effect 执行之间视口可能已经变了.
     setIsMobile(mql.matches)

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -898,7 +898,7 @@ table.auto-table {
 }
 
 .round-wind-tag {
-  font-size: 0.78rem;
+  font-size: 0.85rem;
   background: var(--sol-base2);
   color: var(--sol-yellow);
   padding: 2px 6px;
@@ -906,19 +906,9 @@ table.auto-table {
   border: 1px solid var(--sol-base1);
   font-weight: 700;
   white-space: nowrap;
-
-  /* The 局 column is a fixed width, so clip rather than spill into the score columns.
-     With the （N）form this should not trigger; it is a backstop for a 2-digit 本场. */
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-@media (width <= 480px) {
-  .round-wind-tag {
-    font-size: 0.72rem;
-    padding: 2px 4px;
-  }
 }
 
 /* Best Hand Card */

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1821,13 +1821,8 @@ table.auto-table {
   }
 
   .round-form .score-inline-group {
-    flex-wrap: nowrap !important;
+    flex-wrap: wrap;
     width: 100%;
-  }
-
-  .round-form .score-input-compact {
-    flex: 1 !important;
-    max-width: none !important;
   }
 
   .options-grid.compact.cols-3 {
@@ -2714,12 +2709,6 @@ table.auto-table {
   font-weight: 700;
 }
 
-.round-form .score-input-compact {
-  flex: 1;
-  max-width: 280px;
-  padding: 6px 10px;
-}
-
 .round-form .form-section-title {
   background: var(--sol-base3);
   font-size: 0.85rem;
@@ -3447,13 +3436,17 @@ table.auto-table {
 /* ==========================================================================
    Photo Recognition (AI 3.6 Flash) Styles
    ========================================================================== */
-.calc-header-bar {
+.calc-photo-rec-row {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  justify-content: flex-end;
   margin-bottom: 12px;
-  flex-wrap: wrap;
-  gap: 12px;
+}
+
+@media (width <= 600px) {
+  .calc-photo-rec-row .btn-photo-rec {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 .calc-tabs {
@@ -4229,10 +4222,4 @@ table.auto-table {
   background: rgb(0 0 0 / 90%);
   border-color: #fff;
   transform: translateY(-1px);
-}
-
-/* Inline variant used by the in-progress round form, next to 重置 */
-.btn-photo-rec-compact {
-  padding: 6px 12px;
-  font-size: 0.8rem;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2090,10 +2090,6 @@ table.auto-table {
     max-width: 18px;
   }
 
-  .win-action-row-three {
-    flex-direction: column;
-  }
-
   .claim-name-row {
     flex-direction: column;
     gap: 12px;
@@ -2584,18 +2580,6 @@ table.auto-table {
   margin-bottom: 8px;
 }
 
-/* Always keep 点炮/自摸 and 重置 on the same row */
-.win-action-row {
-  grid-column: 1 / -1;
-  display: flex;
-  gap: 8px;
-  width: 100%;
-}
-
-.win-action-row .quick-player-btn {
-  flex: 1;
-}
-
 .quick-player-btn {
   width: 100%;
   padding: 6px 28px 6px 10px; /* Increased right padding to avoid badge overlap */
@@ -2644,15 +2628,6 @@ table.auto-table {
   box-shadow: 0 0 0 1px var(--sol-red);
 }
 
-.quick-player-btn.win-type-btn {
-  border-color: var(--sol-blue) !important;
-  color: var(--sol-blue) !important;
-  background: rgb(38 139 210 / 4%) !important;
-  font-weight: 700;
-  border-width: 1.5px !important;
-  transition: all 0.2s ease;
-}
-
 .quick-player-btn.reset-btn {
   border-color: var(--primary);
   color: var(--primary);
@@ -2661,18 +2636,6 @@ table.auto-table {
 
 .quick-player-btn.reset-btn:hover {
   background: rgb(7 54 66 / 14%);
-}
-
-.quick-player-btn.win-type-btn:hover:not(:disabled) {
-  background: rgb(38 139 210 / 12%) !important;
-  transform: translateY(-2px);
-}
-
-.quick-player-btn.win-type-btn.active {
-  border-color: var(--sol-blue) !important;
-  color: white !important;
-  background: var(--sol-blue) !important;
-  box-shadow: 0 2px 5px rgb(38 139 210 / 30%) !important;
 }
 
 .round-form .score-inline-group {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -877,10 +877,9 @@ table.auto-table {
 }
 
 .player-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* 永不截断: 名字再长也要完整显示, 装不下就折行 (最长基准 WalkingAFK). */
   max-width: 100%;
+  overflow-wrap: anywhere;
   font-weight: 500;
 }
 
@@ -897,6 +896,28 @@ table.auto-table {
   margin-top: 2px;
 }
 
+/* 对局记分表在手机上的收紧 —— 与统计表同一套思路.
+   393px 视口的宽度预算: 393 −32(main) −32(card) = 329px 表宽,
+   局列 68 + 删除列 32 + 4×玩家列 57 = 328px. 单元格 padding 收到 4px、
+   分数缩到 0.8rem 才腾得出这个空间, 否则六位数分数和 局 标签都会挤出格子. */
+@media (width <= 640px) {
+  table.session-rounds-table th,
+  table.session-rounds-table td {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+
+  .session-rounds-table .score-cell,
+  .session-rounds-table .total-val {
+    font-size: 0.8rem;
+  }
+
+  .session-rounds-table .round-wind-tag {
+    font-size: 0.8rem;
+    padding: 2px 4px;
+  }
+}
+
 .round-wind-tag {
   font-size: 0.85rem;
   background: var(--sol-base2);
@@ -906,9 +927,6 @@ table.auto-table {
   border: 1px solid var(--sol-base1);
   font-weight: 700;
   white-space: nowrap;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* Best Hand Card */
@@ -1095,9 +1113,8 @@ table.auto-table {
 }
 
 .player-select-card div {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* 玩家名永不截断 (基准 WalkingAFK): 装不下就折行. */
+  overflow-wrap: anywhere;
 }
 
 .player-select-card.selected {
@@ -2914,9 +2931,9 @@ table.auto-table {
   font-size: 0.75rem;
   margin-top: 4px;
   color: var(--sol-base01);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+
+  /* 番种列表可以很长, 折行显示完整内容而不是截断. */
+  overflow-wrap: anywhere;
 }
 
 /* Dashboard Header */
@@ -3045,10 +3062,7 @@ table.auto-table {
   font-weight: 600;
   color: var(--primary);
   font-size: 0.9rem;
-  max-width: 120px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
 }
 
 .game-card .player-score {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2682,6 +2682,20 @@ table.auto-table {
   font-weight: 700;
 }
 
+/* Must follow the desktop rule above: same specificity, and a media query adds none,
+   so source order decides. Stacking stops the lone pill button hugging the left edge. */
+@media (width <= 640px) {
+  .round-form .score-inline-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .round-form .score-inline-group .btn-photo-rec {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 .round-form .form-section-title {
   background: var(--sol-base3);
   font-size: 0.85rem;
@@ -3415,15 +3429,11 @@ table.auto-table {
   margin-bottom: 12px;
 }
 
-@media (width <= 600px) {
+@media (width <= 640px) {
   .calc-photo-rec-row .btn-photo-rec {
     width: 100%;
     justify-content: center;
   }
-}
-
-.calc-tabs {
-  margin-bottom: 0 !important;
 }
 
 .btn-photo-rec {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -979,16 +979,6 @@ table.auto-table {
   font-weight: 800;
 }
 
-.loser-label {
-  color: var(--mj-red);
-  font-weight: 800;
-}
-
-.zimo-label {
-  color: var(--sol-blue);
-  font-style: italic;
-}
-
 .session-link-label a {
   color: var(--sol-cyan);
   text-decoration: underline;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2668,33 +2668,6 @@ table.auto-table {
   box-shadow: 0 2px 5px rgb(38 139 210 / 30%) !important;
 }
 
-.reset-btn-score-compact {
-  padding: 4px 0 !important;
-  font-size: 0.75rem !important;
-  height: 28px !important;
-  line-height: 1 !important;
-  border-radius: 4px !important;
-  border: 1px solid var(--sol-yellow) !important;
-  background: rgb(181 137 0 / 5%) !important;
-  color: var(--sol-yellow) !important;
-  cursor: pointer !important;
-  white-space: nowrap !important;
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  flex-shrink: 0 !important;
-  width: 52px !important;
-  font-weight: 700 !important;
-  box-shadow: none !important;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.reset-btn-score-compact:hover {
-  background: rgb(181 137 0 / 15%) !important;
-  border-color: var(--sol-yellow) !important;
-  color: var(--sol-yellow) !important;
-}
-
 .round-form .score-inline-group {
   display: flex;
   flex-direction: row;

--- a/ui/src/logic/shared/__tests__/winSelection.test.ts
+++ b/ui/src/logic/shared/__tests__/winSelection.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { nextWinSelection, EMPTY_WIN_SELECTION, WinSelection } from '../winSelection'
+
+/** 连点若干下, 返回最终状态. allowChombo 对应国标. */
+function taps(pids: string[], allowChombo: boolean, from: WinSelection = EMPTY_WIN_SELECTION) {
+  return pids.reduce((cur, pid) => nextWinSelection(cur, pid, allowChombo), from)
+}
+
+describe('nextWinSelection: 点击循环', () => {
+  it('点空位 → 该玩家和牌, 默认点炮', () => {
+    expect(taps(['A'], false)).toEqual({ winnerId: 'A', dealInPlayerId: '', kind: 'ron' })
+  })
+
+  it('再点同一人 → 自摸', () => {
+    expect(taps(['A', 'A'], false)).toEqual({ winnerId: 'A', dealInPlayerId: '', kind: 'tsumo' })
+  })
+
+  it('国标第三下 → 诈胡', () => {
+    expect(taps(['A', 'A', 'A'], true)).toEqual({ winnerId: 'A', dealInPlayerId: '', kind: 'chombo' })
+  })
+
+  it('国标第四下 → 清空', () => {
+    expect(taps(['A', 'A', 'A', 'A'], true)).toEqual(EMPTY_WIN_SELECTION)
+  })
+
+  it('非国标没有诈胡, 第三下就清空', () => {
+    expect(taps(['A', 'A', 'A'], false)).toEqual(EMPTY_WIN_SELECTION)
+  })
+})
+
+describe('nextWinSelection: 点炮者', () => {
+  it('点炮模式下点另一人 → 指定点炮者', () => {
+    expect(taps(['A', 'B'], false)).toEqual({ winnerId: 'A', dealInPlayerId: 'B', kind: 'ron' })
+  })
+
+  it('再点同一个点炮者 → 取消', () => {
+    expect(taps(['A', 'B', 'B'], false)).toEqual({ winnerId: 'A', dealInPlayerId: '', kind: 'ron' })
+  })
+
+  it('点第三人 → 换点炮者', () => {
+    expect(taps(['A', 'B', 'C'], false)).toEqual({ winnerId: 'A', dealInPlayerId: 'C', kind: 'ron' })
+  })
+
+  // 核心诉求: 和牌者与点炮者不会因为点击顺序而互换
+  it('先点的人始终是和牌者, 不会被后点的人顶掉', () => {
+    const s = taps(['A', 'B'], false)
+    expect(s.winnerId).toBe('A')
+    expect(s.dealInPlayerId).toBe('B')
+  })
+
+  it('切到自摸时清掉已选的点炮者', () => {
+    expect(taps(['A', 'B', 'A'], false)).toEqual({ winnerId: 'A', dealInPlayerId: '', kind: 'tsumo' })
+  })
+
+  it('切到诈胡时也清掉点炮者', () => {
+    expect(taps(['A', 'B', 'A', 'A'], true)).toEqual({ winnerId: 'A', dealInPlayerId: '', kind: 'chombo' })
+  })
+})
+
+describe('nextWinSelection: 自摸/诈胡下换人', () => {
+  it('自摸下点另一人 → 换和牌者并保留自摸', () => {
+    expect(taps(['A', 'A', 'B'], false)).toEqual({ winnerId: 'B', dealInPlayerId: '', kind: 'tsumo' })
+  })
+
+  it('诈胡下点另一人 → 换诈胡者并保留诈胡', () => {
+    expect(taps(['A', 'A', 'A', 'B'], true)).toEqual({ winnerId: 'B', dealInPlayerId: '', kind: 'chombo' })
+  })
+
+  it('换人后循环从当前胡法继续推进, 而不是从头开始', () => {
+    // A 自摸 → 换成 B(仍自摸) → 再点 B 应进入诈胡(国标)
+    expect(taps(['A', 'A', 'B', 'B'], true)).toEqual({ winnerId: 'B', dealInPlayerId: '', kind: 'chombo' })
+  })
+})
+
+describe('nextWinSelection: 不变量', () => {
+  it('自摸与诈胡下永远没有点炮者', () => {
+    const seqs = [
+      ['A', 'A'],
+      ['A', 'B', 'A'],
+      ['A', 'A', 'B'],
+      ['A', 'A', 'A'],
+      ['A', 'B', 'A', 'A'],
+      ['A', 'A', 'A', 'B'],
+    ]
+    for (const seq of seqs) {
+      const s = taps(seq, true)
+      if (s.kind !== 'ron') expect(s.dealInPlayerId).toBe('')
+    }
+  })
+
+  it('点炮者永远不等于和牌者', () => {
+    for (const seq of [
+      ['A', 'B'],
+      ['A', 'B', 'C'],
+      ['A', 'A', 'B', 'C'],
+      ['A', 'B', 'A', 'A'],
+    ]) {
+      const s = taps(seq, true)
+      if (s.dealInPlayerId) expect(s.dealInPlayerId).not.toBe(s.winnerId)
+    }
+  })
+
+  it('清空后是干净状态, 可以重新开始', () => {
+    const cleared = taps(['A', 'A', 'A'], false)
+    expect(cleared).toEqual(EMPTY_WIN_SELECTION)
+    expect(taps(['B'], false, cleared)).toEqual({ winnerId: 'B', dealInPlayerId: '', kind: 'ron' })
+  })
+})

--- a/ui/src/logic/shared/winSelection.ts
+++ b/ui/src/logic/shared/winSelection.ts
@@ -1,0 +1,50 @@
+/** 和牌方式. `ron` = 点炮和, 需要一名点炮者; `tsumo` / `chombo` 不需要. */
+export type WinKind = 'ron' | 'tsumo' | 'chombo'
+
+export interface WinSelection {
+  /** 和牌者(诈胡时为诈胡者); 空串表示未选. */
+  winnerId: string
+  /** 点炮者; 空串表示未选. 仅 `ron` 有意义. */
+  dealInPlayerId: string
+  kind: WinKind
+}
+
+export const EMPTY_WIN_SELECTION: WinSelection = { winnerId: '', dealInPlayerId: '', kind: 'ron' }
+
+/**
+ * 点一下玩家按钮后的新状态 —— 一个按钮承担"选人"和"定胡法"两件事, 靠点击次数区分,
+ * 与流局分支的 立直/默听 循环同一套交互.
+ *
+ * <p>规则:
+ * <ul>
+ *   <li>点未选中的人, 且还没有和牌者 → 他成为和牌者, 胡法默认 ron
+ *   <li>反复点和牌者 → ron → tsumo →(允许时) chombo → 全部清空
+ *   <li>ron 下点另一个人 → 指定/取消点炮者
+ *   <li>tsumo / chombo 下点另一个人 → 换和牌者, 保留当前胡法(不需要点炮者)
+ * </ul>
+ *
+ * <p>为什么是纯函数: 这套循环分支不少, 直接写在组件里只能靠手点验证; 抽出来才能穷举测试。
+ */
+export function nextWinSelection(cur: WinSelection, pid: string, allowChombo: boolean): WinSelection {
+  if (cur.winnerId === pid) {
+    if (cur.kind === 'ron') {
+      // 自摸没有点炮者, 顺手清掉之前可能已经选上的人
+      return { winnerId: pid, dealInPlayerId: '', kind: 'tsumo' }
+    }
+    if (cur.kind === 'tsumo' && allowChombo) {
+      return { winnerId: pid, dealInPlayerId: '', kind: 'chombo' }
+    }
+    return EMPTY_WIN_SELECTION
+  }
+
+  if (cur.winnerId && cur.kind === 'ron') {
+    return { ...cur, dealInPlayerId: cur.dealInPlayerId === pid ? '' : pid }
+  }
+
+  // 没有和牌者(此时 kind 归位到 ron), 或 tsumo/chombo 下换人(保留胡法)
+  return {
+    winnerId: pid,
+    dealInPlayerId: '',
+    kind: cur.winnerId ? cur.kind : 'ron',
+  }
+}

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -67,22 +67,22 @@ const CalculatorPage: React.FC = () => {
 
   return (
     <div className="container calc-page-wrapper">
-      <div className="calc-header-bar">
-        <div className="tabs">
-          <button
-            className={`calc-mode-tab-btn ${activeTab === 'GUOBIAO' ? 'active' : ''}`}
-            onClick={() => setActiveTab('GUOBIAO')}
-          >
-            国标算番器
-          </button>
-          <button
-            className={`calc-mode-tab-btn ${activeTab === 'RIICHI' ? 'active' : ''}`}
-            onClick={() => setActiveTab('RIICHI')}
-          >
-            立直算番器
-          </button>
-        </div>
+      <div className="tabs">
+        <button
+          className={`calc-mode-tab-btn ${activeTab === 'GUOBIAO' ? 'active' : ''}`}
+          onClick={() => setActiveTab('GUOBIAO')}
+        >
+          国标算番器
+        </button>
+        <button
+          className={`calc-mode-tab-btn ${activeTab === 'RIICHI' ? 'active' : ''}`}
+          onClick={() => setActiveTab('RIICHI')}
+        >
+          立直算番器
+        </button>
+      </div>
 
+      <div className="calc-photo-rec-row">
         <button className="btn-photo-rec" onClick={() => setIsPhotoModalOpen(true)}>
           <span className="btn-photo-rec-icon">📷</span>
           <span>拍照识别</span>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -37,7 +37,6 @@ export default function SessionPage() {
   const [fanDetails, setFanDetails] = useState<string>('')
   const [fanCount, setFanCount] = useState<number>(0)
   const [tsumoDetail, setTsumoDetail] = useState<{ dealer: number; nonDealer: number } | null>(null)
-  const [isBackfill, setIsBackfill] = useState(false)
   const [isChomboManual, setIsChomboManual] = useState(false)
   const [calcError, setCalcError] = useState('')
   const [error, setError] = useState('')
@@ -125,7 +124,6 @@ export default function SessionPage() {
     setFanDetails('')
     setFanCount(0)
     setTsumoDetail(null)
-    setIsBackfill(false)
     setIsChomboManual(false)
     setCalcError('')
     setCalcResetCount((prev) => prev + 1)
@@ -203,7 +201,6 @@ export default function SessionPage() {
           winHand,
           fanDetails,
           riichiPlayerIds: riichiPlayerIds.length > 0 ? riichiPlayerIds : undefined,
-          backfill: isBackfill || undefined,
         })
       } else if (isDongbei) {
         await addRound(session.id, {
@@ -619,10 +616,6 @@ export default function SessionPage() {
                         <span>拍照识别</span>
                         <span className="btn-photo-rec-badge">AI 识别</span>
                       </button>
-                      <label className="checkbox-toggle">
-                        <input type="checkbox" checked={isBackfill} onChange={(e) => setIsBackfill(e.target.checked)} />
-                        <span>补录 (不计入局数)</span>
-                      </label>
                     </div>
                     <div className="inline-calc-wrapper">
                       <RiichiCalculator

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -17,6 +17,7 @@ import { PhotoRecognitionModal, RecognizedHand } from '../components/PhotoRecogn
 import { Meld as GuobiaoMeld } from '../logic/guobiao/types'
 import { Meld as RiichiMeld } from '../logic/riichi/types'
 import { ImportedHand, toGuobiaoMelds, toRiichiMelds } from '../logic/shared/importedHand'
+import { nextWinSelection } from '../logic/shared/winSelection'
 
 const ROUND_COL_PX = 68
 
@@ -133,21 +134,24 @@ export default function SessionPage() {
     setRiichiImportedHand(null)
   }
 
+  /**
+   * 一个按钮承担"选人"和"定胡法"两件事, 靠点几下区分 —— 循环规则见 nextWinSelection,
+   * 那边是纯函数并有穷举测试, 这里只做状态映射。
+   */
   const handlePlayerClick = (pid: string) => {
-    if (winnerId === pid) {
-      setWinnerId('')
-      setDealInPlayerId('')
-      setIsSelfDraw(false)
-    } else if (dealInPlayerId === pid) {
-      setDealInPlayerId('')
-      setIsSelfDraw(false)
-    } else if (!winnerId) {
-      setWinnerId(pid)
-      setIsSelfDraw(false)
-    } else {
-      setDealInPlayerId(pid)
-      setIsSelfDraw(false)
-    }
+    const next = nextWinSelection(
+      {
+        winnerId,
+        dealInPlayerId,
+        kind: isChomboManual ? 'chombo' : isSelfDraw ? 'tsumo' : 'ron',
+      },
+      pid,
+      isGuobiao
+    )
+    setWinnerId(next.winnerId)
+    setDealInPlayerId(next.dealInPlayerId)
+    setIsSelfDraw(next.kind === 'tsumo')
+    setIsChomboManual(next.kind === 'chombo')
   }
 
   const canSubmit =
@@ -544,8 +548,23 @@ export default function SessionPage() {
                         <button key={p.id} className={btnClass} onClick={() => handlePlayerClick(String(p.id))}>
                           <div className="btn-name">{p.userName}</div>
                           <div className={`btn-wind${p.id === gameState.dealerPlayerId ? ' btn-wind-dealer' : ''}`}>
-                            {getWindName(getPlayerMenfeng(getPlayerSeat(p, idx)))}
-                            {p.id === gameState.dealerPlayerId ? ' 庄' : ''}
+                            {/* 选中后第二行改写角色, 让"谁是什么"看文字而不是记颜色 —— 同流局分支. */}
+                            {isWinner ? (
+                              isChomboManual ? (
+                                '诈胡'
+                              ) : isSelfDraw ? (
+                                '自摸'
+                              ) : (
+                                '和牌'
+                              )
+                            ) : isLoser && !isChomboManual && !isSelfDraw ? (
+                              '点炮'
+                            ) : (
+                              <>
+                                {getWindName(getPlayerMenfeng(getPlayerSeat(p, idx)))}
+                                {p.id === gameState.dealerPlayerId ? ' 庄' : ''}
+                              </>
+                            )}
                           </div>
                         </button>
                       )
@@ -571,6 +590,7 @@ export default function SessionPage() {
                         onClick={() => {
                           setIsSelfDraw(true)
                           setIsChomboManual(false)
+                          setDealInPlayerId('')
                         }}
                       >
                         自摸
@@ -582,6 +602,7 @@ export default function SessionPage() {
                           onClick={() => {
                             setIsSelfDraw(false)
                             setIsChomboManual(true)
+                            setDealInPlayerId('')
                           }}
                         >
                           诈胡
@@ -589,6 +610,15 @@ export default function SessionPage() {
                       )}
                     </div>
                   </div>
+                  <span className="field-hint">
+                    {!winnerId
+                      ? '点一下选和牌者'
+                      : isChomboManual
+                      ? '再点一下清空重选'
+                      : isSelfDraw
+                      ? `自摸无需选点炮者 · 再点${isGuobiao ? '一下改诈胡' : '一下清空'}`
+                      : '再点和牌者可切自摸' + (isGuobiao ? '/诈胡' : '') + ' · 另点一人为点炮者'}
+                  </span>
                 </div>
 
                 {isRiichi && (

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -17,7 +17,7 @@ import { Meld as GuobiaoMeld } from '../logic/guobiao/types'
 import { Meld as RiichiMeld } from '../logic/riichi/types'
 import { ImportedHand, toGuobiaoMelds, toRiichiMelds } from '../logic/shared/importedHand'
 
-const ROUND_COL_PX = 76
+const ROUND_COL_PX = 62
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>()
@@ -925,7 +925,7 @@ export default function SessionPage() {
                     >
                       <div className="total-score-box">
                         <div className="total-val">{displayVal}</div>
-                        {rankDelta != null && <div className="rank-delta-val">{formatDelta(rankDelta)} 段位分</div>}
+                        {rankDelta != null && <div className="rank-delta-val">{formatDelta(rankDelta)}</div>}
                       </div>
                     </td>
                   )

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -614,30 +614,10 @@ export default function SessionPage() {
                 {isRiichi && (
                   <div className="form-group">
                     <div className="score-inline-group">
-                      <label>分数</label>
-                      <input
-                        type="text"
-                        inputMode="numeric"
-                        value={score}
-                        onChange={(e) => {
-                          setScore(e.target.value)
-                          setTsumoDetail(null)
-                          setWinHand('')
-                          setFanDetails('')
-                          setFanCount(0)
-                        }}
-                        placeholder="输入分数"
-                        className="score-input-compact"
-                      />
-                      <button type="button" className="reset-btn-score-compact" onClick={resetForm}>
-                        重置
-                      </button>
-                      <button
-                        type="button"
-                        className="btn-photo-rec btn-photo-rec-compact"
-                        onClick={() => setIsPhotoModalOpen(true)}
-                      >
-                        📷 拍照识别
+                      <button type="button" className="btn-photo-rec" onClick={() => setIsPhotoModalOpen(true)}>
+                        <span className="btn-photo-rec-icon">📷</span>
+                        <span>拍照识别</span>
+                        <span className="btn-photo-rec-badge">AI 识别</span>
                       </button>
                       <label className="checkbox-toggle">
                         <input type="checkbox" checked={isBackfill} onChange={(e) => setIsBackfill(e.target.checked)} />
@@ -686,33 +666,16 @@ export default function SessionPage() {
 
                 {!isRiichi && isGuobiao && (
                   <div className="form-group">
-                    <div className="score-inline-group">
-                      <label>分数</label>
-                      <input
-                        type="text"
-                        inputMode="numeric"
-                        value={score}
-                        onChange={(e) => {
-                          setScore(e.target.value)
-                          setWinHand('')
-                          setFanDetails('')
-                          setFanCount(0)
-                        }}
-                        placeholder={isChomboManual ? '诈胡免输分数' : '输入分数'}
-                        className="score-input-compact"
-                        disabled={isChomboManual}
-                      />
-                      <button type="button" className="reset-btn-score-compact" onClick={resetForm}>
-                        重置
-                      </button>
-                      <button
-                        type="button"
-                        className="btn-photo-rec btn-photo-rec-compact"
-                        onClick={() => setIsPhotoModalOpen(true)}
-                      >
-                        📷 拍照识别
-                      </button>
-                    </div>
+                    {/* 诈胡 hides the calculator and needs no score, so the importer is moot too. */}
+                    {!isChomboManual && (
+                      <div className="score-inline-group">
+                        <button type="button" className="btn-photo-rec" onClick={() => setIsPhotoModalOpen(true)}>
+                          <span className="btn-photo-rec-icon">📷</span>
+                          <span>拍照识别</span>
+                          <span className="btn-photo-rec-badge">AI 识别</span>
+                        </button>
+                      </div>
+                    )}
                     <div className="inline-calc-wrapper" style={{ display: isChomboManual ? 'none' : 'block' }}>
                       <GuobiaoCalculator
                         key="guobiao-calc"

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -6,7 +6,8 @@ import { rankByScore } from '../logic/ranking'
 import { GuobiaoCalculator } from '../components/GuobiaoCalculator'
 import { RiichiCalculator } from '../components/RiichiCalculator'
 import { MahjongHand } from '../components/MahjongHand'
-import { nameFontSize } from '../utils/fontSize'
+import { tableNameFontSize } from '../utils/fontSize'
+import { useIsMobile } from '../hooks/useIsMobile'
 import { deriveGameState, deriveRoundState, getWindName } from '../utils/gameState'
 import { scoreClass, parseError, seatRankMedal } from '../utils/format'
 import { MSG } from '../constants'
@@ -17,10 +18,11 @@ import { Meld as GuobiaoMeld } from '../logic/guobiao/types'
 import { Meld as RiichiMeld } from '../logic/riichi/types'
 import { ImportedHand, toGuobiaoMelds, toRiichiMelds } from '../logic/shared/importedHand'
 
-const ROUND_COL_PX = 62
+const ROUND_COL_PX = 68
 
 export default function SessionPage() {
   const { id } = useParams<{ id: string }>()
+  const isMobile = useIsMobile()
   const [session, setSession] = useState<SessionDetail | null>(null)
   const [winnerId, setWinnerId] = useState<string>('')
   const [score, setScore] = useState('')
@@ -769,7 +771,7 @@ export default function SessionPage() {
           </div>
         </div>
         <div className="table-wrap">
-          <table className="fixed-table">
+          <table className="fixed-table session-rounds-table">
             <thead>
               <tr>
                 <th style={{ textAlign: 'center', verticalAlign: 'top', width: `${ROUND_COL_PX}px` }}>局</th>
@@ -780,7 +782,7 @@ export default function SessionPage() {
                         {seatRankMedal(rankMap[p.id]?.rank ?? 0) ?? `#${rankMap[p.id]?.rank ?? 0}`}
                       </span>
                       <RankBadge tier={p.tier} size="sm" userName={p.userName} />
-                      <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
+                      <span className="player-name" style={{ fontSize: tableNameFontSize(p.userName, isMobile) }}>
                         {p.userName}
                       </span>
                     </div>
@@ -915,7 +917,7 @@ export default function SessionPage() {
                         <span className={`rank-tag rank-tag-${rank}`}>{seatRankMedal(rank) ?? `#${rank}`}</span>
                       </td>
                       <td>
-                        <span className="player-name" style={{ fontSize: nameFontSize(p.userName) }}>
+                        <span className="player-name" style={{ fontSize: tableNameFontSize(p.userName, isMobile) }}>
                           {p.userName}
                         </span>
                       </td>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -267,25 +267,6 @@ export default function SessionPage() {
     (a, b) => (session.totalScores[b.id] || 0) - (session.totalScores[a.id] || 0)
   )
 
-  // Find max fan hand(s)
-  const parseFanCount = (r: RoundInfo) => {
-    if (r.fanCount) return r.fanCount
-    if (!r.fanDetails) return 0
-    // Fallback: parse from "Name(Score)" or "Name(ScorexCount)"
-    const matches = r.fanDetails.match(/\((\d+)(x\d+)?\)/g)
-    if (!matches) return 0
-    return matches.reduce((sum: number, m: string) => {
-      const score = parseInt(m.match(/\d+/)?.[0] || '0')
-      const multMatch = m.match(/x(\d+)/)
-      const mult = multMatch ? parseInt(multMatch[1]) : 1
-      return sum + score * mult
-    }, 0)
-  }
-
-  const roundsWithFan = session.rounds.map((r) => ({ ...r, effectiveFan: parseFanCount(r) }))
-  const maxFan = roundsWithFan.reduce((max, r) => Math.max(max, r.effectiveFan), 0)
-  const bestRounds = maxFan > 0 ? roundsWithFan.filter((r) => r.effectiveFan === maxFan) : []
-
   const rankings = rankByScore(
     session.players.map((p) => ({ playerId: p.id, score: session.totalScores[p.id] || 0 })),
     (s) => s.score
@@ -930,43 +911,6 @@ export default function SessionPage() {
                 })}
               </tbody>
             </table>
-          </div>
-        </div>
-      )}
-
-      {bestRounds.length > 0 && (
-        <div className="card best-hand-card">
-          <div className="best-hand-header">
-            <span className="best-hand-crown">👑</span>
-            <h2>最高番和牌</h2>
-          </div>
-          <div>
-            {bestRounds.map((round) => {
-              const winner = session.players.find((p) => p.id === round.winnerId)
-              const loser =
-                round.dealInPlayerId != null ? session.players.find((p) => p.id === round.dealInPlayerId) : null
-
-              return (
-                <div key={round.roundNumber} className="best-hand-item">
-                  <div className="best-hand-meta">
-                    <span className="best-hand-fan-count">{round.effectiveFan} 番</span>
-                    <span className="best-hand-players">
-                      <span className="winner-label">赢家:</span> {winner?.userName}
-                      {round.dealInPlayerId != null ? (
-                        <>
-                          <span className="loser-label ml-2">输家:</span> {loser?.userName || '?'}
-                        </>
-                      ) : (
-                        <span className="zimo-label ml-2">(自摸)</span>
-                      )}
-                    </span>
-                  </div>
-                  <div className="best-hand-display">
-                    <MahjongHand hand={round.winHand} details={round.fanDetails} />
-                  </div>
-                </div>
-              )
-            })}
           </div>
         </div>
       )}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -569,50 +569,10 @@ export default function SessionPage() {
                         </button>
                       )
                     })}
-                    <div className={`win-action-row${isGuobiao ? ' win-action-row-three' : ''}`}>
-                      <button
-                        type="button"
-                        className={`quick-player-btn win-type-btn dianpao ${
-                          !isSelfDraw && !isChomboManual ? 'active' : ''
-                        }`}
-                        onClick={() => {
-                          setIsSelfDraw(false)
-                          setIsChomboManual(false)
-                        }}
-                      >
-                        点炮
-                      </button>
-                      <button
-                        type="button"
-                        className={`quick-player-btn win-type-btn zimo ${
-                          isSelfDraw && !isChomboManual ? 'active' : ''
-                        }`}
-                        onClick={() => {
-                          setIsSelfDraw(true)
-                          setIsChomboManual(false)
-                          setDealInPlayerId('')
-                        }}
-                      >
-                        自摸
-                      </button>
-                      {isGuobiao && (
-                        <button
-                          type="button"
-                          className={`quick-player-btn win-type-btn chombo ${isChomboManual ? 'active' : ''}`}
-                          onClick={() => {
-                            setIsSelfDraw(false)
-                            setIsChomboManual(true)
-                            setDealInPlayerId('')
-                          }}
-                        >
-                          诈胡
-                        </button>
-                      )}
-                    </div>
                   </div>
                   <span className="field-hint">
                     {!winnerId
-                      ? '点一下选和牌者'
+                      ? `点一下选和牌者 · 连点同一人切换自摸${isGuobiao ? '/诈胡' : ''}`
                       : isChomboManual
                       ? '再点一下清空重选'
                       : isSelfDraw

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -647,19 +647,13 @@ export default function SessionPage() {
                   <div className="round-form-grid">
                     <div className="form-group">
                       <label>番</label>
-                      <div style={{ display: 'flex', alignItems: 'center' }}>
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          value={fan}
-                          onChange={(e) => setFan(e.target.value)}
-                          placeholder="输入番"
-                          style={{ flex: 1 }}
-                        />
-                        <button type="button" className="reset-btn-score-compact" onClick={resetForm}>
-                          重置
-                        </button>
-                      </div>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={fan}
+                        onChange={(e) => setFan(e.target.value)}
+                        placeholder="输入番"
+                      />
                     </div>
                   </div>
                 )}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -111,7 +111,6 @@ export interface RoundInfo {
   prevalentWind?: number
   riichiPlayerIds?: number[]
   tenpaiPlayerIds?: number[] // for drawn games; undefined on legacy rounds
-  backfill?: boolean
 }
 
 export interface SessionDetail {
@@ -149,7 +148,6 @@ export interface AddRoundData {
   fanDetails?: string
   fanCount?: number
   prevalentWind?: number
-  backfill?: boolean
   chombo?: boolean
 }
 

--- a/ui/src/utils/__tests__/gameState.test.ts
+++ b/ui/src/utils/__tests__/gameState.test.ts
@@ -46,31 +46,31 @@ describe('deriveGameState: riichi ryuukyoku dealer rotation', () => {
   it('全员未听 → 流庄, 本场 +1', () => {
     const s = deriveGameState(session([draw([])]))
     expect(s.dealerPlayerId).toBe(2)
-    expect(s.displayName).toBe('东2（1）')
+    expect(s.displayName).toBe('东2(1)')
   })
 
   it('全员听牌 → 连庄, 本场 +1', () => {
     const s = deriveGameState(session([draw([1, 2, 3, 4])]))
     expect(s.dealerPlayerId).toBe(1)
-    expect(s.displayName).toBe('东1（1）')
+    expect(s.displayName).toBe('东1(1)')
   })
 
   it('庄家听牌 (部分听) → 连庄', () => {
     const s = deriveGameState(session([draw([1, 3])]))
     expect(s.dealerPlayerId).toBe(1)
-    expect(s.displayName).toBe('东1（1）')
+    expect(s.displayName).toBe('东1(1)')
   })
 
   it('庄家未听 (部分听) → 流庄, 本场 +1', () => {
     const s = deriveGameState(session([draw([2, 3])]))
     expect(s.dealerPlayerId).toBe(2)
-    expect(s.displayName).toBe('东2（1）')
+    expect(s.displayName).toBe('东2(1)')
   })
 
   it('连续流局本场累加, 庄家轮转', () => {
     const s = deriveGameState(session([draw([]), draw([]), draw([1, 2, 3, 4])]))
     expect(s.dealerPlayerId).toBe(3)
-    expect(s.displayName).toBe('东3（3）')
+    expect(s.displayName).toBe('东3(3)')
   })
 
   it('legacy 流局 (无听牌名单) 沿用点数推断', () => {
@@ -80,7 +80,7 @@ describe('deriveGameState: riichi ryuukyoku dealer rotation', () => {
     }
     const s = deriveGameState(session([notenDealer]))
     expect(s.dealerPlayerId).toBe(2)
-    expect(s.displayName).toBe('东2（1）')
+    expect(s.displayName).toBe('东2(1)')
   })
 
   it('闲家和牌 → 流庄, 本场清零', () => {
@@ -94,7 +94,7 @@ describe('deriveGameState: riichi ryuukyoku dealer rotation', () => {
     const win: RoundInfo = { roundNumber: 1, scores: { 1: 5800, 2: -5800, 3: 0, 4: 0 }, winnerId: 1 }
     const s = deriveGameState(session([win]))
     expect(s.dealerPlayerId).toBe(1)
-    expect(s.displayName).toBe('东1（1）')
+    expect(s.displayName).toBe('东1(1)')
   })
 
   it('立直棒流局保留, 和牌清零', () => {

--- a/ui/src/utils/fontSize.ts
+++ b/ui/src/utils/fontSize.ts
@@ -21,9 +21,6 @@ const FULLWIDTH =
 
 /**
  * 视觉宽度(以"半个字"为单位): 全角记 2, 大写字母记 1.4, 其他记 1.
- *
- * <p>text.length 会把 "小明同学" 和 "abcd" 当成一样长, 但前者实际宽一倍; 大写字母也明显比小写宽
- * (Helvetica 里 W 是 l 的 4 倍), 所以 "WalkingAFK" 这种混了 4 个大写的名字按 length 分档会溢出.
  */
 function visualWidth(text: string) {
   let w = 0

--- a/ui/src/utils/gameState.ts
+++ b/ui/src/utils/gameState.ts
@@ -65,8 +65,6 @@ export function deriveGameState(session: SessionDetail): GameState {
   let kyoutaku = 0
 
   for (const round of session.rounds) {
-    if (round.backfill) continue
-
     const riichiCount = round.riichiPlayerIds?.length ?? 0
     kyoutaku += riichiCount * 1000
 

--- a/ui/src/utils/gameState.ts
+++ b/ui/src/utils/gameState.ts
@@ -97,7 +97,7 @@ export function deriveGameState(session: SessionDetail): GameState {
     handNumber,
     honba,
     kyoutaku,
-    displayName: honba > 0 ? `${windHand}（${honba}）` : windHand,
+    displayName: honba > 0 ? `${windHand}(${honba})` : windHand,
     playerCount,
   }
 }


### PR DESCRIPTION
## 1. 移动端文字截断（iPhone 14 Pro = 393px）

上一个 PR 我给 `.round-wind-tag` 加的 `overflow: hidden + text-overflow: ellipsis` 本意是兜底，实际把「装不下」从溢出变成了**静默截断**，更难发现。已删除。列宽也算错了 —— 62px 里漏算 `td` 自己的 `padding: 0 6px`，实际只剩 36px 放字，而 `南3(1)` 需 37px。

**根因是整表超预算**，不只是 `局` 列：

```
可用: 393 −32(main) −32(card) = 329px
原需: 局 70 + 删除列 32 + 4×玩家列 70 = 382px   ← 超 53px
```

`.score-cell` 此前**没有任何移动端缩字号**（只设了 `tabular-nums`），六位数分数在 iPhone 上本来就会挤出格子 —— 既有问题，非本次引入。

方案：把 `.stats-table` 早就有的那套移动端处理搬过来。新增 `.session-rounds-table` class（原来只有 `fixed-table`，无法精确选中而不误伤排名表），`≤640px` 时 padding `6px→4px`、分数 `→0.8rem`、局标签 `→0.8rem`，列宽 `62→68`。

> 写 CSS 时踩到权重坑：`table.fixed-table th` 是 (0,1,2)，最初写的 `.session-rounds-table th` 只有 (0,1,1)，padding 覆盖不上；提成 `table.session-rounds-table th` 才同权重、靠源码顺序取胜。

## 2. 长名字永不截断

四处去掉 `nowrap + ellipsis`，改 `overflow-wrap: anywhere` —— **装不下折行，而不是截断**：`.player-name`、`.game-card .player-name`（并去掉 `max-width: 120px`）、`.player-select-card div`（开新对局的选人卡片，容易被忽略）、`.best-hand-summary-detail`（首页最高和牌的番种列表）。

字号从 `nameFontSize` 换成 `tableNameFontSize`：前者按 `text.length` 分档，`WalkingAFK` 10 字符含 4 个大写，宽度被低估；后者按 `visualWidth` 分档（大写记 1.4），项目里本来就有这个机制，只是记分表没用上。

保留的 ellipsis 均不涉及玩家名：`.user-display-name` 渲染字面量「我的」，`.tab-btn` 是标签文案。

## 3. 本场格式与段位分

`东N M本场` → `东N(M)`（先做了全角 `（M）`，因为 PingFang 里全角括号各占 1em、显得过大，改半角）。合计行的段位分变化去掉「段位分」字样只留 `+N`，下方排名表已有带表头的段位分列。

## 4. 记分表单精简

去掉 `分数` 标签、分数输入框、`重置`（三种模式都去掉，东北的 `番` 输入保留 —— 该模式没有算番器必须手填）。拍照识别改用完整尺寸按钮，独占一行；算番器页的标签页恢复整行（之前被 `.calc-header-bar` 的 `space-between` 挤成缩宽，下划线也只画一小段），AI 按钮移到下方独立一行。

**后果**：分数只能由算番器产生（无手动输入）；`重置` 按钮全站消失，但提交成功后与勾选流局时仍会自动重置。

## 5. 和牌者选择改为点击循环

原交互靠**点击顺序**隐式决定角色，且 `点炮/自摸` 的选择在玩家行**下方** —— 等于「先点人，后定义点击的含义」，顺序点错就把和牌者和点炮者搞反，而界面只用颜色区分。

改为与流局分支 `立直/默听` 同一套循环：

| 操作 | 结果 |
|---|---|
| 点空位 | 该玩家和牌，默认点炮 |
| 再点和牌者 | → 自摸 |
| 第三下（仅国标） | → 诈胡 |
| 再一下 | 清空 |
| 点炮时点另一人 | 指定 / 取消点炮者 |
| 自摸·诈胡时点另一人 | 换和牌者，保留胡法 |

按钮第二行改写角色文字（和牌/自摸/诈胡/点炮）替代风位。`点炮/自摸/诈胡` 那排按钮已删除，避免两套机制并存。

循环分支多，抽成纯函数 `logic/shared/winSelection.ts` + **17 个测试**，含两条不变量：自摸/诈胡下永远没有点炮者、点炮者永远不等于和牌者。

## 6. 删除 补录 功能

前后端一并删除（`Round` 实体、`AddRoundRequest`/`SessionDetailResponse` 字段、`GameService` 四处、前端勾选框与 `gameState` 的 skip）。**与 `TierService.backfillAllHistory` 无关**，那是段位分历史重放，同名但未触碰。

线上数据已查证（生产库副本，只读）：988 局中仅 1 局标了补录（第 175 场第 14 局，立直，已完成）。按实际算法模拟，删除 skip 后**仅 2 行标签变化**：第 15 局 `南2(4)→南3`、第 16 局 `南3(5)→南3(1)`，第 17 局收敛回 `南4`；分数与名次不受影响。`ROUNDS.BACKFILL` 列不会被 `ddl-auto: update` 删除，留空列无害。

## 7. 删除 session 页最高番和牌

整块 JSX + 随之无引用的 `parseFanCount`/`roundsWithFan`/`maxFan`/`bestRounds`。统计页的最高番和牌不受影响（`best-hand-*` 类仍被它使用，只删了失去引用的 `.loser-label`/`.zimo-label`）。

## 验证

`./gradlew test pmdMain spotlessCheck npmTest` → BUILD SUCCESSFUL，1361 前端测试 + 8 后端测试，pre-commit 五项检查通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added streamlined win selection for ron, tsumo, chombo, and deal-in scenarios.
- Backfill rounds are now included in session progression and score calculations.

## UI Improvements
- Improved mobile layouts, text wrapping, table spacing, and player-name sizing.
- Clarified score-entry roles and instructions.
- Reorganized photo-recognition and calculator controls.
- Unavailable controls are now hidden in chombo mode.

## Bug Fixes
- Corrected round progression, dealer rotation, honba, and kyoutaku handling.
- Standardized parentheses formatting in displayed game information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->