### PR TITLE
feat: 保留识别过的照片, 为本地模型攒训练数据

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
               -p 127.0.0.1:8080:8080 \
               -p '[::1]:8080:8080' \
               -v mahjong-data:/app/data \
+              -v mahjong-samples:/app/samples \
               -e ADMIN_EMAILS="${{ secrets.ADMIN_EMAILS }}" \
               -e CORS_ORIGINS="${{ secrets.CORS_ORIGINS }}" \
               -e GEMINI_API_KEYS="${{ secrets.GEMINI_API_KEYS }}" \

--- a/server/src/main/java/com/mahjong/omakase/service/RecognitionSampleStore.java
+++ b/server/src/main/java/com/mahjong/omakase/service/RecognitionSampleStore.java
@@ -1,0 +1,131 @@
+package com.mahjong.omakase.service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Keeps a copy of every recognised photo next to what the model answered.
+ *
+ * <p>Written for one purpose: a local tile detector needs training and evaluation data, and the
+ * only source of realistically framed photos of this particular tile set is the app itself. Today
+ * each photo is decoded, sent, and dropped, so every session that goes by is data lost for good.
+ * The corrected hand is already kept as {@code Round.winHand}; this supplies the missing half.
+ *
+ * <p>Deliberately best-effort. A failure here is logged and swallowed, never propagated — losing a
+ * training sample is a nuisance, failing a recognition the user is waiting on is not.
+ */
+@Slf4j
+@Component
+public class RecognitionSampleStore {
+
+  /** Server-generated, so nothing user-supplied ever reaches a path. */
+  private static final DateTimeFormatter DAY =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+
+  private static final DateTimeFormatter STAMP =
+      DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssSSS'Z'").withZone(ZoneOffset.UTC);
+
+  private static final Map<String, String> EXTENSIONS =
+      Map.of(
+          "image/jpeg", "jpg",
+          "image/png", "png",
+          "image/webp", "webp",
+          "image/heic", "heic",
+          "image/heif", "heif");
+
+  private final Optional<Path> root;
+
+  public RecognitionSampleStore(@Value("${recognition.sample-dir:}") String sampleDir) {
+    this.root =
+        sampleDir == null || sampleDir.isBlank()
+            ? Optional.empty()
+            : Optional.of(Path.of(sampleDir));
+    root.ifPresentOrElse(
+        dir -> log.info("Recognition samples will be written to {}", dir),
+        () -> log.info("Recognition samples are not being kept (recognition.sample-dir is unset)"));
+  }
+
+  /**
+   * Writes the photo and a sidecar JSON describing what the model made of it.
+   *
+   * <p>Both files share a stem so a later training script can pair them by name, and they are
+   * grouped into a directory per UTC day so no single directory grows unbounded and a date range is
+   * easy to pull.
+   */
+  public void save(String imageBase64, String mimeType, String model, String rawJson) {
+    if (root.isEmpty()) {
+      return;
+    }
+    try {
+      Instant now = Instant.now();
+      Path dir = root.get().resolve(DAY.format(now));
+      Files.createDirectories(dir);
+
+      String stem = STAMP.format(now) + "-" + model;
+      byte[] image = Base64.getDecoder().decode(imageBase64);
+      Files.write(dir.resolve(stem + "." + extensionFor(mimeType)), image);
+      Files.writeString(
+          dir.resolve(stem + ".json"),
+          sidecar(now, mimeType, model, rawJson),
+          StandardCharsets.UTF_8);
+
+      log.info("Kept recognition sample {} ({} KB)", stem, image.length / 1024);
+    } catch (IOException | RuntimeException e) {
+      log.warn("Could not keep a recognition sample: {}", e.toString());
+    }
+  }
+
+  private static String extensionFor(String mimeType) {
+    return EXTENSIONS.getOrDefault(mimeType, "bin");
+  }
+
+  /**
+   * Hand-built rather than serialised through Jackson because {@code rawJson} is the model's own
+   * JSON text and must be embedded verbatim, not re-parsed and reformatted — the point of keeping
+   * it is to see exactly what came back.
+   */
+  private static String sidecar(Instant now, String mimeType, String model, String rawJson) {
+    return "{\"recognizedAt\":\""
+        + now
+        + "\",\"model\":\""
+        + model
+        + "\",\"mimeType\":\""
+        + mimeType
+        + "\",\"rawJson\":"
+        + quote(rawJson)
+        + "}\n";
+  }
+
+  private static String quote(String value) {
+    StringBuilder out = new StringBuilder(value.length() + 2).append('"');
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"' -> out.append("\\\"");
+        case '\\' -> out.append("\\\\");
+        case '\n' -> out.append("\\n");
+        case '\r' -> out.append("\\r");
+        case '\t' -> out.append("\\t");
+        default -> {
+          if (c < 0x20) {
+            out.append(String.format("\\u%04x", (int) c));
+          } else {
+            out.append(c);
+          }
+        }
+      }
+    }
+    return out.append('"').toString();
+  }
+}

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -139,6 +139,7 @@ public class TileRecognitionService {
 
   private final ObjectMapper objectMapper;
   private final RestClient restClient;
+  private final RecognitionSampleStore sampleStore;
   private final List<String> apiKeys;
   private final List<String> models;
   private final String legendBase64;
@@ -147,9 +148,11 @@ public class TileRecognitionService {
   public TileRecognitionService(
       ObjectMapper objectMapper,
       RestClient geminiRestClient,
+      RecognitionSampleStore sampleStore,
       @Value("${gemini.api-keys:}") String rawApiKeys,
       @Value("${gemini.models:}") String rawModels) {
     this.objectMapper = objectMapper;
+    this.sampleStore = sampleStore;
     this.apiKeys = splitList(rawApiKeys);
     List<String> configured = splitList(rawModels);
     this.models = configured.isEmpty() ? List.of(DEFAULT_MODEL) : configured;
@@ -224,6 +227,8 @@ public class TileRecognitionService {
             keyIndex,
             model,
             text.length());
+        // After extractText, so a photo is only kept once there is an answer to pair it with.
+        sampleStore.save(imageBase64, mimeType, model, text);
         return text;
       } catch (RestClientResponseException e) {
         int status = e.getStatusCode().value();

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -52,3 +52,10 @@ google:
 gemini:
   api-keys: ${GEMINI_API_KEYS:}
   models: ${GEMINI_MODELS:gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite}
+
+# Every recognised photo is kept next to what the model answered, as training and evaluation data
+# for a possible local tile detector. Deliberately its own volume, not the DB one: at ~1.2MB a photo
+# this grows by a few hundred MB a month and would drag the nightly DB backup along with it.
+# Set to an empty value to stop keeping them.
+recognition:
+  sample-dir: ${RECOGNITION_SAMPLE_DIR:/app/samples}

--- a/server/src/test/java/com/mahjong/omakase/service/RecognitionSampleStoreTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/RecognitionSampleStoreTest.java
@@ -1,0 +1,108 @@
+package com.mahjong.omakase.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RecognitionSampleStoreTest {
+
+  private static final String JPEG = Base64.getEncoder().encodeToString(new byte[] {1, 2, 3, 4});
+
+  private static List<Path> filesUnder(Path root) throws IOException {
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile).sorted().toList();
+    }
+  }
+
+  @Test
+  void writesThePhotoAndASidecarSharingOneStem(@TempDir Path dir) throws IOException {
+    new RecognitionSampleStore(dir.toString())
+        .save(JPEG, "image/jpeg", "gemini-3.6-flash", "{\"concealed\":[\"1m\"]}");
+
+    List<Path> files = filesUnder(dir);
+    assertThat(files).hasSize(2);
+    String jpg = files.get(0).getFileName().toString();
+    String json = files.get(1).getFileName().toString();
+    assertThat(jpg).endsWith("-gemini-3.6-flash.jpg");
+    assertThat(json).endsWith("-gemini-3.6-flash.json");
+    // Pairing a photo with its answer is the whole point, so the stems have to match exactly.
+    assertThat(jpg.replace(".jpg", "")).isEqualTo(json.replace(".json", ""));
+  }
+
+  @Test
+  void writesTheDecodedImageBytesNotTheBase64(@TempDir Path dir) throws IOException {
+    new RecognitionSampleStore(dir.toString()).save(JPEG, "image/jpeg", "m", "{}");
+
+    Path jpg = filesUnder(dir).get(0);
+    assertThat(Files.readAllBytes(jpg)).containsExactly(1, 2, 3, 4);
+  }
+
+  @Test
+  void groupsSamplesIntoADirectoryPerDay(@TempDir Path dir) throws IOException {
+    new RecognitionSampleStore(dir.toString()).save(JPEG, "image/jpeg", "m", "{}");
+
+    Path day = filesUnder(dir).get(0).getParent();
+    assertThat(day.getFileName().toString()).matches("\\d{4}-\\d{2}-\\d{2}");
+    assertThat(day.getParent()).isEqualTo(dir);
+  }
+
+  /** The model's own JSON must survive verbatim — reformatting it would defeat keeping it. */
+  @Test
+  void embedsTheModelAnswerWithoutReparsingIt(@TempDir Path dir) throws IOException {
+    String raw = "{\n  \"notes\": \"quote \\\" and \\\\ backslash\",\n  \"concealed\": []\n}";
+    new RecognitionSampleStore(dir.toString()).save(JPEG, "image/heic", "gemini-3.5-flash", raw);
+
+    String sidecar =
+        Files.readString(
+            filesUnder(dir).stream()
+                .filter(p -> p.toString().endsWith(".json"))
+                .findFirst()
+                .orElseThrow(),
+            StandardCharsets.UTF_8);
+    assertThat(sidecar).contains("\"model\":\"gemini-3.5-flash\"", "\"mimeType\":\"image/heic\"");
+    // Escaped, so the sidecar stays parseable, and recoverable, so the original text is not lost.
+    assertThat(sidecar).contains("quote \\\\\\\" and \\\\\\\\ backslash");
+  }
+
+  @Test
+  void namesTheFileAfterTheActualImageType(@TempDir Path dir) throws IOException {
+    new RecognitionSampleStore(dir.toString()).save(JPEG, "image/heic", "m", "{}");
+    assertThat(filesUnder(dir).get(0).toString()).endsWith(".heic");
+  }
+
+  @Test
+  void keepsNothingWhenNoDirectoryIsConfigured(@TempDir Path dir) throws IOException {
+    new RecognitionSampleStore("").save(JPEG, "image/jpeg", "m", "{}");
+    new RecognitionSampleStore(null).save(JPEG, "image/jpeg", "m", "{}");
+    assertThat(filesUnder(dir)).isEmpty();
+  }
+
+  /**
+   * The caller is a user waiting on a recognition that already succeeded. Losing a training sample
+   * is a nuisance; turning it into a failed recognition is not acceptable.
+   */
+  @Test
+  void swallowsAnUndecodableImageRatherThanFailingTheRecognition(@TempDir Path dir)
+      throws IOException {
+    new RecognitionSampleStore(dir.toString()).save("not base64!!", "image/jpeg", "m", "{}");
+    assertThat(filesUnder(dir)).isEmpty();
+  }
+
+  @Test
+  void swallowsAnUnwritableDirectoryRatherThanFailingTheRecognition(@TempDir Path dir)
+      throws IOException {
+    // A path whose parent is a regular file can never be created.
+    Path file = Files.createFile(dir.resolve("occupied"));
+    new RecognitionSampleStore(file.resolve("nested").toString())
+        .save(JPEG, "image/jpeg", "m", "{}");
+    assertThat(filesUnder(dir)).containsExactly(file);
+  }
+}

--- a/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
@@ -35,7 +35,9 @@ class TileRecognitionServiceTest {
     RestClient.Builder builder = RestClient.builder();
     MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
     return new Fixture(
-        new TileRecognitionService(new ObjectMapper(), builder.build(), keys, models), server);
+        new TileRecognitionService(
+            new ObjectMapper(), builder.build(), new RecognitionSampleStore(""), keys, models),
+        server);
   }
 
   private static String overloadBody() {
@@ -252,7 +254,8 @@ class TileRecognitionServiceTest {
     RestClient.Builder builder = RestClient.builder();
     MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
     TileRecognitionService service =
-        new TileRecognitionService(new ObjectMapper(), builder.build(), "key-a", "  ");
+        new TileRecognitionService(
+            new ObjectMapper(), builder.build(), new RecognitionSampleStore(""), "key-a", "  ");
     server
         .expect(requestTo(org.hamcrest.Matchers.containsString("models/gemini-3.6-flash:")))
         .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));


### PR DESCRIPTION
起因是在讨论「本地训一个牌面检测器会不会比调 API 更快更稳」时发现的一件事：

**现在每张照片解码、发出去、然后就丢了。** 想训本地模型的话，唯一能拿到「这副牌、这个拍摄角度、这种光线」的真实照片来源就是这个 app 本身 —— 所以每打一局过去，就是永久丢掉一份数据。

人工校正后的手牌其实已经存着（`Round.winHand`），缺的只是照片这一半。这个 PR 补上。

## 落盘结构

照片和 sidecar 同名，便于配对：

```
/app/samples/2026-08-07/20260807T023027123Z-gemini-3.6-flash.jpg
/app/samples/2026-08-07/20260807T023027123Z-gemini-3.6-flash.json
```

sidecar 内容：

```json
{"recognizedAt":"2026-08-07T02:30:27.123Z","model":"gemini-3.6-flash","mimeType":"image/jpeg","rawJson":"{\"concealed\":[...]}"}
```

按 UTC 日期分目录 —— 单个目录不会无限膨胀，取某个日期区间也方便。

## 刻意的决定

| 决定 | 原因 |
|---|---|
| **独立卷 `mahjong-samples`** | 不放进 `mahjong-data`。后者是 DB 所在且有备份 cron 在拷，塞进每月几百 MB 的照片会让备份越来越慢越来越大 |
| **存原图不缩放** | 服务器 18GB 可用，按 1.2MB/张、每月 250 张算能存 **约 5 年**。而缩放会丢掉恰恰需要的细节 —— 比如 5s 中间那根红竖条，那正是现在 prompt 里要写规则去纠正的地方 |
| **不加容量上限 / 不加清理逻辑** | 5 年的余量，写了就是投机性代码。数学写在注释里，到时候再说 |
| **只在识别成功后存** | 这样照片总有一份答案可配对。失败的照片没有标签 |
| **`rawJson` 手工拼、不过 Jackson** | 那是模型自己输出的 JSON 文本，必须**原样**保留。重新解析再格式化就失去了保留它的意义 |
| **catch 写得很宽，且只记日志不抛** | 见下 |
| **路径完全由服务端生成** | 时间戳 + 模型名，用户提供的内容不参与路径构造，没有穿越风险 |

## 关于那个宽泛的 catch

```java
} catch (IOException | RuntimeException e) {
  log.warn("Could not keep a recognition sample: {}", e.toString());
}
```

调用点在**用户正在等的那次识别的成功路径上**。从这里抛出任何异常都会逃出 `recognize()`，控制器只 catch `IllegalStateException`，于是会被 `GlobalExceptionHandler` 兜成 500 —— 把一次成功的识别变成失败。

丢一份训练样本是小事，把成功的识别搞失败不是。两个测试专门钉住这一点：`swallowsAnUndecodableImageRatherThanFailingTheRecognition` 和 `swallowsAnUnwritableDirectoryRatherThanFailingTheRecognition`。

（`AvoidCatchingGenericException` 在 `config/pmd/ruleset.xml:106` 已经是排除项。）

## 部署后需要做的

新增了一个 volume，所以**这次要重新 deploy 才会生效**（`docker run` 的参数变了）。生效后启动日志会有：

```
Recognition samples will be written to /app/samples
```

之后每次识别成功会多一行：

```
Kept recognition sample 20260807T023027123Z-gemini-3.6-flash (1042 KB)
```

想停止收集：`-e RECOGNITION_SAMPLE_DIR=""`，或者把 `application.yml` 里的 `sample-dir` 清空。

查看已攒了多少：

```bash
du -sh /var/lib/docker/volumes/mahjong-samples/_data
find /var/lib/docker/volumes/mahjong-samples/_data -name '*.json' | wc -l
```

## 这个 PR 不做的事

**没有把照片和「人工校正后的手牌」显式关联起来。** 现在只能靠时间戳 + session 顺序离线对齐 —— 日志里 `Recognition succeeded` 到 `Adding round` 通常在一分钟内，多数情况够用，但用户识别完又删掉重识别的时候会对错（8/7 的日志里就有这种情况）。

要做到精确关联需要：`/api/recognize` 返回一个 sample id → 前端把它带进 `addRound` → `Round` 加一列存它。那是跨 DTO / 实体 / 前端的改动，等这批数据真的开始用于评估时再说。

**照片的主要价值（检测框的训练数据）不依赖这个关联** —— 框是要靠标注工具画的，`winHand` 主要用于评估阶段的验证。所以先把照片存下来是无论如何都不亏的一步。

## 测试

`RecognitionSampleStoreTest` 8 个：

- 照片和 sidecar 同 stem（配对是全部意义所在）
- 写的是解码后的字节而不是 base64
- 按天分目录
- 模型答案原样嵌入且转义正确
- 扩展名跟随实际图片类型（heic 不会被写成 .jpg）
- 未配置目录时什么都不写
- 图片解不开时不抛
- 目录不可写时不抛

`./gradlew spotlessApply` / `tsc --noEmit` / `lint:css` / `compileJava` / `pmdMain` 全过，**119 个 Java 测试 + 1368 个前端测试全绿**。