### PR TITLE
fix: 修 iPhone 拍照识别静默失败, 并让错误提示说清原因

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,8 @@ jobs:
             docker run -d \
               --name mahjong \
               --restart always \
-              -p 8080:8080 \
+              -p 127.0.0.1:8080:8080 \
+              -p '[::1]:8080:8080' \
               -v mahjong-data:/app/data \
               -e ADMIN_EMAILS="${{ secrets.ADMIN_EMAILS }}" \
               -e CORS_ORIGINS="${{ secrets.CORS_ORIGINS }}" \

--- a/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
@@ -16,8 +16,17 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  /**
+   * 静态资源缺失照旧返回空 404, 但 /api/** 的 404 要带上路径 —— 空 body 的 404 在前端 只会显示成一句"操作失败"(空 body 过不了 JSON 解析),
+   * 排查时完全看不出是接口不存在。
+   */
   @ExceptionHandler(NoResourceFoundException.class)
-  public ResponseEntity<Void> handleNoResource(NoResourceFoundException e) {
+  public ResponseEntity<Map<String, String>> handleNoResource(NoResourceFoundException e) {
+    String path = e.getResourcePath();
+    if (path != null && path.startsWith("/api")) {
+      log.warn("No handler for API path: {}", path);
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", "接口不存在: " + path));
+    }
     return ResponseEntity.notFound().build();
   }
 

--- a/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package com.mahjong.omakase.config;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -16,18 +18,24 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-  /**
-   * 静态资源缺失照旧返回空 404, 但 /api/** 的 404 要带上路径 —— 空 body 的 404 在前端 只会显示成一句"操作失败"(空 body 过不了 JSON 解析),
-   * 排查时完全看不出是接口不存在。
-   */
   @ExceptionHandler(NoResourceFoundException.class)
   public ResponseEntity<Map<String, String>> handleNoResource(NoResourceFoundException e) {
+    // resourcePath is a final field set from the request path, so it is never null.
     String path = e.getResourcePath();
-    if (path != null && path.startsWith("/api")) {
+    if (path.startsWith("/api")) {
       log.warn("No handler for API path: {}", path);
-      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", "接口不存在: " + path));
+      // Log the path, don't echo it: reflecting a caller-controlled string is a needless risk.
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", "接口不存在"));
     }
     return ResponseEntity.notFound().build();
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<Map<String, String>> handleMethodNotSupported(
+      HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+    log.warn("Method {} not supported for {}", e.getMethod(), request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+        .body(Map.of("message", "该地址不支持此请求方式"));
   }
 
   @ExceptionHandler(NoSuchElementException.class)

--- a/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
@@ -3,11 +3,13 @@ package com.mahjong.omakase.config;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -41,7 +43,13 @@ public class GlobalExceptionHandler {
             .map(err -> err.getField() + ": " + err.getDefaultMessage())
             .findFirst()
             .orElse("Validation failed");
+    log.warn("Request validation failed: {}", message);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", message));
+  }
+
+  @ExceptionHandler({ClientAbortException.class, AsyncRequestNotUsableException.class})
+  public void handleClientDisconnect(Exception e) {
+    log.debug("Client disconnected before the response was written: {}", e.getMessage());
   }
 
   @ExceptionHandler(Exception.class)

--- a/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
@@ -23,7 +23,9 @@ public class GlobalExceptionHandler {
   public ResponseEntity<Map<String, String>> handleNoResource(NoResourceFoundException e) {
     // resourcePath is a final field set from the request path, so it is never null.
     String path = e.getResourcePath();
-    if (path.startsWith("/api")) {
+    // Match the segment boundary: a bare startsWith("/api") also claims /apix/logo.svg, whose 404
+    // must stay an empty static-resource response.
+    if ("/api".equals(path) || path.startsWith("/api/")) {
       log.warn("No handler for API path: {}", path);
       // Log the path, don't echo it: reflecting a caller-controlled string is a needless risk.
       return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", "接口不存在"));

--- a/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -67,6 +68,20 @@ public class GlobalExceptionHandler {
   @ExceptionHandler({ClientAbortException.class, AsyncRequestNotUsableException.class})
   public void handleClientDisconnect(Exception e) {
     log.debug("Client disconnected before the response was written: {}", e.getMessage());
+  }
+
+  /**
+   * Controllers throw this to pick their own status — 403 from the admin guard, 400 for a bad
+   * year/month, 404 for a missing player. Without this handler they all fell through to
+   * handleGeneral, which reported "An unexpected error occurred" with a 500 and logged a full stack
+   * trace, hiding both the real status and the reason.
+   */
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<Map<String, String>> handleResponseStatus(ResponseStatusException e) {
+    String reason = e.getReason();
+    log.warn("Rejected with {}: {}", e.getStatusCode(), reason);
+    return ResponseEntity.status(e.getStatusCode())
+        .body(Map.of("message", reason != null ? reason : "请求被拒绝"));
   }
 
   @ExceptionHandler(Exception.class)

--- a/server/src/main/java/com/mahjong/omakase/config/RequestSizeLimitFilter.java
+++ b/server/src/main/java/com/mahjong/omakase/config/RequestSizeLimitFilter.java
@@ -1,0 +1,55 @@
+package com.mahjong.omakase.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Rejects oversized request bodies before anything reads them.
+ *
+ * <p>Bean Validation cannot do this job: {@code @Size} on a DTO field only runs once Jackson has
+ * already deserialized the whole body into the heap. With {@code -Xmx512m}, a single
+ * multi-hundred-MB POST would exhaust memory before validation ever executed.
+ *
+ * <p>Scope of the guard: this checks the declared {@code Content-Length}, which covers every normal
+ * client (fetch, curl, the app itself) and the realistic accident of an oversized photo. A request
+ * using chunked transfer encoding declares no length and slips past — Cloudflare's own request-size
+ * cap and requiring authentication are the outer layers for that case.
+ */
+@Slf4j
+@Component
+public class RequestSizeLimitFilter extends OncePerRequestFilter {
+
+  /**
+   * Generous next to the real payload: the recognition DTO caps base64 at 8MB, and JSON overhead on
+   * top of that is small.
+   */
+  static final long MAX_REQUEST_BYTES = 12L * 1024 * 1024;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    long declared = request.getContentLengthLong();
+    if (declared > MAX_REQUEST_BYTES) {
+      log.warn(
+          "Rejected {} byte body on {} (limit {})",
+          declared,
+          request.getRequestURI(),
+          MAX_REQUEST_BYTES);
+      response.setStatus(HttpStatus.PAYLOAD_TOO_LARGE.value());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.setCharacterEncoding("UTF-8");
+      response.getWriter().write("{\"message\":\"请求内容过大\"}");
+      return;
+    }
+    chain.doFilter(request, response);
+  }
+}

--- a/server/src/main/java/com/mahjong/omakase/config/RequestSizeLimitFilter.java
+++ b/server/src/main/java/com/mahjong/omakase/config/RequestSizeLimitFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -18,10 +19,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * already deserialized the whole body into the heap. With {@code -Xmx512m}, a single
  * multi-hundred-MB POST would exhaust memory before validation ever executed.
  *
- * <p>Scope of the guard: this checks the declared {@code Content-Length}, which covers every normal
- * client (fetch, curl, the app itself) and the realistic accident of an oversized photo. A request
- * using chunked transfer encoding declares no length and slips past — Cloudflare's own request-size
- * cap and requiring authentication are the outer layers for that case.
+ * <p>Two ways in, both closed: an oversized declared {@code Content-Length} is refused with 413,
+ * and a chunked body — which declares no length at all and would otherwise stream straight into
+ * Jackson — is refused with 411. Nothing in this app sends chunked requests; {@code fetch} and
+ * {@code curl} both set a length. A missing length without chunked encoding is left alone, because
+ * a bodyless {@code PUT}/{@code DELETE} (completing a session, deleting a round) legitimately has
+ * neither.
  */
 @Slf4j
 @Component
@@ -44,12 +47,29 @@ public class RequestSizeLimitFilter extends OncePerRequestFilter {
           declared,
           request.getRequestURI(),
           MAX_REQUEST_BYTES);
-      response.setStatus(HttpStatus.PAYLOAD_TOO_LARGE.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      response.setCharacterEncoding("UTF-8");
-      response.getWriter().write("{\"message\":\"请求内容过大\"}");
+      reject(response, HttpStatus.PAYLOAD_TOO_LARGE, "请求内容过大");
       return;
     }
+
+    if (isChunked(request)) {
+      log.warn("Rejected chunked body on {}: length must be declared", request.getRequestURI());
+      reject(response, HttpStatus.LENGTH_REQUIRED, "请求需要声明内容长度");
+      return;
+    }
+
     chain.doFilter(request, response);
+  }
+
+  private static boolean isChunked(HttpServletRequest request) {
+    String encoding = request.getHeader("Transfer-Encoding");
+    return encoding != null && encoding.toLowerCase(Locale.ROOT).contains("chunked");
+  }
+
+  private void reject(HttpServletResponse response, HttpStatus status, String message)
+      throws IOException {
+    response.setStatus(status.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("{\"message\":\"" + message + "\"}");
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/config/SecurityInterceptor.java
+++ b/server/src/main/java/com/mahjong/omakase/config/SecurityInterceptor.java
@@ -40,8 +40,10 @@ public class SecurityInterceptor implements HandlerInterceptor {
 
     String path = request.getRequestURI();
 
-    // Static assets and SPA routes are not /api, so they never need a token.
-    if (!path.startsWith("/api") || "/error".equals(path) || PUBLIC_API_PATHS.contains(path)) {
+    // Static assets and SPA routes are not /api, so they never need a token. Match on the segment
+    // boundary so a path like /apix/logo.svg is not mistaken for an API call and refused.
+    boolean isApi = "/api".equals(path) || path.startsWith("/api/");
+    if (!isApi || "/error".equals(path) || PUBLIC_API_PATHS.contains(path)) {
       return true;
     }
 

--- a/server/src/main/java/com/mahjong/omakase/config/SecurityInterceptor.java
+++ b/server/src/main/java/com/mahjong/omakase/config/SecurityInterceptor.java
@@ -5,12 +5,25 @@ import com.mahjong.omakase.repository.PlayerRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
 public class SecurityInterceptor implements HandlerInterceptor {
+
+  /**
+   * Endpoints reachable before a token exists. Matched exactly, never by prefix: a prefix check on
+   * {@code /api/auth/} would also expose {@code /api/auth/me}, and {@code startsWith} on a single
+   * path would accept {@code /api/auth/googleAnything}.
+   *
+   * <p>Each of these authenticates itself. {@code google} and {@code setup-profile} verify a Google
+   * credential; {@code lookup-claimable} only answers whether a name is already taken. All three
+   * are on the registration path, before {@code setup-profile} issues the session token.
+   */
+  private static final Set<String> PUBLIC_API_PATHS =
+      Set.of("/api/auth/google", "/api/auth/setup-profile", "/api/auth/lookup-claimable");
 
   private final PlayerRepository playerRepo;
 
@@ -27,27 +40,25 @@ public class SecurityInterceptor implements HandlerInterceptor {
 
     String path = request.getRequestURI();
 
-    // 1. 放行 Google 认证接口、静态资源、Spa路由转发、以及错误信息
-    if (path.startsWith("/api/auth/google") || "/error".equals(path) || !path.startsWith("/api")) {
+    // Static assets and SPA routes are not /api, so they never need a token.
+    if (!path.startsWith("/api") || "/error".equals(path) || PUBLIC_API_PATHS.contains(path)) {
       return true;
     }
 
-    // 2. 检查 Authorization 请求头 "Bearer <token>"
     String authHeader = request.getHeader("Authorization");
     if (authHeader != null && authHeader.startsWith("Bearer ")) {
       String token = authHeader.substring(7);
       Optional<Player> player = playerRepo.findByToken(token);
       if (player.isPresent()) {
-        // 将登录的当前用户注入请求属性，供后续业务提取
         request.setAttribute("currentUser", player.get());
         return true;
       }
     }
 
-    // 3. 未登录或 Token 无效，拦截并返回 401 Unauthorized
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     response.setContentType("application/json");
-    response.getWriter().write("{\"error\": \"Unauthorized. Please login first.\"}");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("{\"error\": \"请先登录\"}");
     return false;
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/config/WebConfig.java
+++ b/server/src/main/java/com/mahjong/omakase/config/WebConfig.java
@@ -10,16 +10,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-  // 暂时注释掉拦截器注入，等到验证通过后再启用 cutover 强鉴权
-  // private final SecurityInterceptor securityInterceptor;
+  private final SecurityInterceptor securityInterceptor;
 
   @NonNull
   @Value("${app.cors.allowed-origins:http://localhost:5173}")
   private String[] allowedOrigins = new String[0];
 
-  // public WebConfig(SecurityInterceptor securityInterceptor) {
-  //   this.securityInterceptor = securityInterceptor;
-  // }
+  public WebConfig(SecurityInterceptor securityInterceptor) {
+    this.securityInterceptor = securityInterceptor;
+  }
 
   @Override
   public void addCorsMappings(@NonNull CorsRegistry registry) {
@@ -32,7 +31,6 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(@NonNull InterceptorRegistry registry) {
-    // 暂时不在 Spring MVC 中启用全站强鉴权拦截器，保证当前旧 API 正常提供服务
-    // registry.addInterceptor(securityInterceptor).addPathPatterns("/api/**");
+    registry.addInterceptor(securityInterceptor).addPathPatterns("/api/**");
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/TileRecognitionRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/TileRecognitionRequest.java
@@ -14,6 +14,8 @@ public class TileRecognitionRequest {
   @Size(max = 8_000_000, message = "图片过大，请重新拍摄")
   private String imageBase64;
 
-  @Pattern(regexp = "image/(jpeg|png|webp|heic|heif)", message = "仅支持 JPEG / PNG / WebP / HEIC 图片")
+  @Pattern(
+      regexp = "image/(jpeg|png|webp|heic|heif)",
+      message = "仅支持 JPEG / PNG / WebP / HEIC / HEIF 图片")
   private String mimeType = "image/jpeg";
 }

--- a/server/src/main/java/com/mahjong/omakase/dto/TileRecognitionRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/TileRecognitionRequest.java
@@ -14,6 +14,6 @@ public class TileRecognitionRequest {
   @Size(max = 8_000_000, message = "图片过大，请重新拍摄")
   private String imageBase64;
 
-  @Pattern(regexp = "image/(jpeg|png|webp)", message = "仅支持 JPEG / PNG / WebP 图片")
+  @Pattern(regexp = "image/(jpeg|png|webp|heic|heif)", message = "仅支持 JPEG / PNG / WebP / HEIC 图片")
   private String mimeType = "image/jpeg";
 }

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -148,6 +148,10 @@ public class TileRecognitionService {
     Map<String, Object> payload = buildPayload(imageBase64, mimeType);
     int start = keyCursor.get();
     String lastError = null;
+    // Log on the way in as well as on failure: Gemini takes tens of seconds for two images, and
+    // without this a request in flight looks identical to one that never arrived.
+    long startedAtNanos = System.nanoTime();
+    log.info("Recognition request received: {} KB of {}", imageBase64.length() / 1024, mimeType);
 
     for (int attempt = 0; attempt < apiKeys.size(); attempt++) {
       int index = (start + attempt) % apiKeys.size();
@@ -163,7 +167,13 @@ public class TileRecognitionService {
                 .body(String.class);
         // Success: next request starts at the key after this one.
         keyCursor.set((index + 1) % apiKeys.size());
-        return extractText(body);
+        String text = extractText(body);
+        log.info(
+            "Recognition succeeded in {} ms on key #{} ({} chars returned)",
+            (System.nanoTime() - startedAtNanos) / 1_000_000,
+            index,
+            text.length());
+        return text;
       } catch (RestClientResponseException e) {
         int status = e.getStatusCode().value();
         String detail = errorMessage(e.getResponseBodyAsString());

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -25,6 +25,9 @@ spring:
 
 server:
   port: ${PORT:8080}
+  # Cloudflare fronts this app, so honour X-Forwarded-Proto / -For: without it Spring believes it
+  # is serving plain HTTP and can emit http:// in redirects, and every client IP logs as Cloudflare.
+  forward-headers-strategy: framework
   servlet:
     encoding:
       charset: UTF-8

--- a/server/src/test/java/com/mahjong/omakase/config/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,65 @@
+package com.mahjong.omakase.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+class GlobalExceptionHandlerTest {
+
+  private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+  /** The admin guard's 403 used to surface as a 500 "An unexpected error occurred". */
+  @Test
+  void keepsTheStatusAndReasonOfAnAdminRejection() {
+    ResponseEntity<Map<String, String>> response =
+        handler.handleResponseStatus(
+            new ResponseStatusException(HttpStatus.FORBIDDEN, "Admin authorization required"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody()).containsEntry("message", "Admin authorization required");
+  }
+
+  @Test
+  void keepsA400FromRequestParsing() {
+    ResponseEntity<Map<String, String>> response =
+        handler.handleResponseStatus(
+            new ResponseStatusException(HttpStatus.BAD_REQUEST, "Month must be between 1 and 12"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).containsEntry("message", "Month must be between 1 and 12");
+  }
+
+  @Test
+  void keepsA404ForAMissingPlayer() {
+    ResponseEntity<Map<String, String>> response =
+        handler.handleResponseStatus(
+            new ResponseStatusException(HttpStatus.NOT_FOUND, "Player not found"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody()).containsEntry("message", "Player not found");
+  }
+
+  @Test
+  void fallsBackToAGenericMessageWhenNoReasonWasGiven() {
+    ResponseEntity<Map<String, String>> response =
+        handler.handleResponseStatus(new ResponseStatusException(HttpStatus.CONFLICT));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody()).containsEntry("message", "请求被拒绝");
+  }
+
+  /** Anything genuinely unexpected still answers 500 without leaking internals. */
+  @Test
+  void stillHidesTrulyUnexpectedFailures() {
+    ResponseEntity<Map<String, String>> response =
+        handler.handleGeneral(new NullPointerException("some internal detail"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody()).containsEntry("message", "An unexpected error occurred");
+    assertThat(response.getBody().get("message")).doesNotContain("some internal detail");
+  }
+}

--- a/server/src/test/java/com/mahjong/omakase/config/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/config/GlobalExceptionHandlerTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 class GlobalExceptionHandlerTest {
 
@@ -61,5 +63,35 @@ class GlobalExceptionHandlerTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     assertThat(response.getBody()).containsEntry("message", "An unexpected error occurred");
     assertThat(response.getBody().get("message")).doesNotContain("some internal detail");
+  }
+
+  @Test
+  void answersAJsonMessageForAnUnknownApiPath() {
+    ResponseEntity<Map<String, String>> response = handleMissing("/api/nope");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody()).containsEntry("message", "接口不存在");
+  }
+
+  @Test
+  void answersAJsonMessageForABareApiPath() {
+    assertThat(handleMissing("/api").getBody()).containsEntry("message", "接口不存在");
+  }
+
+  /**
+   * A prefix check without the segment boundary would claim these too, turning a static-asset 404
+   * into a JSON API error.
+   */
+  @Test
+  void leavesStaticAssetMissesAsAnEmpty404() {
+    for (String path : new String[] {"/apix/logo.svg", "/api-docs", "/logo.svg", "/apis"}) {
+      ResponseEntity<Map<String, String>> response = handleMissing(path);
+      assertThat(response.getStatusCode()).as(path).isEqualTo(HttpStatus.NOT_FOUND);
+      assertThat(response.getBody()).as(path).isNull();
+    }
+  }
+
+  private ResponseEntity<Map<String, String>> handleMissing(String path) {
+    return handler.handleNoResource(new NoResourceFoundException(HttpMethod.GET, path));
   }
 }

--- a/server/src/test/java/com/mahjong/omakase/config/RequestSizeLimitFilterTest.java
+++ b/server/src/test/java/com/mahjong/omakase/config/RequestSizeLimitFilterTest.java
@@ -11,37 +11,61 @@ class RequestSizeLimitFilterTest {
 
   private final RequestSizeLimitFilter filter = new RequestSizeLimitFilter();
 
-  private MockHttpServletResponse run(long contentLength) throws Exception {
+  /**
+   * A 200 status alone proves nothing — a filter that returned early without calling {@code
+   * doFilter} would leave the same default status. {@code MockFilterChain} only records a request
+   * once it has actually been invoked, so that is what tells the two apart.
+   */
+  private record Result(MockHttpServletResponse response, MockFilterChain chain) {
+    boolean reachedTheChain() {
+      return chain.getRequest() != null;
+    }
+  }
+
+  private Result run(long contentLength) throws Exception {
+    return run("POST", contentLength, null);
+  }
+
+  private Result run(String method, long contentLength, String transferEncoding) throws Exception {
     // Override the getter the filter actually reads: MockHttpServletRequest derives its content
     // length from setContent(), which cannot express a body larger than the heap.
     MockHttpServletRequest request =
-        new MockHttpServletRequest("POST", "/api/recognize") {
+        new MockHttpServletRequest(method, "/api/recognize") {
           @Override
           public long getContentLengthLong() {
             return contentLength;
           }
         };
+    if (transferEncoding != null) {
+      request.addHeader("Transfer-Encoding", transferEncoding);
+    }
     MockHttpServletResponse response = new MockHttpServletResponse();
-    filter.doFilter(request, response, new MockFilterChain());
-    return response;
+    MockFilterChain chain = new MockFilterChain();
+    filter.doFilter(request, response, chain);
+    return new Result(response, chain);
   }
 
   @Test
   void passesABodyUnderTheLimit() throws Exception {
-    assertThat(run(1_000_000).getStatus()).isEqualTo(200);
+    Result result = run(1_000_000);
+    assertThat(result.response().getStatus()).isEqualTo(200);
+    assertThat(result.reachedTheChain()).isTrue();
   }
 
   @Test
   void passesABodyExactlyAtTheLimit() throws Exception {
-    assertThat(run(RequestSizeLimitFilter.MAX_REQUEST_BYTES).getStatus()).isEqualTo(200);
+    Result result = run(RequestSizeLimitFilter.MAX_REQUEST_BYTES);
+    assertThat(result.response().getStatus()).isEqualTo(200);
+    assertThat(result.reachedTheChain()).isTrue();
   }
 
   @Test
   void rejectsABodyOverTheLimit() throws Exception {
-    MockHttpServletResponse response = run(RequestSizeLimitFilter.MAX_REQUEST_BYTES + 1);
-    assertThat(response.getStatus()).isEqualTo(413);
-    assertThat(response.getContentAsString()).contains("请求内容过大");
-    assertThat(response.getContentType()).contains("application/json");
+    Result result = run(RequestSizeLimitFilter.MAX_REQUEST_BYTES + 1);
+    assertThat(result.response().getStatus()).isEqualTo(413);
+    assertThat(result.response().getContentAsString()).contains("请求内容过大");
+    assertThat(result.response().getContentType()).contains("application/json");
+    assertThat(result.reachedTheChain()).isFalse();
   }
 
   /**
@@ -49,20 +73,42 @@ class RequestSizeLimitFilterTest {
    */
   @Test
   void rejectsABodyLargerThanTheHeap() throws Exception {
-    assertThat(run(1024L * 1024 * 1024).getStatus()).isEqualTo(413);
+    Result result = run(1024L * 1024 * 1024);
+    assertThat(result.response().getStatus()).isEqualTo(413);
+    assertThat(result.reachedTheChain()).isFalse();
   }
 
-  /** No Content-Length (chunked) is documented as passing through — pin the behaviour. */
+  /** A bodyless PUT/DELETE declares no length either, so this must keep passing through. */
   @Test
   void allowsRequestsWithNoDeclaredLength() throws Exception {
-    assertThat(run(-1).getStatus()).isEqualTo(200);
+    Result result = run(-1);
+    assertThat(result.response().getStatus()).isEqualTo(200);
+    assertThat(result.reachedTheChain()).isTrue();
+  }
+
+  /**
+   * Chunked is the size-limit bypass: no Content-Length to compare against, so the body would
+   * stream straight into Jackson however large it is.
+   */
+  @Test
+  void rejectsAChunkedBodyBecauseItsSizeCannotBeChecked() throws Exception {
+    Result result = run("POST", -1, "chunked");
+    assertThat(result.response().getStatus()).isEqualTo(411);
+    assertThat(result.response().getContentAsString()).contains("请求需要声明内容长度");
+    assertThat(result.reachedTheChain()).isFalse();
+  }
+
+  @Test
+  void rejectsChunkedRegardlessOfHeaderCasing() throws Exception {
+    Result result = run("POST", -1, "gzip, Chunked");
+    assertThat(result.response().getStatus()).isEqualTo(411);
+    assertThat(result.reachedTheChain()).isFalse();
   }
 
   @Test
   void leavesNormalGetRequestsAlone() throws Exception {
-    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/sessions");
-    MockHttpServletResponse response = new MockHttpServletResponse();
-    filter.doFilter(request, response, new MockFilterChain());
-    assertThat(response.getStatus()).isEqualTo(200);
+    Result result = run("GET", -1, null);
+    assertThat(result.response().getStatus()).isEqualTo(200);
+    assertThat(result.reachedTheChain()).isTrue();
   }
 }

--- a/server/src/test/java/com/mahjong/omakase/config/RequestSizeLimitFilterTest.java
+++ b/server/src/test/java/com/mahjong/omakase/config/RequestSizeLimitFilterTest.java
@@ -1,0 +1,68 @@
+package com.mahjong.omakase.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestSizeLimitFilterTest {
+
+  private final RequestSizeLimitFilter filter = new RequestSizeLimitFilter();
+
+  private MockHttpServletResponse run(long contentLength) throws Exception {
+    // Override the getter the filter actually reads: MockHttpServletRequest derives its content
+    // length from setContent(), which cannot express a body larger than the heap.
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/api/recognize") {
+          @Override
+          public long getContentLengthLong() {
+            return contentLength;
+          }
+        };
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilter(request, response, new MockFilterChain());
+    return response;
+  }
+
+  @Test
+  void passesABodyUnderTheLimit() throws Exception {
+    assertThat(run(1_000_000).getStatus()).isEqualTo(200);
+  }
+
+  @Test
+  void passesABodyExactlyAtTheLimit() throws Exception {
+    assertThat(run(RequestSizeLimitFilter.MAX_REQUEST_BYTES).getStatus()).isEqualTo(200);
+  }
+
+  @Test
+  void rejectsABodyOverTheLimit() throws Exception {
+    MockHttpServletResponse response = run(RequestSizeLimitFilter.MAX_REQUEST_BYTES + 1);
+    assertThat(response.getStatus()).isEqualTo(413);
+    assertThat(response.getContentAsString()).contains("请求内容过大");
+    assertThat(response.getContentType()).contains("application/json");
+  }
+
+  /**
+   * The realistic OOM case: a body far larger than the 512MB heap, rejected before Jackson reads.
+   */
+  @Test
+  void rejectsABodyLargerThanTheHeap() throws Exception {
+    assertThat(run(1024L * 1024 * 1024).getStatus()).isEqualTo(413);
+  }
+
+  /** No Content-Length (chunked) is documented as passing through — pin the behaviour. */
+  @Test
+  void allowsRequestsWithNoDeclaredLength() throws Exception {
+    assertThat(run(-1).getStatus()).isEqualTo(200);
+  }
+
+  @Test
+  void leavesNormalGetRequestsAlone() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/sessions");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilter(request, response, new MockFilterChain());
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+}

--- a/server/src/test/java/com/mahjong/omakase/config/SecurityInterceptorTest.java
+++ b/server/src/test/java/com/mahjong/omakase/config/SecurityInterceptorTest.java
@@ -1,0 +1,122 @@
+package com.mahjong.omakase.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.mahjong.omakase.model.Player;
+import com.mahjong.omakase.repository.PlayerRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * The whole API was unauthenticated while this interceptor sat commented out, so pin the allowlist
+ * down: every entry that opens up is a route anyone on the internet can call.
+ */
+class SecurityInterceptorTest {
+
+  private static final String VALID_TOKEN = "token_abc123";
+
+  private final PlayerRepository repo = mock(PlayerRepository.class);
+  private final SecurityInterceptor interceptor = new SecurityInterceptor(repo);
+
+  private boolean handle(String method, String path, String token) throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+    if (token != null) {
+      request.addHeader("Authorization", "Bearer " + token);
+    }
+    return interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+  }
+
+  private MockHttpServletResponse responseFor(String path, String token) throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+    if (token != null) {
+      request.addHeader("Authorization", "Bearer " + token);
+    }
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    interceptor.preHandle(request, response, new Object());
+    return response;
+  }
+
+  // ── public: reachable before a token exists ────────────────────────────────
+
+  @Test
+  void allowsTheRegistrationPathWithoutAToken() throws Exception {
+    assertThat(handle("POST", "/api/auth/google", null)).isTrue();
+    assertThat(handle("POST", "/api/auth/setup-profile", null)).isTrue();
+    assertThat(handle("GET", "/api/auth/lookup-claimable", null)).isTrue();
+  }
+
+  @Test
+  void allowsStaticAssetsAndSpaRoutes() throws Exception {
+    assertThat(handle("GET", "/index.html", null)).isTrue();
+    assertThat(handle("GET", "/session/193", null)).isTrue();
+    assertThat(handle("GET", "/assets/index-abc.js", null)).isTrue();
+    assertThat(handle("GET", "/error", null)).isTrue();
+  }
+
+  // ── protected ──────────────────────────────────────────────────────────────
+
+  @Test
+  void rejectsApiCallsWithoutAToken() throws Exception {
+    for (String path :
+        new String[] {
+          "/api/sessions",
+          "/api/players",
+          "/api/stats",
+          "/api/auth/me",
+          "/api/recognize",
+          "/api/admin/sessions",
+          "/api/players/check-username"
+        }) {
+      assertThat(handle("GET", path, null)).as(path).isFalse();
+    }
+  }
+
+  @Test
+  void rejectsAnInvalidToken() throws Exception {
+    when(repo.findByToken(anyString())).thenReturn(Optional.empty());
+    assertThat(handle("GET", "/api/sessions", "bogus")).isFalse();
+  }
+
+  /** A prefix check would have accepted this; the allowlist matches exact paths. */
+  @Test
+  void rejectsPathsThatMerelyStartWithAPublicOne() throws Exception {
+    assertThat(handle("POST", "/api/auth/googleAnything", null)).isFalse();
+    assertThat(handle("GET", "/api/auth/google/../me", null)).isFalse();
+  }
+
+  @Test
+  void answers401WithJson() throws Exception {
+    MockHttpServletResponse response = responseFor("/api/sessions", null);
+    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getContentType()).contains("application/json");
+    assertThat(response.getContentAsString()).contains("请先登录");
+  }
+
+  // ── authenticated ──────────────────────────────────────────────────────────
+
+  @Test
+  void allowsAValidTokenAndExposesTheCurrentUser() throws Exception {
+    Player player = new Player();
+    player.setId(7L);
+    when(repo.findByToken(VALID_TOKEN)).thenReturn(Optional.of(player));
+
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/sessions");
+    request.addHeader("Authorization", "Bearer " + VALID_TOKEN);
+    assertThat(interceptor.preHandle(request, new MockHttpServletResponse(), new Object()))
+        .isTrue();
+    assertThat(request.getAttribute("currentUser")).isSameAs(player);
+  }
+
+  @Test
+  void ignoresAnAuthorizationHeaderThatIsNotBearer() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/sessions");
+    request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+    assertThat(interceptor.preHandle(request, new MockHttpServletResponse(), new Object()))
+        .isFalse();
+  }
+}

--- a/server/src/test/java/com/mahjong/omakase/config/SecurityInterceptorTest.java
+++ b/server/src/test/java/com/mahjong/omakase/config/SecurityInterceptorTest.java
@@ -58,6 +58,15 @@ class SecurityInterceptorTest {
     assertThat(handle("GET", "/error", null)).isTrue();
   }
 
+  /** A bare startsWith("/api") would have refused these as API calls and broken the SPA. */
+  @Test
+  void treatsOnlyWholeApiSegmentsAsApiPaths() throws Exception {
+    assertThat(handle("GET", "/apix/logo.svg", null)).isTrue();
+    assertThat(handle("GET", "/api-docs", null)).isTrue();
+    assertThat(handle("GET", "/apis", null)).isTrue();
+    assertThat(handle("GET", "/api", null)).isFalse();
+  }
+
   // ── protected ──────────────────────────────────────────────────────────────
 
   @Test

--- a/server/src/test/java/com/mahjong/omakase/dto/TileRecognitionRequestTest.java
+++ b/server/src/test/java/com/mahjong/omakase/dto/TileRecognitionRequestTest.java
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/** 这些校验以前是静默 400 (handleValidation 不打日志), iPhone 上的识别失败就因此完全没有线索, 所以把每条规则钉住。 */
+/**
+ * These constraints used to fail as a silent 400 (handleValidation did not log), which is why the
+ * iPhone recognition failure left no trace at all. Pin every rule down.
+ */
 class TileRecognitionRequestTest {
 
   private static ValidatorFactory factory;
@@ -42,7 +45,7 @@ class TileRecognitionRequestTest {
     assertThat(violations("AAAA", "image/jpeg")).isEmpty();
   }
 
-  /** iPhone 默认存 HEIC, 归一化在大图解码失败时会退回原始文件, 所以必须放行。 */
+  /** iPhone stores HEIC, and normalisation falls back to the original on a decode failure. */
   @Test
   void acceptsHeicAndHeif() {
     assertThat(violations("AAAA", "image/heic")).isEmpty();
@@ -61,13 +64,13 @@ class TileRecognitionRequestTest {
     assertThat(violations("AAAA", "application/pdf")).anyMatch(v -> v.contains("mimeType"));
   }
 
-  /** mimeType 可选: 不传就用默认的 image/jpeg。 */
+  /** mimeType is optional — omitting it falls back to image/jpeg. */
   @Test
   void allowsNullMime() {
     assertThat(violations("AAAA", null)).isEmpty();
   }
 
-  /** 客户端把空 data URL 切出 undefined 时, 字段会缺失 —— 就是 iPhone 上踩到的那条路。 */
+  /** Slicing an empty data URL yields undefined, so the field goes missing — the iPhone path. */
   @Test
   void rejectsBlankImage() {
     assertThat(violations(null, "image/jpeg")).anyMatch(v -> v.contains("imageBase64"));

--- a/server/src/test/java/com/mahjong/omakase/dto/TileRecognitionRequestTest.java
+++ b/server/src/test/java/com/mahjong/omakase/dto/TileRecognitionRequestTest.java
@@ -1,0 +1,89 @@
+package com.mahjong.omakase.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** 这些校验以前是静默 400 (handleValidation 不打日志), iPhone 上的识别失败就因此完全没有线索, 所以把每条规则钉住。 */
+class TileRecognitionRequestTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  private Set<String> violations(String imageBase64, String mimeType) {
+    TileRecognitionRequest req = new TileRecognitionRequest();
+    req.setImageBase64(imageBase64);
+    req.setMimeType(mimeType);
+    return validator.validate(req).stream()
+        .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+        .collect(Collectors.toSet());
+  }
+
+  @Test
+  void acceptsJpeg() {
+    assertThat(violations("AAAA", "image/jpeg")).isEmpty();
+  }
+
+  /** iPhone 默认存 HEIC, 归一化在大图解码失败时会退回原始文件, 所以必须放行。 */
+  @Test
+  void acceptsHeicAndHeif() {
+    assertThat(violations("AAAA", "image/heic")).isEmpty();
+    assertThat(violations("AAAA", "image/heif")).isEmpty();
+  }
+
+  @Test
+  void acceptsPngAndWebp() {
+    assertThat(violations("AAAA", "image/png")).isEmpty();
+    assertThat(violations("AAAA", "image/webp")).isEmpty();
+  }
+
+  @Test
+  void rejectsUnsupportedMime() {
+    assertThat(violations("AAAA", "image/gif")).anyMatch(v -> v.contains("mimeType"));
+    assertThat(violations("AAAA", "application/pdf")).anyMatch(v -> v.contains("mimeType"));
+  }
+
+  /** mimeType 可选: 不传就用默认的 image/jpeg。 */
+  @Test
+  void allowsNullMime() {
+    assertThat(violations("AAAA", null)).isEmpty();
+  }
+
+  /** 客户端把空 data URL 切出 undefined 时, 字段会缺失 —— 就是 iPhone 上踩到的那条路。 */
+  @Test
+  void rejectsBlankImage() {
+    assertThat(violations(null, "image/jpeg")).anyMatch(v -> v.contains("imageBase64"));
+    assertThat(violations("", "image/jpeg")).anyMatch(v -> v.contains("imageBase64"));
+    assertThat(violations("   ", "image/jpeg")).anyMatch(v -> v.contains("imageBase64"));
+  }
+
+  @Test
+  void rejectsOversizedImage() {
+    String tooBig = "A".repeat(8_000_001);
+    assertThat(violations(tooBig, "image/jpeg")).anyMatch(v -> v.contains("图片过大"));
+  }
+
+  @Test
+  void acceptsImageAtTheSizeLimit() {
+    String atLimit = "A".repeat(8_000_000);
+    assertThat(violations(atLimit, "image/jpeg")).isEmpty();
+  }
+}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -28,7 +28,11 @@ async function handleResponse<T = void>(res: Response): Promise<T> {
     let message = ''
     try {
       const body = JSON.parse(raw)
-      message = body.error || body.message || ''
+      // JSON.parse('null') succeeds and yields null, so reading .error off it would throw a
+      // TypeError and lose the status fallback entirely.
+      if (body && typeof body === 'object') {
+        message = body.error || body.message || ''
+      }
     } catch {
       message = raw
         .replace(/<[^>]*>/g, ' ')

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -24,8 +24,19 @@ function getAuthHeaders(headers: Record<string, string> = {}): Record<string, st
 
 async function handleResponse<T = void>(res: Response): Promise<T> {
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}))
-    throw new Error(body.error || body.message || MSG.ERROR)
+    const raw = await res.text().catch(() => '')
+    let message = ''
+    try {
+      const body = JSON.parse(raw)
+      message = body.error || body.message || ''
+    } catch {
+      message = raw
+        .replace(/<[^>]*>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 120)
+    }
+    throw new Error(message || `${MSG.ERROR} (HTTP ${res.status}${res.statusText ? ' ' + res.statusText : ''})`)
   }
   const text = await res.text()
   if (!text.trim()) return undefined as T

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -85,7 +85,7 @@ export function safeParseJSON(str: string): any {
   }
 }
 
-/** iOS Safari 的 toDataURL 在超出画布上限时不抛错, 而是返回 "data:," 这种空串。 */
+/** iOS Safari's toDataURL does not throw past the canvas limit — it returns a bare "data:,". */
 export function isUsableImageDataUrl(dataUrl: string | null | undefined): dataUrl is string {
   return typeof dataUrl === 'string' && /^data:image\/[a-z+]+;base64,.+/i.test(dataUrl)
 }

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -434,6 +434,9 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
 
   // Tile Selection Modal for editing misrecognized tiles
   const [editingTileIndex, setEditingTileIndex] = useState<number | null>(null)
+  // HEIC decodes on iOS but not in desktop Chrome, and the fallback keeps the original file
+  // so recognition still works — show that rather than a broken-image icon.
+  const [previewFailed, setPreviewFailed] = useState(false)
 
   // Both callers keep this mounted and only toggle isOpen, so without this a reopen would
   // still show the previous photo and result.
@@ -447,6 +450,7 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
       setError(null)
       setResult(null)
       setEditingTileIndex(null)
+      setPreviewFailed(false)
     }
   }
 
@@ -469,6 +473,7 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
       setError(null)
       setResult(null)
       setRotation(0)
+      setPreviewFailed(false)
       try {
         const normalizedBase64 = await normalizeUploadedImage(file)
         setSourceImage(normalizedBase64)
@@ -676,7 +681,16 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
               </label>
             ) : (
               <div className="image-preview-wrapper">
-                <img src={imagePreview} alt="Hand preview" className="uploaded-img-preview" />
+                {previewFailed ? (
+                  <p className="upload-sub-text">此格式无法在当前浏览器预览，但可以正常识别</p>
+                ) : (
+                  <img
+                    src={imagePreview}
+                    alt="Hand preview"
+                    className="uploaded-img-preview"
+                    onError={() => setPreviewFailed(true)}
+                  />
+                )}
               </div>
             )}
           </div>

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -85,6 +85,11 @@ export function safeParseJSON(str: string): any {
   }
 }
 
+/** iOS Safari 的 toDataURL 在超出画布上限时不抛错, 而是返回 "data:," 这种空串。 */
+export function isUsableImageDataUrl(dataUrl: string | null | undefined): dataUrl is string {
+  return typeof dataUrl === 'string' && /^data:image\/[a-z+]+;base64,.+/i.test(dataUrl)
+}
+
 // Downscales an upload to at most 2048px and forces landscape (long edge on the X axis).
 // EXIF orientation is not decoded here — browsers already apply it when drawing an <img>
 // to a canvas (`image-orientation: from-image` is the default).
@@ -94,6 +99,7 @@ export function normalizeUploadedImage(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = (e) => {
+      const original = e.target?.result as string
       const img = new Image()
       img.crossOrigin = 'Anonymous'
       img.onload = () => {
@@ -122,7 +128,7 @@ export function normalizeUploadedImage(file: File): Promise<string> {
         canvas.width = targetW
         canvas.height = targetH
 
-        if (!ctx) return resolve(e.target?.result as string)
+        if (!ctx) return resolve(original)
 
         if (isVertical) {
           // Rotate 90° clockwise so portrait image becomes landscape with long edge left-to-right
@@ -133,10 +139,11 @@ export function normalizeUploadedImage(file: File): Promise<string> {
           ctx.drawImage(img, 0, 0, targetW, targetH)
         }
 
-        resolve(canvas.toDataURL('image/jpeg', 0.88))
+        const jpeg = canvas.toDataURL('image/jpeg', 0.88)
+        resolve(isUsableImageDataUrl(jpeg) ? jpeg : original)
       }
-      img.onerror = () => resolve(e.target?.result as string)
-      img.src = e.target?.result as string
+      img.onerror = () => resolve(original)
+      img.src = original
     }
     reader.onerror = (err) => reject(err)
     reader.readAsDataURL(file)
@@ -510,8 +517,15 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
 
     try {
       // The prompt, the 34-tile calibration legend and the API key all live on the server.
+      if (!isUsableImageDataUrl(imagePreview)) {
+        throw new Error('图片处理失败，请重新拍摄或换一张照片')
+      }
       const mimeType = imagePreview.match(/^data:(image\/[a-zA-Z+]+);base64,/)?.[1] || 'image/jpeg'
-      const responseText = await recognizeHandPhoto(imagePreview.split(',')[1], mimeType)
+      const base64 = imagePreview.slice(imagePreview.indexOf(',') + 1)
+      if (base64.length > 8_000_000) {
+        throw new Error('图片过大，请用较低分辨率重拍，或关闭 iPhone 的 ProRAW / 48MP')
+      }
+      const responseText = await recognizeHandPhoto(base64, mimeType)
 
       const jsonOutput = safeParseJSON(responseText)
 

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -85,9 +85,31 @@ export function safeParseJSON(str: string): any {
   }
 }
 
-/** iOS Safari's toDataURL does not throw past the canvas limit — it returns a bare "data:,". */
+/** Formats the server accepts, which are also the formats Gemini reads. */
+const SUPPORTED_IMAGE_TYPES = ['jpeg', 'png', 'webp', 'heic', 'heif'] as const
+
+// Case-insensitive on purpose: a data URL may arrive as `data:IMAGE/HEIC;base64,...`.
+const IMAGE_DATA_URL = new RegExp(`^data:image/(${SUPPORTED_IMAGE_TYPES.join('|')});base64,(.+)$`, 'i')
+
+/**
+ * Splits a data URL into the MIME type the server expects and the bare base64 payload.
+ *
+ * One parser does both jobs so validation and extraction can never disagree — previously the guard
+ * accepted any `image/*` (avif included, which the server rejects) while the extractor matched
+ * `data:image` case-sensitively, so an uppercase `data:IMAGE/HEIC` was silently relabelled as JPEG.
+ *
+ * <p>Also rejects iOS Safari's `"data:,"`, which is what toDataURL returns past the canvas limit
+ * instead of throwing.
+ */
+export function parseImageDataUrl(dataUrl: string | null | undefined): { mimeType: string; base64: string } | null {
+  if (typeof dataUrl !== 'string') return null
+  const m = dataUrl.match(IMAGE_DATA_URL)
+  if (!m) return null
+  return { mimeType: `image/${m[1].toLowerCase()}`, base64: m[2] }
+}
+
 export function isUsableImageDataUrl(dataUrl: string | null | undefined): dataUrl is string {
-  return typeof dataUrl === 'string' && /^data:image\/[a-z+]+;base64,.+/i.test(dataUrl)
+  return parseImageDataUrl(dataUrl) !== null
 }
 
 // Downscales an upload to at most 2048px and forces landscape (long edge on the X axis).
@@ -522,11 +544,11 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
 
     try {
       // The prompt, the 34-tile calibration legend and the API key all live on the server.
-      if (!isUsableImageDataUrl(imagePreview)) {
-        throw new Error('图片处理失败，请重新拍摄或换一张照片')
+      const parsed = parseImageDataUrl(imagePreview)
+      if (!parsed) {
+        throw new Error('图片格式不支持或处理失败，请重新拍摄或换一张照片')
       }
-      const mimeType = imagePreview.match(/^data:(image\/[a-zA-Z+]+);base64,/)?.[1] || 'image/jpeg'
-      const base64 = imagePreview.slice(imagePreview.indexOf(',') + 1)
+      const { mimeType, base64 } = parsed
       if (base64.length > 8_000_000) {
         throw new Error('图片过大，请用较低分辨率重拍，或关闭 iPhone 的 ProRAW / 48MP')
       }

--- a/ui/src/components/__tests__/photoRecognition.test.ts
+++ b/ui/src/components/__tests__/photoRecognition.test.ts
@@ -5,6 +5,7 @@ import {
   parseTileList,
   safeParseJSON,
   checkRecognizedHand,
+  isUsableImageDataUrl,
   RecognizedHand,
 } from '../PhotoRecognitionModal'
 import { Tile } from '../../logic/shared/tiles'
@@ -208,5 +209,26 @@ describe('meld kind inference', () => {
     // Three non-identical, non-consecutive tiles: only the label can say what was meant.
     expect(toGuobiaoMelds([meld('pon', '159m')])[0].type).toBe('ke')
     expect(toGuobiaoMelds([meld('kan', '159m')])[0].type).toBe('gang')
+  })
+})
+
+describe('isUsableImageDataUrl', () => {
+  it('接受正常的 data URL', () => {
+    expect(isUsableImageDataUrl('data:image/jpeg;base64,/9j/4AAQ')).toBe(true)
+    expect(isUsableImageDataUrl('data:image/heic;base64,AAAA')).toBe(true)
+  })
+
+  // 这是 iPhone 上真正踩到的: 画布超限时 iOS 的 toDataURL 不抛错, 只返回 "data:,"
+  // 于是 split(',')[1] 得到 undefined, 被当成图片发出去, 服务端 @NotBlank 拒掉返回 400。
+  it('拦住 iOS 画布超限时返回的空 data URL', () => {
+    expect(isUsableImageDataUrl('data:,')).toBe(false)
+    expect(isUsableImageDataUrl('data:image/jpeg;base64,')).toBe(false)
+  })
+
+  it('拦住空值与非图片', () => {
+    expect(isUsableImageDataUrl(null)).toBe(false)
+    expect(isUsableImageDataUrl(undefined)).toBe(false)
+    expect(isUsableImageDataUrl('')).toBe(false)
+    expect(isUsableImageDataUrl('data:text/plain;base64,QQ==')).toBe(false)
   })
 })

--- a/ui/src/components/__tests__/photoRecognition.test.ts
+++ b/ui/src/components/__tests__/photoRecognition.test.ts
@@ -213,19 +213,19 @@ describe('meld kind inference', () => {
 })
 
 describe('isUsableImageDataUrl', () => {
-  it('接受正常的 data URL', () => {
+  it('accepts a normal data URL', () => {
     expect(isUsableImageDataUrl('data:image/jpeg;base64,/9j/4AAQ')).toBe(true)
     expect(isUsableImageDataUrl('data:image/heic;base64,AAAA')).toBe(true)
   })
 
-  // 这是 iPhone 上真正踩到的: 画布超限时 iOS 的 toDataURL 不抛错, 只返回 "data:,"
-  // 于是 split(',')[1] 得到 undefined, 被当成图片发出去, 服务端 @NotBlank 拒掉返回 400。
-  it('拦住 iOS 画布超限时返回的空 data URL', () => {
+  // The real iPhone path: past the canvas limit iOS returns "data:," without throwing, so
+  // split(',')[1] is undefined, gets sent as the image, and the server rejects it with a 400.
+  it('rejects the empty data URL iOS returns past the canvas limit', () => {
     expect(isUsableImageDataUrl('data:,')).toBe(false)
     expect(isUsableImageDataUrl('data:image/jpeg;base64,')).toBe(false)
   })
 
-  it('拦住空值与非图片', () => {
+  it('rejects empty values and non-images', () => {
     expect(isUsableImageDataUrl(null)).toBe(false)
     expect(isUsableImageDataUrl(undefined)).toBe(false)
     expect(isUsableImageDataUrl('')).toBe(false)

--- a/ui/src/components/__tests__/photoRecognition.test.ts
+++ b/ui/src/components/__tests__/photoRecognition.test.ts
@@ -6,6 +6,7 @@ import {
   safeParseJSON,
   checkRecognizedHand,
   isUsableImageDataUrl,
+  parseImageDataUrl,
   RecognizedHand,
 } from '../PhotoRecognitionModal'
 import { Tile } from '../../logic/shared/tiles'
@@ -230,5 +231,36 @@ describe('isUsableImageDataUrl', () => {
     expect(isUsableImageDataUrl(undefined)).toBe(false)
     expect(isUsableImageDataUrl('')).toBe(false)
     expect(isUsableImageDataUrl('data:text/plain;base64,QQ==')).toBe(false)
+  })
+})
+
+describe('parseImageDataUrl', () => {
+  it('returns the MIME type and payload separately', () => {
+    expect(parseImageDataUrl('data:image/png;base64,iVBORw0K')).toEqual({
+      mimeType: 'image/png',
+      base64: 'iVBORw0K',
+    })
+  })
+
+  // The server's @Pattern only accepts lowercase, so an uppercase data URL from a browser must be
+  // normalized here rather than rejected with a silent 400.
+  it('accepts uppercase subtypes and lowercases the MIME type it reports', () => {
+    expect(parseImageDataUrl('data:image/HEIC;base64,AAAA')?.mimeType).toBe('image/heic')
+    expect(parseImageDataUrl('DATA:IMAGE/JPEG;BASE64,/9j/4AAQ')?.mimeType).toBe('image/jpeg')
+  })
+
+  // Only the five types the server allows; anything else would be sent and then 400'd.
+  it('rejects image types the server does not accept', () => {
+    expect(parseImageDataUrl('data:image/gif;base64,R0lGOD')).toBeNull()
+    expect(parseImageDataUrl('data:image/svg+xml;base64,PHN2Zz4=')).toBeNull()
+    expect(parseImageDataUrl('data:image/bmp;base64,Qk0=')).toBeNull()
+  })
+
+  it('rejects malformed and payload-less URLs', () => {
+    expect(parseImageDataUrl('data:,')).toBeNull()
+    expect(parseImageDataUrl('data:image/jpeg;base64,')).toBeNull()
+    expect(parseImageDataUrl('data:image/jpeg,notbase64')).toBeNull()
+    expect(parseImageDataUrl('https://example.com/a.jpg')).toBeNull()
+    expect(parseImageDataUrl(null)).toBeNull()
   })
 })


### PR DESCRIPTION
## 现象

iPhone 上拍照识别报错，但**服务端日志里没有任何识别相关记录** —— 识别代码有 7 处失败日志点（`Gemini rejected the request`、`Gemini key #N exhausted` 等），一条都没触发，说明 Gemini 根本没被调用。前端只显示一句「操作失败」。

## 为什么完全查不到

两层都在丢信息：

**前端** `handleResponse` 是 `res.json().catch(() => ({}))` —— 响应体不是 JSON 时整个被丢成 `{}`，最后只抛 `MSG.ERROR`（「操作失败」），**状态码和正文全部丢失**。

**后端** `handleValidation` 返回 400 但不打日志；`handleNoResource` 对所有 404 返回**空 body**，而空 body 恰好过不了前端的 JSON 解析 → 又退化成「操作失败」。

也就是说：接口不存在、图片格式不对、图片过大，三种完全不同的失败在前后端都长得一模一样。

## 根因（在我之前写的 `normalizeUploadedImage` 里）

两条静默退路：

1. **`img.onerror` 时 `resolve(原始文件)`。** iPhone 48MP 原图解码要几百 MB 内存，Safari 解码失败就走这里，于是原始 `image/heic` 被发到服务端，撞上 `@Pattern` 只允许 `jpeg|png|webp` → 400
2. **iOS Safari 的 `canvas.toDataURL` 超出画布上限时不抛错，而是返回 `"data:,"`。** 随后 `split(,)[1]` 得到 `undefined`，请求体里字段直接缺失，撞上 `@NotBlank` → 400

两种都是 400，都不打日志。

## 修复

**让 iPhone 能用**
- 服务端放行 `image/heic` / `image/heif` —— iPhone 默认就存 HEIC，且 **Gemini 本身支持这两种格式**，不需要转码
- 客户端加 `isUsableImageDataUrl` 守卫：`toDataURL` 返回空串时退回原图而不是继续往下走
- 发请求前自查 data URL 与体积，超 8MB 直接给可操作的提示（关闭 ProRAW / 48MP），而不是让服务端拒了才知道

**让失败能被看见**
- `handleResponse`：只读一次 `text`，能解析 JSON 就用后端 message（保持「分数必须 ≥ 8」这类文案原样）；不是 JSON 就剥掉 HTML 取一段；都拿不到时至少带状态码 —— `操作失败 (HTTP 404 Not Found)`
- `handleValidation` 补 `log.warn`
- `/api/**` 的 404 返回 `{"message": "接口不存在: /api/xxx"}` 并打日志；静态资源仍返回空 404

**清掉日志噪音**
- `ClientAbortException` / `AsyncRequestNotUsableException` 单独处理并降到 debug。客户端断开（多数是 favicon 下载中断）本来被记成 ERROR，之后 `handleGeneral` 还要往一个 Content-Type 已是 `image/x-icon` 的响应里写 JSON，再抛一个 `HttpMessageNotWritableException` —— 线上日志里那一大片噪音就是它。

## 顺便说明：log 里其余 ERROR 全是外网噪音

| 报错 | 真相 |
|---|---|
| `Invalid character found in method name [0x16 0x03 0x01 ...]` | `0x16` 是 TLS handshake 记录头 —— 有人用 HTTPS 连明文的 8080 端口（扫描器） |
| `/index.php?s=/index/\think\app/invokefunction` | ThinkPHP RCE 漏洞扫描机器人 |
| `HttpRequestMethodNotSupportedException: POST` ×6 | POST 打到 SPA 路径。`SpaForwardController` 用不限方法的 `@RequestMapping`，POST 也会被 forward 到 index.html，而静态资源只支持 GET。log 没记路径，无法归因；已确认 SessionPage 没有 `<form>`，不是按钮误提交 |

## 测试

- 8 个 DTO 校验测试：HEIC/HEIF 放行、空图与超 8MB 拒绝、mimeType 可省略
- 3 个 `isUsableImageDataUrl` 测试，含 iOS 的 `"data:,"` 这条真实路径

`./gradlew test pmdMain spotlessCheck npmTest` → BUILD SUCCESSFUL，1364 前端测试 + 后端测试全过。

## 部署后请再试一次

如果**仍然**失败，现在的提示会直接说明是哪一层：

- `接口不存在: /api/recognize` → 端点没注册（那就是部署问题，不是图片问题）
- `图片过大...` / `仅支持 JPEG / PNG / WebP / HEIC` → 客户端已提前拦住并说明
- `操作失败 (HTTP 502 ...)` → Gemini 侧，且服务端日志这次一定会有对应的 warn
- 之前那个「操作失败」不会再出现了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved photo upload support by accepting HEIC and HEIF images.
  * Added stronger image validation and safer fallback behavior when previews cannot be rendered or processed.
  * Added clearer JSON responses for unsupported requests and oversized uploads.

* **Bug Fixes**
  * Missing API resources now return clearer JSON error messages.
  * Error messages are cleaner and more informative when requests fail.
  * Protected API access now more reliably enforces authentication and returns readable login-required responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->