### PR TITLE
fix: 识别失败改 503 并支持模型降级, 不再等 Google 恢复

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GlobalExceptionHandler.java
@@ -33,6 +33,14 @@ public class GlobalExceptionHandler {
     return ResponseEntity.notFound().build();
   }
 
+  /**
+   * Only reached when the 405 comes from a {@code @Controller} path, where the exception is thrown
+   * by handler mapping and leaves the handler null. A 405 on a static resource keeps a non-null,
+   * non-{@code HandlerMethod} handler, and {@code AbstractHandlerMethodExceptionResolver} skips
+   * {@code @ControllerAdvice} entirely in that case — those land on Spring's default resolver and
+   * log without a path. That is the scanner traffic (POST/PROPFIND against {@code /}), and leaving
+   * it as an empty 405 is correct; this handler exists to give our own frontend a JSON body.
+   */
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
   public ResponseEntity<Map<String, String>> handleMethodNotSupported(
       HttpRequestMethodNotSupportedException e, HttpServletRequest request) {

--- a/server/src/main/java/com/mahjong/omakase/controller/TileRecognitionController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/TileRecognitionController.java
@@ -31,9 +31,9 @@ public class TileRecognitionController {
       String rawJson = service.recognize(request.getImageBase64(), request.getMimeType());
       return ResponseEntity.ok(new TileRecognitionResponse(rawJson));
     } catch (IllegalStateException e) {
-      // Upstream/config failure rather than a bad client request — 502 keeps that distinction.
       log.warn("Photo recognition unavailable: {}", e.getMessage());
-      return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(Map.of("message", e.getMessage()));
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+          .body(Map.of("message", e.getMessage()));
     }
   }
 }

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -140,7 +140,7 @@ public class TileRecognitionService {
   private final ObjectMapper objectMapper;
   private final RestClient restClient;
   private final List<String> apiKeys;
-  private final String model;
+  private final List<String> models;
   private final String legendBase64;
   private final AtomicInteger keyCursor = new AtomicInteger();
 
@@ -148,98 +148,126 @@ public class TileRecognitionService {
       ObjectMapper objectMapper,
       RestClient geminiRestClient,
       @Value("${gemini.api-keys:}") String rawApiKeys,
-      @Value("${gemini.model:}") String model) {
+      @Value("${gemini.models:}") String rawModels) {
     this.objectMapper = objectMapper;
-    this.model = model == null || model.isBlank() ? DEFAULT_MODEL : model;
-    this.apiKeys =
-        Arrays.stream(rawApiKeys.split(",")).map(String::trim).filter(k -> !k.isEmpty()).toList();
+    this.apiKeys = splitList(rawApiKeys);
+    List<String> configured = splitList(rawModels);
+    this.models = configured.isEmpty() ? List.of(DEFAULT_MODEL) : configured;
     this.restClient = geminiRestClient;
     this.legendBase64 = loadCalibrationLegend();
 
     if (apiKeys.isEmpty()) {
-      log.warn("GEMINI_API_KEYS is not set — photo recognition will return 503 until configured");
+      log.warn("GEMINI_API_KEYS is not set — photo recognition will fail until configured");
     } else {
-      log.info("Photo recognition ready: {} Gemini key(s), model {}", apiKeys.size(), this.model);
+      log.info("Photo recognition ready: {} Gemini key(s), models {}", apiKeys.size(), this.models);
     }
+  }
+
+  private static List<String> splitList(String raw) {
+    if (raw == null) {
+      return List.of();
+    }
+    return Arrays.stream(raw.split(",")).map(String::trim).filter(v -> !v.isEmpty()).toList();
   }
 
   /**
    * Returns the model's raw JSON text for one hand photo.
    *
-   * @throws IllegalStateException if no key is configured or every key failed
+   * <p>Failures advance whichever dimension can actually help, which is why there are two cursors
+   * rather than one loop over keys. A 429 is our key's own allowance, so the next key is tried on
+   * the same model. A 503 is the model being over capacity — global to that model, identical for
+   * every key — so rotating keys there is three guaranteed failures in a row, as production showed;
+   * the next model is tried on the same key instead.
+   *
+   * @throws IllegalStateException if no key is configured, or nothing left to fall back to
    */
   public String recognize(String imageBase64, String mimeType) {
     if (apiKeys.isEmpty()) {
       throw new IllegalStateException("服务端未配置 Gemini API Key，请联系管理员");
     }
 
-    String url = String.format(ENDPOINT, model);
     Map<String, Object> payload = buildPayload(imageBase64, mimeType);
-    int start = keyCursor.get();
+    int firstKey = keyCursor.get();
+    int keyOffset = 0;
+    int modelIndex = 0;
     String lastError = null;
     // Log on the way in as well as on failure: Gemini takes tens of seconds for two images, and
     // without this a request in flight looks identical to one that never arrived.
     long startedAtNanos = System.nanoTime();
     log.info("Recognition request received: {} KB of {}", imageBase64.length() / 1024, mimeType);
 
-    for (int attempt = 0; attempt < apiKeys.size(); attempt++) {
+    while (true) {
       long elapsedMs = (System.nanoTime() - startedAtNanos) / 1_000_000;
-      if (attempt > 0 && elapsedMs > RETRY_BUDGET_MS) {
-        log.warn(
-            "Stopping after {} of {} keys: {} ms spent, not enough left before the gateway gives up",
-            attempt,
-            apiKeys.size(),
-            elapsedMs);
+      if ((keyOffset > 0 || modelIndex > 0) && elapsedMs > RETRY_BUDGET_MS) {
+        log.warn("Giving up after {} ms: not enough left before the gateway gives up", elapsedMs);
         break;
       }
-      int index = (start + attempt) % apiKeys.size();
+
+      int keyIndex = (firstKey + keyOffset) % apiKeys.size();
+      String model = models.get(modelIndex);
       try {
         String body =
             restClient
                 .post()
-                .uri(url)
-                .header("x-goog-api-key", apiKeys.get(index))
+                .uri(String.format(ENDPOINT, model))
+                .header("x-goog-api-key", apiKeys.get(keyIndex))
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(payload)
                 .retrieve()
                 .body(String.class);
         // Success: next request starts at the key after this one.
-        keyCursor.set((index + 1) % apiKeys.size());
+        keyCursor.set((keyIndex + 1) % apiKeys.size());
         String text = extractText(body);
         log.info(
-            "Recognition succeeded in {} ms on key #{} ({} chars returned)",
+            "Recognition succeeded in {} ms on key #{} with {} ({} chars returned)",
             (System.nanoTime() - startedAtNanos) / 1_000_000,
-            index,
+            keyIndex,
+            model,
             text.length());
         return text;
       } catch (RestClientResponseException e) {
         int status = e.getStatusCode().value();
         String detail = errorMessage(e.getResponseBodyAsString());
-        boolean quota = isQuotaFailure(status, detail);
         if (!isRetryable(status, detail)) {
-          log.warn("Gemini rejected the request ({}): {}", status, detail);
+          log.warn("Gemini rejected the request ({} on {}): {}", status, model, detail);
           throw new IllegalStateException(
               detail.isEmpty() ? "Gemini returned an error with no message" : detail, e);
         }
-        log.warn(
-            "Gemini key #{} {} ({}): {}",
-            index,
-            quota ? "is out of quota" : "hit a transient upstream failure",
-            status,
-            detail);
         lastError = detail;
+        if (isQuotaFailure(status, detail)) {
+          log.warn("Gemini key #{} is out of quota ({}): {}", keyIndex, status, detail);
+          keyCursor.set((keyIndex + 1) % apiKeys.size());
+          keyOffset++;
+          if (keyOffset >= apiKeys.size()) {
+            log.warn("All {} keys are out of quota", apiKeys.size());
+            break;
+          }
+        } else {
+          log.warn("Model {} is over capacity ({}): {}", model, status, detail);
+          modelIndex++;
+          if (modelIndex >= models.size()) {
+            log.warn("All {} models are over capacity: {}", models.size(), models);
+            break;
+          }
+          log.info("Falling back to model {}", models.get(modelIndex));
+        }
       } catch (ResourceAccessException e) {
-        log.warn("Gemini request failed on key #{}: {}", index, e.getMessage());
+        // A timeout says nothing about which model or key is at fault, so treat it like the key
+        // being unusable and move on rather than hammering the same one.
+        log.warn("Gemini request failed on key #{} with {}: {}", keyIndex, model, e.getMessage());
         // Coalesced because a null would reach Map.of("message", ...) in the controller and NPE
         // into a 500, hiding the timeout behind "An unexpected error occurred".
         lastError = e.getMessage() != null ? e.getMessage() : "Upstream request failed";
+        keyCursor.set((keyIndex + 1) % apiKeys.size());
+        keyOffset++;
+        if (keyOffset >= apiKeys.size()) {
+          break;
+        }
       }
-      // Skip past the key that just failed so the next request does not retry it first.
-      keyCursor.set((index + 1) % apiKeys.size());
     }
 
-    // Non-null by construction: apiKeys is non-empty, so the loop ran at least once, and every
-    // path out of an attempt either returns, throws, or records a reason here.
+    // Non-null by construction: apiKeys is non-empty, so the loop ran at least once, and every path
+    // out of an attempt either returns, throws, or records a reason here.
     throw new IllegalStateException(lastError);
   }
 

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -215,21 +215,32 @@ public class TileRecognitionService {
       } catch (RestClientResponseException e) {
         int status = e.getStatusCode().value();
         String detail = errorMessage(e.getResponseBodyAsString());
+        boolean quota = isQuotaFailure(status, detail);
         if (!isRetryable(status, detail)) {
           log.warn("Gemini rejected the request ({}): {}", status, detail);
-          throw new IllegalStateException(detail.isEmpty() ? "识别服务返回错误" : detail, e);
+          throw new IllegalStateException(
+              detail.isEmpty() ? "Gemini returned an error with no message" : detail, e);
         }
-        log.warn("Gemini key #{} exhausted ({}): {}", index, status, detail);
+        log.warn(
+            "Gemini key #{} {} ({}): {}",
+            index,
+            quota ? "is out of quota" : "hit a transient upstream failure",
+            status,
+            detail);
         lastError = detail;
       } catch (ResourceAccessException e) {
         log.warn("Gemini request failed on key #{}: {}", index, e.getMessage());
-        lastError = "识别服务连接超时，请重试";
+        // Coalesced because a null would reach Map.of("message", ...) in the controller and NPE
+        // into a 500, hiding the timeout behind "An unexpected error occurred".
+        lastError = e.getMessage() != null ? e.getMessage() : "Upstream request failed";
       }
       // Skip past the key that just failed so the next request does not retry it first.
       keyCursor.set((index + 1) % apiKeys.size());
     }
 
-    throw new IllegalStateException(lastError == null ? "所有 Gemini API Key 均不可用" : lastError);
+    // Non-null by construction: apiKeys is non-empty, so the loop ran at least once, and every
+    // path out of an attempt either returns, throws, or records a reason here.
+    throw new IllegalStateException(lastError);
   }
 
   private Map<String, Object> buildPayload(String imageBase64, String mimeType) {
@@ -287,11 +298,20 @@ public class TileRecognitionService {
 
   /** Quota, rate limit and transient upstream failures are worth trying another key. */
   private boolean isRetryable(int status, String detail) {
-    if (status == 429 || status == 503 || status == 500) {
-      return true;
-    }
+    return status == 503 || status == 500 || isQuotaFailure(status, detail);
+  }
+
+  /**
+   * Whether the key itself ran out, as opposed to Gemini being over capacity — a 503 "experiencing
+   * high demand" is Google's own problem and hits every key at once, so reporting it as an
+   * exhausted key sends anyone reading the log to look at their quota instead of at the upstream
+   * status.
+   */
+  private static boolean isQuotaFailure(int status, String detail) {
     String lower = detail.toLowerCase(Locale.ROOT);
-    return lower.contains("quota") || lower.contains("resource has been exhausted");
+    return status == 429
+        || lower.contains("quota")
+        || lower.contains("resource has been exhausted");
   }
 
   private String loadCalibrationLegend() {

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -228,12 +228,16 @@ public class TileRecognitionService {
       } catch (RestClientResponseException e) {
         int status = e.getStatusCode().value();
         String detail = errorMessage(e.getResponseBodyAsString());
+        // errorMessage() yields "" for an empty or non-JSON body, and an empty reason would travel
+        // all the way out as {"message":""}. The status is then the only thing left to report, and
+        // it is worth reporting: it still says whether this was quota or capacity.
+        String reason =
+            detail.isBlank() ? "Gemini returned HTTP " + status + " with no message" : detail;
         if (!isRetryable(status, detail)) {
           log.warn("Gemini rejected the request ({} on {}): {}", status, model, detail);
-          throw new IllegalStateException(
-              detail.isEmpty() ? "Gemini returned an error with no message" : detail, e);
+          throw new IllegalStateException(reason, e);
         }
-        lastError = detail;
+        lastError = reason;
         if (isQuotaFailure(status, detail)) {
           log.warn("Gemini key #{} is out of quota ({}): {}", keyIndex, status, detail);
           keyCursor.set((keyIndex + 1) % apiKeys.size());

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -44,6 +44,8 @@ google:
 
 # Photo hand recognition. Keys stay server-side — never expose them to the browser.
 # Comma-separate several keys to rotate away from one that hit its quota.
+# Models are a fallback chain, tried in order: a 503 is that model being over capacity, which every
+# key sees alike, so the only thing that helps is a different model.
 gemini:
   api-keys: ${GEMINI_API_KEYS:}
-  model: ${GEMINI_MODEL:gemini-3.6-flash}
+  models: ${GEMINI_MODELS:gemini-3.6-flash}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -42,10 +42,13 @@ app:
 google:
   client-id: 471645797225-qtqf1nlv8l807tblfhpa9d36p5q456l3.apps.googleusercontent.com
 
-# Photo hand recognition. Keys stay server-side — never expose them to the browser.
-# Comma-separate several keys to rotate away from one that hit its quota.
 # Models are a fallback chain, tried in order: a 503 is that model being over capacity, which every
 # key sees alike, so the only thing that helps is a different model.
+# All GA, all vision-capable, each its own capacity pool. The -lite hop is a deliberate last resort:
+# it is weaker at counting tiles and telling 4s from 5s, so check its output before saving — but a
+# shaky read beats no read when both flash tiers are full.
+# Still excluded: -pro (recognition already takes 11-24s; pro risks the 100s gateway ceiling) and
+# -preview (those names get withdrawn, which would turn the fallback into a 404).
 gemini:
   api-keys: ${GEMINI_API_KEYS:}
-  models: ${GEMINI_MODELS:gemini-3.6-flash}
+  models: ${GEMINI_MODELS:gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite}

--- a/server/src/test/java/com/mahjong/omakase/controller/TileRecognitionControllerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/controller/TileRecognitionControllerTest.java
@@ -1,0 +1,65 @@
+package com.mahjong.omakase.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.mahjong.omakase.dto.TileRecognitionRequest;
+import com.mahjong.omakase.service.TileRecognitionService;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class TileRecognitionControllerTest {
+
+  private final TileRecognitionService service = mock(TileRecognitionService.class);
+  private final TileRecognitionController controller = new TileRecognitionController(service);
+
+  private static TileRecognitionRequest request() {
+    TileRecognitionRequest request = new TileRecognitionRequest();
+    request.setImageBase64("BASE64");
+    request.setMimeType("image/jpeg");
+    return request;
+  }
+
+  /**
+   * Was 502, which Cloudflare replaces with its own branded gateway-error page — the user saw that
+   * instead of the reason. 503 is passed through, so the message below actually reaches the
+   * browser.
+   */
+  @Test
+  void answers503SoTheProxyDoesNotReplaceOurMessage() {
+    when(service.recognize(anyString(), anyString()))
+        .thenThrow(new IllegalStateException("This model is currently experiencing high demand."));
+
+    ResponseEntity<Object> response = controller.recognize(request());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getStatusCode()).isNotEqualTo(HttpStatus.BAD_GATEWAY);
+    assertThat(response.getBody())
+        .isEqualTo(Map.of("message", "This model is currently experiencing high demand."));
+  }
+
+  /** A missing key is a server-side configuration gap, so it belongs on the same branch. */
+  @Test
+  void answers503WhenNoKeyIsConfigured() {
+    when(service.recognize(anyString(), anyString()))
+        .thenThrow(new IllegalStateException("服务端未配置 Gemini API Key，请联系管理员"));
+
+    assertThat(controller.recognize(request()).getStatusCode())
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void returnsTheModelJsonOnSuccess() {
+    when(service.recognize(anyString(), anyString())).thenReturn("{\"concealed\":[\"1m\"]}");
+
+    ResponseEntity<Object> response = controller.recognize(request());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody())
+        .hasToString("TileRecognitionResponse(rawJson={\"concealed\":[\"1m\"]})");
+  }
+}

--- a/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
@@ -198,6 +198,34 @@ class TileRecognitionServiceTest {
     f.server().verify();
   }
 
+  /** An empty upstream body must not become {"message":""} — the status is all we have left. */
+  @Test
+  void reportsTheStatusWhenTheUpstreamBodyIsEmpty() {
+    Fixture f = build("key-a", "only-model");
+    f.server()
+        .expect(ExpectedCount.once(), header("x-goog-api-key", "key-a"))
+        .andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE));
+
+    assertThatThrownBy(() -> f.service().recognize("BASE64", "image/jpeg"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Gemini returned HTTP 503 with no message");
+    f.server().verify();
+  }
+
+  /** Same for a status nothing can retry: a bare 403 still has to say what happened. */
+  @Test
+  void reportsTheStatusWhenARejectionHasNoBody() {
+    Fixture f = build("key-a");
+    f.server()
+        .expect(ExpectedCount.once(), header("x-goog-api-key", "key-a"))
+        .andRespond(withStatus(HttpStatus.FORBIDDEN));
+
+    assertThatThrownBy(() -> f.service().recognize("BASE64", "image/jpeg"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Gemini returned HTTP 403 with no message");
+    f.server().verify();
+  }
+
   @Test
   void rejectsCallWhenNoKeyConfigured() {
     Fixture f = build("");

--- a/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
@@ -28,11 +28,18 @@ class TileRecognitionServiceTest {
   private record Fixture(TileRecognitionService service, MockRestServiceServer server) {}
 
   private Fixture build(String keys) {
+    return build(keys, "gemini-test");
+  }
+
+  private Fixture build(String keys, String models) {
     RestClient.Builder builder = RestClient.builder();
     MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
     return new Fixture(
-        new TileRecognitionService(new ObjectMapper(), builder.build(), keys, "gemini-test"),
-        server);
+        new TileRecognitionService(new ObjectMapper(), builder.build(), keys, models), server);
+  }
+
+  private static String overloadBody() {
+    return "{\"error\":{\"message\":\"This model is currently experiencing high demand.\"}}";
   }
 
   @Test
@@ -111,21 +118,63 @@ class TileRecognitionServiceTest {
   }
 
   /**
-   * The failure that actually happened in production. A 503 is Google running out of capacity, not
-   * our key running out of quota — the two must stay distinguishable, which is why the upstream
-   * text is passed through instead of being folded into one message.
+   * The failure that actually happened in production: three keys, three 503s, eight seconds, all
+   * doomed. A 503 is the model being over capacity, which every key sees alike, so with nothing to
+   * fall back to the right move is to stop at one call rather than burn the pool.
    */
   @Test
-  void surfacesUpstreamOverloadDistinctlyFromAQuotaFailure() {
-    Fixture f = build("key-a,key-b");
+  void doesNotRotateKeysWhenTheModelItselfIsOverCapacity() {
+    Fixture f = build("key-a,key-b,key-c", "only-model");
     f.server()
-        .expect(
-            ExpectedCount.twice(), header("x-goog-api-key", org.hamcrest.Matchers.notNullValue()))
+        .expect(ExpectedCount.once(), header("x-goog-api-key", "key-a"))
+        .andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE).body(overloadBody()));
+
+    assertThatThrownBy(() -> f.service().recognize("BASE64", "image/jpeg"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("experiencing high demand");
+    f.server().verify();
+  }
+
+  /** The point of the fallback chain: a busy model is survivable without waiting for Google. */
+  @Test
+  void fallsBackToTheNextModelWhenTheFirstIsOverCapacity() {
+    Fixture f = build("key-a", "busy-model,spare-model");
+    f.server()
+        .expect(requestTo(org.hamcrest.Matchers.containsString("models/busy-model:")))
+        .andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE).body(overloadBody()));
+    f.server()
+        .expect(requestTo(org.hamcrest.Matchers.containsString("models/spare-model:")))
+        .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));
+
+    assertThat(f.service().recognize("BASE64", "image/jpeg")).contains("1m");
+    f.server().verify();
+  }
+
+  /** The key is fine when the model is busy, so the fallback must not waste a key rotation. */
+  @Test
+  void keepsTheSameKeyWhenFallingBackToAnotherModel() {
+    Fixture f = build("key-a,key-b", "busy-model,spare-model");
+    f.server()
+        .expect(ExpectedCount.twice(), header("x-goog-api-key", "key-a"))
         .andRespond(
-            withStatus(HttpStatus.SERVICE_UNAVAILABLE)
-                .body(
-                    "{\"error\":{\"message\":\"This model is currently experiencing high"
-                        + " demand.\"}}"));
+            request ->
+                request.getURI().toString().contains("busy-model")
+                    ? withStatus(HttpStatus.SERVICE_UNAVAILABLE)
+                        .body(overloadBody())
+                        .createResponse(request)
+                    : withSuccess(OK_BODY, MediaType.APPLICATION_JSON).createResponse(request));
+
+    assertThat(f.service().recognize("BASE64", "image/jpeg")).contains("1m");
+    f.server().verify();
+  }
+
+  /** Every model busy means the fallback chain is spent, not that the keys are bad. */
+  @Test
+  void givesUpWhenEveryModelIsOverCapacity() {
+    Fixture f = build("key-a", "busy-one,busy-two");
+    f.server()
+        .expect(ExpectedCount.twice(), header("x-goog-api-key", "key-a"))
+        .andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE).body(overloadBody()));
 
     assertThatThrownBy(() -> f.service().recognize("BASE64", "image/jpeg"))
         .isInstanceOf(IllegalStateException.class)

--- a/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
@@ -95,6 +95,7 @@ class TileRecognitionServiceTest {
     f.server().verify();
   }
 
+  /** The upstream reason is surfaced verbatim — it is the most precise thing we have. */
   @Test
   void failsWithUpstreamMessageWhenEveryKeyIsExhausted() {
     Fixture f = build("key-a,key-b");
@@ -106,6 +107,29 @@ class TileRecognitionServiceTest {
     assertThatThrownBy(() -> f.service().recognize("BASE64", "image/jpeg"))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Quota exceeded");
+    f.server().verify();
+  }
+
+  /**
+   * The failure that actually happened in production. A 503 is Google running out of capacity, not
+   * our key running out of quota — the two must stay distinguishable, which is why the upstream
+   * text is passed through instead of being folded into one message.
+   */
+  @Test
+  void surfacesUpstreamOverloadDistinctlyFromAQuotaFailure() {
+    Fixture f = build("key-a,key-b");
+    f.server()
+        .expect(
+            ExpectedCount.twice(), header("x-goog-api-key", org.hamcrest.Matchers.notNullValue()))
+        .andRespond(
+            withStatus(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(
+                    "{\"error\":{\"message\":\"This model is currently experiencing high"
+                        + " demand.\"}}"));
+
+    assertThatThrownBy(() -> f.service().recognize("BASE64", "image/jpeg"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("experiencing high demand");
     f.server().verify();
   }
 


### PR DESCRIPTION
起因是 8/7 05:10 线上一次真实失败，日志完整记录了全过程：

```
05:10:33  Recognition request received: 1162 KB
05:10:35  Gemini key #1 exhausted (503): This model is currently experiencing high demand
05:10:36  Gemini key #2 exhausted (503): 同上
05:10:41  Gemini key #0 exhausted (503): 同上
05:10:41  Photo recognition unavailable → 返回 502
05:10:47  用户手动重试
05:11:21  Recognition succeeded in 34464 ms on key #0
```

一次失败暴露了四个独立的问题，每个 commit 修一个。

## 1. 502 让 Cloudflare 盖掉了错误原因（`1765082`）

`TileRecognitionController` 把上游失败包成 **502**。502 是「源站坏了」的专用信号，Cloudflare 看到就用自己的品牌错误页替换掉响应体 —— 于是「模型繁忙」这个准确提示被吃掉，用户看到一个跟麻将无关的网关错误页。

实际根本不是网关故障，是上游模型过载，**这正是 503 的语义**。改成 `SERVICE_UNAVAILABLE`，Cloudflare 会透传。

新增 `TileRecognitionControllerTest`（3 个），其中一条显式断言 `isNotEqualTo(BAD_GATEWAY)`。

## 2. 日志把 503 说成 "exhausted"，把排查带偏了（`006a04f`）

`isRetryable` 把 429/503/500 一起放过，但日志一律打印 `exhausted`。照这个措辞读日志会去查配额 —— 而真实原因是 Google 自己容量不够，跟配额毫无关系。**这个误导在 review 过程中真实发生了一次**（「我的 key 是免费的，不应该能用几千次吗？」）。

抽出 `isQuotaFailure`，日志说清是哪一种：

```
Gemini key #1 is out of quota (429): Quota exceeded for ...
Model gemini-3.6-flash is over capacity (503): This model is currently...
```

面向前端的文案**保持透传上游英文原文**，不做转述 —— 上游给的原因比任何概括都精确，而看这些信息的就是维护者本人。超时那条原来写死中文，现在改成 exception message，能区分 connect 还是 read timed out。

两处防御：
- 超时的 `getMessage()` 做了 null 兜底，否则会进到控制器 `Map.of("message", null)` 抛 NPE，变成 500 `An unexpected error occurred`，把超时本身藏起来
- 删掉 `lastError == null` 恒假分支（IDE 报的）

## 3. 换 key 对 503 完全无用（`e684625`）—— 本 PR 的重点

**503 是模型级别的容量问题，对每个 key 都一样。** 上面日志里那 8 秒就是三次注定失败的调用：三个 key 打的是同一个 `gemini-3.6-flash`。

改成两个游标，各自推进**真正能起作用**的那一维：

| 失败 | 原来 | 现在 |
|---|---|---|
| 429 配额 | 换 key ✓ | 换 key，同模型 ✓ |
| **503/500 过载** | **换 key ✗ 三次必失败** | **换模型，同 key** |
| 超时 | 换 key | 换 key（判断不了是谁的问题） |

配置 `gemini.model` → `gemini.models`，逗号分隔按顺序降级，和已有的 `api-keys` 写法一致。

副作用是**单模型下 503 立刻停在第一次调用**，不再浪费另外两次 —— 即使不配降级链，8/7 那次也会从 8 秒缩到 2 秒。

## 4. 降级链填入实际可用的模型（`11302a5`）

模型名不是猜的，是在服务器上拉 `/v1beta/models` 实际列表挑的：

**`gemini-3.6-flash` → `gemini-3.5-flash` → `gemini-3.5-flash-lite`**

都是 GA、都支持图片输入、各自独立容量池。最后一跳的 lite 是兜底：数牌和辨认 4s/5s 更弱，结果最好人过一眼再保存，但两档 flash 都满时有个不太准的结果好过没有。

排除的：`-pro`（识别已经要 11-24s，pro 更慢，有撞 100s 网关上限的风险）、`-preview`（名字会被下架，降级变 404 更糟）、`gemini-flash-latest`（别名，很可能就指向 3.6-flash，同一容量池等于没降级）。

只写在 `application.yml`，**没进 deploy.yml**：Spring 的 `${VAR:default}` 只在变量未定义时用默认值，一旦 deploy 传了个空的 `GEMINI_MODELS`，降级链会静默退化成单模型。

## 效果

8/7 那次如果重演：

```
key #0 + gemini-3.6-flash → 503 高负载   (~2s)
     ↓ 换模型，不换 key
key #0 + gemini-3.5-flash → 成功         (~15s)
```

不用等 Google 恢复，也不用手动重试。识别成功的日志现在会记下是哪个模型认的，结果可疑时先看这个：

```
Recognition succeeded in 15234 ms on key #0 with gemini-3.5-flash (321 chars returned)
```

## Review 时值得重点看的

1. **`TileRecognitionService.recognize()` 的双游标终止条件** —— 两个维度各自判断耗尽（`keyOffset >= apiKeys.size()` / `modelIndex >= models.size()`），加上原有的墙钟预算。这是本 PR 唯一有实质控制流复杂度的地方。
2. **降级链的取舍** —— 是否该把 lite 放进链里（错的手牌 vs 没有结果），以及是否该保留 `gemini-2.5-flash` 作为第四跳。
3. **透传英文** 是明确的决定，不是漏翻译。

## 测试

`TileRecognitionServiceTest` 13 个，新增 4 个全部围绕这次的行为变化：

- `doesNotRotateKeysWhenTheModelItselfIsOverCapacity` —— 单模型 503 只发 1 次请求（钉住不再白打三次）
- `fallsBackToTheNextModelWhenTheFirstIsOverCapacity` —— 降级到下一个模型
- `keepsTheSameKeyWhenFallingBackToAnotherModel` —— 降级时不浪费 key 轮换
- `givesUpWhenEveryModelIsOverCapacity` —— 链耗尽后放弃

另有之前补的 `spendsOnlyOneKeyWhenTheFirstOneSucceeds` / `movesToTheNextKeyOnTheFollowingRequest` 钉住轮换语义。

`./gradlew spotlessApply` / `tsc --noEmit` / `lint:css` / `compileJava` / `pmdMain` 全过，1368 前端测试 + Java 测试全绿。

## 已在服务器上做好的（不在这个 PR 里）

nginx 配置不在 repo 里，deploy 不覆盖。同一次排查里发现并已修：

```nginx
location /api/ {
    client_max_body_size 12m;   # 1.3MB 照片 base64 后超过 nginx 默认 1MB，之前报 413
    proxy_read_timeout 120s;    # 默认 60s，会比 Cloudflare 更早掐断
}
```

`client_max_body_size` 那条是把 Gemini 调用挪到后端代理时引入的回归 —— 以前浏览器直接 POST 给 Google，图片根本不经过 nginx。已验证：4MB 请求体返回 401（鉴权拦下）而不是 413。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tile recognition now supports multiple fallback models for improved availability.
  - Recognition can retry across configured API keys and models based on the type of service failure.
  - Model fallback configuration supports a prioritized, comma-separated list.

- **Bug Fixes**
  - Tile recognition failures now return the more accurate HTTP 503 Service Unavailable response.
  - Error messages and service status are preserved more consistently when recognition services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->