### PR TITLE
fix: 拍照识别可从相册选图, 重试加墙钟预算

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/config/GeminiClientConfig.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GeminiClientConfig.java
@@ -12,6 +12,13 @@ import org.springframework.web.client.RestClient;
  *
  * <p>Kept as its own bean so the timeouts live in one place and {@link
  * com.mahjong.omakase.service.TileRecognitionService} can be handed a test double.
+ *
+ * <p>The numbers are sized against the gateway in front of us, not against Gemini: Cloudflare's
+ * free plan abandons a request after 100s and answers 524, and that ceiling cannot be raised. A
+ * single two-image call takes tens of seconds, so the read timeout stays generous — a slow but
+ * successful call must not be cut off. What stops a failed rotation from running well past the
+ * ceiling is instead {@link com.mahjong.omakase.service.TileRecognitionService#RETRY_BUDGET_MS},
+ * which is paired with the read timeout below so that a timed-out attempt ends the rotation.
  */
 @Configuration
 public class GeminiClientConfig {
@@ -22,7 +29,9 @@ public class GeminiClientConfig {
         .requestFactory(
             ClientHttpRequestFactories.get(
                 ClientHttpRequestFactorySettings.DEFAULTS
-                    .withConnectTimeout(Duration.ofSeconds(10))
+                    // A TCP+TLS handshake to Google never legitimately needs more than this, and
+                    // every second here is a second taken from the retry budget.
+                    .withConnectTimeout(Duration.ofSeconds(5))
                     .withReadTimeout(Duration.ofSeconds(60))))
         .build();
   }

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -108,6 +108,26 @@ public class TileRecognitionService {
       }
       """;
 
+  /**
+   * Wall-clock point after which no further key is tried.
+   *
+   * <p>Sized to block exactly one thing: stacked read timeouts. Three of those in a row would run
+   * to minutes, long after Cloudflare's free plan gave up at 100s and answered 524, spending Gemini
+   * quota on a response nobody will receive. Matching the 60s read timeout is enough to stop them,
+   * because a timed-out attempt always lands above 60s — connecting and uploading the image both
+   * happen before the read wait even starts.
+   *
+   * <p>Deliberately no safety margin below that, and deliberately not derived from the worst case
+   * (100s minus a full 65s attempt would put this near 35s). Every second shaved off here only ever
+   * cancels a retry that had time to succeed: a 503 arriving at 57s still leaves ~40s, plenty for a
+   * call that normally takes twenty-something seconds. Refusing to retry makes failure certain,
+   * whereas retrying and running into the 524 is no worse than that.
+   *
+   * <p>The common case never reaches this at all: a 429 comes back in well under a second, so all
+   * three keys can be tried in a couple of seconds.
+   */
+  private static final long RETRY_BUDGET_MS = 60_000;
+
   private final ObjectMapper objectMapper;
   private final RestClient restClient;
   private final List<String> apiKeys;
@@ -154,6 +174,15 @@ public class TileRecognitionService {
     log.info("Recognition request received: {} KB of {}", imageBase64.length() / 1024, mimeType);
 
     for (int attempt = 0; attempt < apiKeys.size(); attempt++) {
+      long elapsedMs = (System.nanoTime() - startedAtNanos) / 1_000_000;
+      if (attempt > 0 && elapsedMs > RETRY_BUDGET_MS) {
+        log.warn(
+            "Stopping after {} of {} keys: {} ms spent, not enough left before the gateway gives up",
+            attempt,
+            apiKeys.size(),
+            elapsedMs);
+        break;
+      }
       int index = (start + attempt) % apiKeys.size();
       try {
         String body =

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -125,6 +125,15 @@ public class TileRecognitionService {
    *
    * <p>The common case never reaches this at all: a 429 comes back in well under a second, so all
    * three keys can be tried in a couple of seconds.
+   *
+   * <p><strong>This is a floor on wasted work, not a total deadline — a gateway timeout is still
+   * reachable.</strong> A failure at 59s passes the check, and that retry may then use its full
+   * 65s, putting the total near 125s; the caller sees Cloudflare's own 524 page instead of our JSON
+   * error. Accepted rather than fixed. Capping each attempt at the remaining gateway time would
+   * mean rebuilding the request factory per attempt, which replaces the one {@code
+   * MockRestServiceServer} binds to and would point every test in {@code
+   * TileRecognitionServiceTest} at the real Gemini API. The cheaper alternative — lowering this
+   * constant until {@code budget + 65s <= 100s} — is exactly what the paragraph above rejects.
    */
   private static final long RETRY_BUDGET_MS = 60_000;
 

--- a/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
@@ -60,6 +60,41 @@ class TileRecognitionServiceTest {
     f.server().verify();
   }
 
+  /**
+   * Having three keys must not mean three calls per photo. The loop is failover, not fan-out: a
+   * second key is only reached once the first has failed. verify() would report the extra requests.
+   */
+  @Test
+  void spendsOnlyOneKeyWhenTheFirstOneSucceeds() {
+    Fixture f = build("key-a,key-b,key-c");
+    f.server()
+        .expect(ExpectedCount.once(), header("x-goog-api-key", "key-a"))
+        .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));
+
+    assertThat(f.service().recognize("BASE64", "image/jpeg")).contains("1m");
+    f.server().verify();
+  }
+
+  /** The other half of rotation: load is spread across requests, not just on failure. */
+  @Test
+  void movesToTheNextKeyOnTheFollowingRequest() {
+    Fixture f = build("key-a,key-b,key-c");
+    f.server()
+        .expect(header("x-goog-api-key", "key-a"))
+        .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));
+    f.server()
+        .expect(header("x-goog-api-key", "key-b"))
+        .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));
+    f.server()
+        .expect(header("x-goog-api-key", "key-c"))
+        .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));
+
+    for (int i = 0; i < 3; i++) {
+      assertThat(f.service().recognize("BASE64", "image/jpeg")).contains("1m");
+    }
+    f.server().verify();
+  }
+
   @Test
   void failsWithUpstreamMessageWhenEveryKeyIsExhausted() {
     Fixture f = build("key-a,key-b");

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -672,13 +672,7 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
                 ↺
               </button>
               <label className="icon-control-btn" title="重新选择图片">
-                <input
-                  type="file"
-                  accept="image/*"
-                  capture="environment"
-                  onChange={handleFileChange}
-                  style={{ display: 'none' }}
-                />
+                <input type="file" accept="image/*" onChange={handleFileChange} style={{ display: 'none' }} />
                 🔄
               </label>
             </div>
@@ -688,13 +682,9 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
           <div>
             {!imagePreview ? (
               <label className="upload-dropzone">
-                <input
-                  type="file"
-                  accept="image/*"
-                  capture="environment"
-                  onChange={handleFileChange}
-                  style={{ display: 'none' }}
-                />
+                {/* No capture attribute: it would force the camera and hide the photo library,
+                    contradicting the label below. */}
+                <input type="file" accept="image/*" onChange={handleFileChange} style={{ display: 'none' }} />
                 <div className="dropzone-content">
                   <div className="upload-icon">📸</div>
                   <p className="upload-main-text">点击选择照片 或 拍照</p>


### PR DESCRIPTION
两个拍照识别的后续修复，`#159` 部署后发现的。

## 1. 手机上只能拍照，不能从相册选（`ef4d9c4`）

两个 `<input type="file">` 上都有 `capture="environment"`，这个属性会让手机浏览器**直接跳到后置摄像头**，跳过系统的选择菜单 —— 和界面上「点击选择照片 或 拍照」的文案矛盾。

去掉后 iOS/Android 会弹出完整菜单（照片图库 / 拍照 / 浏览）。桌面浏览器本来就忽略 `capture`，行为不变。

顺带说明为什么现在放开相册是安全的：相册原图经常是 HEIC，而这条路径正好是 `#159` 修好的（后端 `@Pattern` 允许 `heic`/`heif`，前端 `parseImageDataUrl` 白名单里也有）。换个顺序先做这个改动就会踩坑。

## 2. 重试会跑到网关放弃之后（`536b00d`）

每次尝试的读超时是**各自独立计时**的，所以 3 个 key 全部慢速超时的时候：

```
key-a 连接 1s + 读等 60s → 61s 超时
key-b 再来一遍          → 122s
key-c 再来一遍          → 183s
      ↑ 但 Cloudflare 免费版 100s 就返回 524 了
      后面这 83 秒是在为没人接收的响应烧 Gemini 配额
```

每一次尝试都「没超时」，但没有任何一层在管**总共**花了多久。加一个墙钟预算：已经花掉 60s 就不再开新的尝试。

```java
long elapsedMs = (System.nanoTime() - startedAtNanos) / 1_000_000;
if (attempt > 0 && elapsedMs > RETRY_BUDGET_MS) break;
```

**60 这个值怎么定的**（review 时最值得看的一点）：

- 拦得住叠加 —— 读超时那次的 elapsed 必然 > 60s，因为建连接和上传图片都发生在开始等读之前
- **故意不留余量，也故意不按最坏情况（100 − 65 ≈ 35s）倒推**。往下调只会取消那些本来有时间成功的重试：一个 57s 才回来的 503，此时还剩 40s，足够一次二十几秒的调用跑完。拒绝重试等于让失败变成必然，而重试即便最后撞上 524，也不比必然失败更糟
- 日常情况根本碰不到 —— 429 一秒内就返回，三个 key 全试完也就两三秒

连接超时 10s → 5s：跟 Google 建 TCP+TLS 握手不需要更久，省下的都是重试预算。**读超时保持 60s 不动**，单次调用慢但最终成功的情况不能被砍。

## 测试

补了两个，专门钉住轮换语义（不是超时相关，是澄清那个 `for` 循环在干什么）：

- `spendsOnlyOneKeyWhenTheFirstOneSucceeds` —— 3 个 key、成功时只发 **1 次**请求。那个循环是失败转移，不是 fan-out
- `movesToTheNextKeyOnTheFollowingRequest` —— 连续 3 次成功请求依次用 key-a → key-b → key-c

墙钟预算本身没有测试：它依赖 `System.nanoTime()`，要测就得注入时钟或者在 mock 里 sleep 60 秒，前者是为一个常量过度设计，后者会让测试跑一分钟。

## 需要在服务器上手工做的事（不在这个 PR 里）

nginx 配置不在 repo 里，deploy 也不会覆盖它。在 `location /api/` 里加：

```nginx
client_max_body_size 12m;     # 已加：1.3MB 的照片 base64 后超过 nginx 默认的 1MB，报 413
proxy_read_timeout 120s;      # 待加：默认 60s，会比 Cloudflare 更早掐断
```

`client_max_body_size` 那条是把 Gemini 调用挪到后端代理时引入的回归 —— 以前浏览器直接 POST 给 Google，图片根本不经过 nginx。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Photo selection now supports choosing existing images from the photo library in addition to capturing a new photo.

* **Bug Fixes**
  * Improved image recognition reliability by rotating through configured recognition keys after failed attempts.
  * Added a time limit for retries to prevent prolonged recognition requests.

* **Tests**
  * Added coverage for recognition key rotation and successful request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->