### PR TITLE
perf(ml): 用几何拟合定位牌格, 识别从 21s 降到 0.7s

### DIFF
--- a/ml/grid_fit.py
+++ b/ml/grid_fit.py
@@ -106,9 +106,9 @@ def fit_grid(
         return None
 
     # Candidate pitches come from the gaps between marks. A gap can span more than one tile — an
-    # undetected boundary leaves a double gap — so each is also divided by 2, 3 and 4. Rounded to
-    # half a pixel: the marks themselves are only that accurate, and without it a photo of this size
-    # produces a couple of thousand near-duplicate candidates and the search dominates the runtime.
+    # undetected boundary leaves a double gap — so each is also divided by 2, 3 and 4. They are then
+    # rounded to PITCH_QUANTUM, which collapses a couple of thousand near-duplicates; see the note on
+    # that constant for why the coarseness matters.
     positions = np.array(marks, dtype=float)
     gaps = positions[None, :] - positions[:, None]
     pitches = np.concatenate([gaps[gaps > 0] / divisor for divisor in (1, 2, 3, 4)])
@@ -154,31 +154,59 @@ CALIBRATION = Path(__file__).resolve().parents[1] / "server/src/main/resources/c
 # Rows of the brown-table photo and columns of the green-felt one, with the counts that are known by
 # construction. The 7-tile row matters: it is the one case where the count differs from the others, so
 # it catches a fit that has quietly learned to answer nine.
+#
+# The pitch is recorded alongside, because the count on its own is a weak assertion: a grid can return
+# the right number of tiles on a pitch that is a few percent out, and every crop then creeps along the
+# row until the last ones straddle two tiles. These pitches were confirmed by eye — the crops they
+# produce are the 34 faces in data/faces_contact_sheet.png — so they are a reference, not a snapshot of
+# whatever the code happened to print.
 KNOWN = [
-    ("brown row 1 (萬)", "system_mahjong_calibration.jpg", (43, 37, 1018, 149), False, 9),
-    ("brown row 2 (饼)", "system_mahjong_calibration.jpg", (41, 186, 1030, 155), False, 9),
-    ("brown row 3 (条)", "system_mahjong_calibration.jpg", (32, 341, 1044, 158), False, 9),
-    ("brown row 4 (字)", "system_mahjong_calibration.jpg", (27, 499, 829, 156), False, 7),
-    ("green column 1", "system_mahjong_calibration_2.jpg", (78, 0, 280, 1924), True, 9),
-    ("green column 2", "system_mahjong_calibration_2.jpg", (358, 0, 280, 1924), True, 9),
-    ("green column 3", "system_mahjong_calibration_2.jpg", (638, 0, 280, 1924), True, 9),
-    ("green column 4", "system_mahjong_calibration_2.jpg", (918, 0, 280, 1924), True, 9),
+    ("brown row 1 (萬)", "system_mahjong_calibration.jpg", (43, 37, 1018, 149), False, 9, 110.5),
+    ("brown row 2 (饼)", "system_mahjong_calibration.jpg", (41, 186, 1030, 155), False, 9, 113.5),
+    ("brown row 3 (条)", "system_mahjong_calibration.jpg", (32, 341, 1044, 158), False, 9, 113.5),
+    ("brown row 4 (字)", "system_mahjong_calibration.jpg", (27, 499, 829, 156), False, 7, 118.0),
+    ("green column 1", "system_mahjong_calibration_2.jpg", (78, 0, 280, 1924), True, 9, 206.5),
+    ("green column 2", "system_mahjong_calibration_2.jpg", (358, 0, 280, 1924), True, 9, 207.0),
+    ("green column 3", "system_mahjong_calibration_2.jpg", (638, 0, 280, 1924), True, 9, 206.0),
+    ("green column 4", "system_mahjong_calibration_2.jpg", (918, 0, 280, 1924), True, 9, 209.0),
 ]
+
+PITCH_TOLERANCE = 0.02  # of the expected pitch
+# The tiles have to account for the run. Anything less means the grid sits on part of it and the rest
+# went unread; anything more and it runs off the end onto the table.
+MIN_SPAN = 0.90
+MAX_SPAN = 1.05
 
 
 def self_check() -> int:
     failures = 0
-    for name, photo, box, vertical, expected in KNOWN:
+    for name, photo, box, vertical, count, pitch in KNOWN:
         bgr = cv2.imread(str(CALIBRATION / photo))
         if bgr is None:
             sys.exit(f"cannot read {CALIBRATION / photo}")
         light = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB)[:, :, 0].astype(float)
+        length = box[3] if vertical else box[2]
         fit = fit_grid(light, box, vertical)
-        got = fit[2] if fit else None
-        ok = got == expected
-        failures += not ok
-        detail = f"pitch {fit[0]:6.2f} offset {fit[1]:6.1f}" if fit else "no fit"
-        print(f"  {'ok  ' if ok else 'FAIL'} {name:20s} expected {expected:2d} got {got}  {detail}")
+
+        if fit is None:
+            print(f"  FAIL {name:20s} no fit")
+            failures += 1
+            continue
+        got_pitch, got_offset, got_count = fit
+        span = (got_offset + got_count * got_pitch) / length
+        problems = []
+        if got_count != count:
+            problems.append(f"count {got_count} != {count}")
+        if abs(got_pitch - pitch) > pitch * PITCH_TOLERANCE:
+            problems.append(f"pitch {got_pitch:.2f} != {pitch:.2f}")
+        if not MIN_SPAN <= span <= MAX_SPAN:
+            problems.append(f"covers {span:.2f} of the run")
+        failures += bool(problems)
+        print(
+            f"  {'ok  ' if not problems else 'FAIL'} {name:20s}"
+            f" count {got_count:2d} pitch {got_pitch:6.2f} offset {got_offset:6.1f}"
+            f" span {span:.2f}  {'; '.join(problems)}"
+        )
     print(f"\n{len(KNOWN) - failures}/{len(KNOWN)} correct")
     return failures
 

--- a/ml/grid_fit.py
+++ b/ml/grid_fit.py
@@ -167,36 +167,47 @@ CALIBRATION = Path(__file__).resolve().parents[1] / "server/src/main/resources/c
 #
 # The pitch is recorded alongside, because the count on its own is a weak assertion: a grid can return
 # the right number of tiles on a pitch that is a few percent out, and every crop then creeps along the
-# row until the last ones straddle two tiles. These pitches were confirmed by eye — the crops they
-# produce are the 34 faces in data/faces_contact_sheet.png — so they are a reference, not a snapshot of
-# whatever the code happened to print.
+# row until the last ones straddle two tiles. These are the constrained path's answers, which is what
+# the slicer uses, and each agrees with (length - offset) / count to within a percent — so they are
+# checkable against the geometry rather than being a snapshot of whatever the code printed.
+# `blind` is what the unconstrained fit should answer — the path a hand photo takes, where the count is
+# unknown. It is not always the truth: the 条 column of the green photo answers thirteen instead of
+# nine, because those tiles lie a quarter turn over and the bamboo runs along the axis being fitted.
+# Recording that keeps the limitation visible and still catches a change to it, which asserting only
+# the constrained path would not: the PITCH_QUANTUM regression that this check caught showed up as a
+# wrong *unconstrained* count, and narrowing the candidates to a known count hides exactly that.
 KNOWN = [
-    ("brown row 1 (萬)", "system_mahjong_calibration.jpg", (43, 37, 1018, 149), False, 9, 110.5),
-    ("brown row 2 (饼)", "system_mahjong_calibration.jpg", (41, 186, 1030, 155), False, 9, 113.5),
-    ("brown row 3 (条)", "system_mahjong_calibration.jpg", (32, 341, 1044, 158), False, 9, 113.5),
-    ("brown row 4 (字)", "system_mahjong_calibration.jpg", (27, 499, 829, 156), False, 7, 118.0),
-    ("green column 1", "system_mahjong_calibration_2.jpg", (78, 0, 280, 1924), True, 9, 206.5),
-    ("green column 2", "system_mahjong_calibration_2.jpg", (358, 0, 280, 1924), True, 9, 207.0),
-    ("green column 3", "system_mahjong_calibration_2.jpg", (638, 0, 280, 1924), True, 9, 206.0),
-    ("green column 4", "system_mahjong_calibration_2.jpg", (918, 0, 280, 1924), True, 9, 209.0),
+    ("brown row 1 (萬)", "system_mahjong_calibration.jpg", (43, 37, 1018, 149), False, 9, 113.0, 9),
+    ("brown row 2 (饼)", "system_mahjong_calibration.jpg", (41, 186, 1030, 155), False, 9, 112.0, 9),
+    ("brown row 3 (条)", "system_mahjong_calibration.jpg", (32, 341, 1044, 158), False, 9, 113.5, 9),
+    ("brown row 4 (字)", "system_mahjong_calibration.jpg", (27, 499, 829, 156), False, 7, 118.2, 7),
+    ("green column 1", "system_mahjong_calibration_2.jpg", (99, 0, 271, 1924), True, 9, 204.5, 9),
+    ("green column 2", "system_mahjong_calibration_2.jpg", (370, 0, 271, 1924), True, 9, 207.0, 13),
+    ("green column 3", "system_mahjong_calibration_2.jpg", (641, 0, 271, 1924), True, 9, 207.0, 9),
+    ("green column 4", "system_mahjong_calibration_2.jpg", (912, 0, 271, 1924), True, 9, 204.5, 9),
 ]
 
-PITCH_TOLERANCE = 0.02  # of the expected pitch
-# The tiles have to account for the run. Anything less means the grid sits on part of it and the rest
-# went unread; anything more and it runs off the end onto the table.
-MIN_SPAN = 0.90
-MAX_SPAN = 1.05
+PITCH_TOLERANCE = 0.03  # of the expected pitch
+# The parameter-free half of the assertion: the tiles have to account for the run, because the run's
+# box *is* the tiles. Anything less means the grid sits on part of it and the rest went unread;
+# anything more and it runs off the end onto the table. Tighter than the pitch check and needing no
+# reference value, so it is the one that would survive a re-shot calibration photo.
+MIN_SPAN = 0.97
+MAX_SPAN = 1.03
 
 
 def self_check() -> int:
     failures = 0
-    for name, photo, box, vertical, count, pitch in KNOWN:
+    for name, photo, box, vertical, count, pitch, blind in KNOWN:
         bgr = cv2.imread(str(CALIBRATION / photo))
         if bgr is None:
             sys.exit(f"cannot read {CALIBRATION / photo}")
         light = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB)[:, :, 0].astype(float)
         length = box[3] if vertical else box[2]
-        fit = fit_grid(light, box, vertical)
+        # Both paths: the slicer tells fit_grid the count it knows, a hand photo cannot.
+        fit = fit_grid(light, box, vertical, expect=count)
+        unconstrained = fit_grid(light, box, vertical)
+        got_blind = unconstrained[2] if unconstrained else None
 
         if fit is None:
             print(f"  FAIL {name:20s} no fit")
@@ -211,11 +222,13 @@ def self_check() -> int:
             problems.append(f"pitch {got_pitch:.2f} != {pitch:.2f}")
         if not MIN_SPAN <= span <= MAX_SPAN:
             problems.append(f"covers {span:.2f} of the run")
+        if got_blind != blind:
+            problems.append(f"unconstrained {got_blind} != {blind}")
         failures += bool(problems)
         print(
             f"  {'ok  ' if not problems else 'FAIL'} {name:20s}"
             f" count {got_count:2d} pitch {got_pitch:6.2f} offset {got_offset:6.1f}"
-            f" span {span:.2f}  {'; '.join(problems)}"
+            f" span {span:.2f} blind {got_blind}  {'; '.join(problems)}"
         )
     print(f"\n{len(KNOWN) - failures}/{len(KNOWN)} correct")
     return failures

--- a/ml/grid_fit.py
+++ b/ml/grid_fit.py
@@ -1,0 +1,187 @@
+"""Locates a row of butted tiles geometrically, before any model is involved.
+
+The first version searched for the grid by brute force — every plausible tile count, times a range of
+pitches, times a range of offsets — and scored each candidate by running the classifier over the crops
+it produced. It works, and on one real photo it cost 1,680 grid hypotheses and 22,680 tile
+classifications: 21 seconds of inference to read one hand. Fine for a script, hopeless for a phone.
+
+Almost all of that was recovering something the pixels already say. Tiles in a row are periodic, so
+the boundaries between them fall at regular intervals, and fitting a regular grid to them gives the
+pitch and offset directly. The count then follows from the length. No inference at all.
+
+Three things about this were learned the hard way, each after getting it wrong first:
+
+**A boundary is not always dark.** On the brown-table calibration photo the tiles are pressed so close
+that what separates two of them is the *lit bevel* of the next one — brighter than the face beside it.
+Looking only for dips read three of its four rows wrong. Both minima and maxima are collected.
+
+**Autocorrelation is not precise enough.** It looked like the obvious tool and returned a pitch of 81
+against a true 86.9 on the real photo. Six percent compounds over thirteen tiles into most of a tile,
+so the boundaries have to be located and fitted individually.
+
+**A grid three times too coarse can explain more marks than the right one.** The bamboo of the 条 suit
+is itself a row of vertical bars, which litters the profile with spurious marks — 31 of them across
+nine tiles. With the tolerance scaled to the pitch, a 3-tile grid over that row had a tolerance of
+36px and caught 13 marks on 4 grid lines, tying the true 9-tile grid. Hence MAX_MARKS_PER_LINE: a
+boundary should account for about one mark, and a grid claiming three each is not describing tiles.
+
+Run `python grid_fit.py` to check all of this against the two calibration photos, whose tile counts
+are known. The margin on the last of those rules is thin — 1.4 passes and 1.5 does not — so the check
+exists to catch the next change that quietly breaks it.
+"""
+
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+# A tile is roughly 3:2, but perspective flattens it, so this stays generous. It only has to exclude
+# pitches that would make a "tile" a sliver or two tiles wide.
+MIN_PITCH_RATIO = 0.45
+MAX_PITCH_RATIO = 2.2
+
+EDGE_STRIP = 0.15  # fraction of the run's width sampled along its edge, where the face is plain
+EDGE_PERCENTILE = 85  # of that strip, so a character reaching into it does not drag the profile down
+SMOOTH = 5
+MIN_SEPARATION = 0.45  # of the smallest plausible pitch; closer extrema are the same boundary
+FIT_TOLERANCE = 0.12  # of the pitch, for a mark to count as explained by a grid line
+MAX_MARKS_PER_LINE = 1.4  # above this the grid is too coarse to be describing tile boundaries
+# Candidate pitches are rounded to this before searching, which collapses a couple of thousand
+# near-duplicates and takes the fit from 450ms to 40ms. Not coarser than this: at half a pixel the
+# 萬 row of the brown photo starts answering fourteen tiles instead of nine, which is what the
+# self-check below is for — the speed-up was written first and this caught it.
+PITCH_QUANTUM = 0.1
+
+
+def _extrema(profile: np.ndarray, separation: int) -> list[int]:
+    """Local minima and maxima of the profile, thinned so each boundary is reported once."""
+    smoothed = np.convolve(profile, np.ones(SMOOTH) / SMOOTH, mode="same")
+    window = max(separation // 2, 3)
+    marks: set[int] = set()
+    for want_min in (True, False):
+        found: list[int] = []
+        for i in range(window, len(smoothed) - window):
+            neighbourhood = smoothed[i - window : i + window + 1]
+            if smoothed[i] != (neighbourhood.min() if want_min else neighbourhood.max()):
+                continue
+            if not found or i - found[-1] > separation:
+                found.append(i)
+            else:
+                better = (
+                    smoothed[i] < smoothed[found[-1]]
+                    if want_min
+                    else smoothed[i] > smoothed[found[-1]]
+                )
+                if better:
+                    found[-1] = i
+        marks.update(found)
+    return sorted(marks)
+
+
+def _edge_profile(light: np.ndarray, box: tuple[int, int, int, int], vertical: bool) -> np.ndarray:
+    """Lightness along the run, sampled from a strip at its edge.
+
+    The edge rather than the whole width: in the middle the engraved characters swing the profile as
+    far as the boundaries do, and the periodic signal disappears into them.
+    """
+    x, y, w, h = box
+    region = light[y : y + h, x : x + w]
+    across = w if vertical else h
+    depth = max(int(across * EDGE_STRIP), 4)
+    strip = region[:, :depth] if vertical else region[:depth, :]
+    return np.percentile(strip, EDGE_PERCENTILE, axis=1 if vertical else 0)
+
+
+def fit_grid(
+    light: np.ndarray, box: tuple[int, int, int, int], vertical: bool
+) -> tuple[float, float, int] | None:
+    """Pitch, offset and tile count for one run, along its long axis and relative to its own box."""
+    x, y, w, h = box
+    length, across = (h, w) if vertical else (w, h)
+    low, high = across * MIN_PITCH_RATIO, across * MAX_PITCH_RATIO
+
+    marks = _extrema(_edge_profile(light, box, vertical), int(low * MIN_SEPARATION))
+    if len(marks) < 3:
+        return None
+
+    # Candidate pitches come from the gaps between marks. A gap can span more than one tile — an
+    # undetected boundary leaves a double gap — so each is also divided by 2, 3 and 4. Rounded to
+    # half a pixel: the marks themselves are only that accurate, and without it a photo of this size
+    # produces a couple of thousand near-duplicate candidates and the search dominates the runtime.
+    positions = np.array(marks, dtype=float)
+    gaps = positions[None, :] - positions[:, None]
+    pitches = np.concatenate([gaps[gaps > 0] / divisor for divisor in (1, 2, 3, 4)])
+    pitches = pitches[(pitches >= low) & (pitches <= high)]
+    if pitches.size == 0:
+        return None
+    candidates = np.unique(np.round(pitches / PITCH_QUANTUM) * PITCH_QUANTUM)
+
+    best = None
+    for pitch in candidates:
+        tolerance = pitch * FIT_TOLERANCE
+        # Every mark is a candidate anchor; score them all at once. offsets[i] is the grid phase that
+        # puts a line exactly on mark i, and distance[i, j] is how far mark j then sits from its
+        # nearest line.
+        offsets = positions % pitch
+        phase = (positions[None, :] - offsets[:, None] + pitch / 2) % pitch - pitch / 2
+        hits = (np.abs(phase) <= tolerance).sum(axis=1)
+        lines = ((length - offsets) / pitch).astype(int) + 1
+        hits = np.where(hits <= lines * MAX_MARKS_PER_LINE, hits, -1)
+        winner = int(hits.argmax())
+        if hits[winner] < 0:
+            continue
+        # Most marks explained wins. Ties go to the larger pitch: half the true pitch explains every
+        # boundary just as well, and then invents one through the middle of each tile.
+        if best is None or (int(hits[winner]), float(pitch)) > best[0]:
+            best = ((int(hits[winner]), float(pitch)), float(pitch), float(offsets[winner]))
+    if best is None:
+        return None
+
+    _, pitch, offset = best
+    # Slide back to the first grid line inside the run, then take as many whole tiles as fit. The
+    # run's box is the tiles themselves, so this is normally all of it.
+    while offset - pitch >= -pitch * 0.25:
+        offset -= pitch
+    count = int((length - offset) / pitch + 0.25)
+    return (pitch, offset, count) if count >= 1 else None
+
+
+# ── self-check ─────────────────────────────────────────────────────────────
+
+CALIBRATION = Path(__file__).resolve().parents[1] / "server/src/main/resources/calibration"
+
+# Rows of the brown-table photo and columns of the green-felt one, with the counts that are known by
+# construction. The 7-tile row matters: it is the one case where the count differs from the others, so
+# it catches a fit that has quietly learned to answer nine.
+KNOWN = [
+    ("brown row 1 (萬)", "system_mahjong_calibration.jpg", (43, 37, 1018, 149), False, 9),
+    ("brown row 2 (饼)", "system_mahjong_calibration.jpg", (41, 186, 1030, 155), False, 9),
+    ("brown row 3 (条)", "system_mahjong_calibration.jpg", (32, 341, 1044, 158), False, 9),
+    ("brown row 4 (字)", "system_mahjong_calibration.jpg", (27, 499, 829, 156), False, 7),
+    ("green column 1", "system_mahjong_calibration_2.jpg", (78, 0, 280, 1924), True, 9),
+    ("green column 2", "system_mahjong_calibration_2.jpg", (358, 0, 280, 1924), True, 9),
+    ("green column 3", "system_mahjong_calibration_2.jpg", (638, 0, 280, 1924), True, 9),
+    ("green column 4", "system_mahjong_calibration_2.jpg", (918, 0, 280, 1924), True, 9),
+]
+
+
+def self_check() -> int:
+    failures = 0
+    for name, photo, box, vertical, expected in KNOWN:
+        bgr = cv2.imread(str(CALIBRATION / photo))
+        if bgr is None:
+            sys.exit(f"cannot read {CALIBRATION / photo}")
+        light = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB)[:, :, 0].astype(float)
+        fit = fit_grid(light, box, vertical)
+        got = fit[2] if fit else None
+        ok = got == expected
+        failures += not ok
+        detail = f"pitch {fit[0]:6.2f} offset {fit[1]:6.1f}" if fit else "no fit"
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:20s} expected {expected:2d} got {got}  {detail}")
+    print(f"\n{len(KNOWN) - failures}/{len(KNOWN)} correct")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if self_check() else 0)

--- a/ml/grid_fit.py
+++ b/ml/grid_fit.py
@@ -94,12 +94,22 @@ def _edge_profile(light: np.ndarray, box: tuple[int, int, int, int], vertical: b
 
 
 def fit_grid(
-    light: np.ndarray, box: tuple[int, int, int, int], vertical: bool
+    light: np.ndarray, box: tuple[int, int, int, int], vertical: bool, expect: int | None = None
 ) -> tuple[float, float, int] | None:
-    """Pitch, offset and tile count for one run, along its long axis and relative to its own box."""
+    """Pitch, offset and tile count for one run, along its long axis and relative to its own box.
+
+    `expect` narrows the candidate pitches to those that would produce that many tiles. It is for
+    callers that know the answer by construction — slicing a calibration photo whose layout is fixed —
+    and is not a substitute for the search: the 条 suit is itself a row of vertical bars, and on the
+    green photo, where the tiles lie a quarter turn over so those bars run along the axis being fitted,
+    the unconstrained fit answers thirteen tiles instead of nine.
+    """
     x, y, w, h = box
     length, across = (h, w) if vertical else (w, h)
     low, high = across * MIN_PITCH_RATIO, across * MAX_PITCH_RATIO
+    if expect:
+        nominal = length / expect
+        low, high = max(low, nominal * 0.9), min(high, nominal * 1.1)
 
     marks = _extrema(_edge_profile(light, box, vertical), int(low * MIN_SEPARATION))
     if len(marks) < 3:

--- a/ml/slice_calibration.py
+++ b/ml/slice_calibration.py
@@ -35,8 +35,12 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from grid_fit import fit_grid
+from synthesize import BACK
+
 ROOT = Path(__file__).resolve().parents[1]
 CALIBRATION = ROOT / "server/src/main/resources/calibration/system_mahjong_calibration.jpg"
+CALIBRATION_2 = ROOT / "server/src/main/resources/calibration/system_mahjong_calibration_2.jpg"
 OUT = Path(__file__).resolve().parent / "data"
 
 # Row layout of the photo, in the order the tiles appear.
@@ -54,6 +58,7 @@ FACE_LIGHTNESS = 130  # a tile face is comfortably above this, bare table well b
 MASK_LIGHTNESS = 140
 
 MIN_COVERAGE = 0.9  # a row or column of a crop must be this much tile to be kept
+
 
 # The shadow line where one tile meets the next: dark across nearly the whole width, and unbroken.
 # Unbroken is the part that matters. The three circles along the bottom of 9p cover 83% of the width
@@ -206,6 +211,95 @@ def trim(
     return tx0, tx1, ty0, ty1 if seam is None else ty0 + seam
 
 
+def write_variant(label: str, source: str, crop: np.ndarray, mask: np.ndarray) -> None:
+    """One appearance of one tile. A label can have several — see the note in synthesize.py."""
+    for directory, image in (("faces", crop), ("masks", mask.astype(np.uint8) * 255)):
+        path = OUT / directory / label
+        path.mkdir(parents=True, exist_ok=True)
+        cv2.imwrite(str(path / f"{source}.png"), image)
+
+
+# The second photo is the other set of tiles, on the other table. Laid out as four columns of nine
+# rather than four rows, rotated a quarter turn, and with a tile back of each colour above the honours.
+# Reading each column from the bottom gives the ascending order.
+COLUMNS = [
+    [f"{n}m" for n in range(1, 10)],
+    [f"{n}s" for n in range(1, 10)],
+    [f"{n}p" for n in range(1, 10)],
+    [f"{n}z" for n in range(1, 8)] + [BACK, BACK],
+]
+
+# The felt is far darker than the brown table was, so the threshold that separates tile from
+# background is different — and the blue tile back is strongly coloured, so it is admitted on
+# lightness alone rather than being required to be neutral.
+GREEN_FELT_LIGHTNESS = 70
+GREEN_FELT_CHROMA = 30
+BACK_LIGHTNESS = 110
+
+
+def slice_second_set() -> list[tuple[str, np.ndarray]]:
+    """Cuts the green-felt photo, adding a second appearance of every face plus the tile backs."""
+    bgr = cv2.imread(str(CALIBRATION_2))
+    if bgr is None:
+        print(f"no second calibration photo at {CALIBRATION_2}, skipping")
+        return []
+    lab = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB)
+    light = lab[:, :, 0].astype(np.int16)
+    chroma = np.hypot(lab[:, :, 1].astype(np.int16) - 128, lab[:, :, 2].astype(np.int16) - 128)
+    solid = (
+        (light > GREEN_FELT_LIGHTNESS)
+        & ((chroma < GREEN_FELT_CHROMA) | (light > BACK_LIGHTNESS))
+    ).astype(np.uint8)
+    solid = cv2.morphologyEx(solid, cv2.MORPH_CLOSE, np.ones((21, 21), np.uint8))
+
+    count, _, stats, _ = cv2.connectedComponentsWithStats(solid, connectivity=4)
+    if count < 2:
+        print("no tiles found in the second calibration photo, skipping")
+        return []
+    block = max(range(1, count), key=lambda i: stats[i][4])
+    _, by, _, bh = (int(v) for v in stats[block][:4])
+
+    # The horizontal span comes from where the mask actually covers the height, not from the blob's
+    # bounding box: closing the mask rounds its corners outward and the box ends up some twenty pixels
+    # wider than the tiles, which is enough drift over four columns to put the last crop on the felt.
+    covered = np.flatnonzero((solid[by : by + bh] > 0).mean(axis=0) > 0.5)
+    if covered.size == 0:
+        print("no columns found in the second calibration photo, skipping")
+        return []
+    bx, bw = int(covered[0]), int(covered[-1]) - int(covered[0]) + 1
+
+    # The columns are butted, so they are divided evenly — but the rows within a column are found by
+    # grid_fit, which is what stops the top tile of each column being cropped with a swathe of felt.
+    light_f = light.astype(float)
+    cells = []
+    for index, labels in enumerate(COLUMNS):
+        x0 = bx + index * bw // len(COLUMNS)
+        width = bw // len(COLUMNS)
+        fit = fit_grid(light_f, (x0, by, width, bh), vertical=True, expect=len(labels))
+        if fit is None or fit[2] != len(labels):
+            print(f"column {index + 1}: expected {len(labels)} tiles, fit gave {fit}")
+            continue
+        pitch, offset, _ = fit
+        # The low numbers sit at the bottom of the column, so label i belongs to the i-th cell up
+        # from the bottom. Reversing the labels *and* counting the rows down was two reversals that
+        # cancelled, which put 9m at the foot of the column and 1m at its head.
+        for index, label in enumerate(labels):
+            top = by + int(offset + (len(labels) - 1 - index) * pitch)
+            # A uniform inset on every side. The grid fit puts the boundaries within a pixel or two,
+            # so unlike the brown photo there is nothing here that needs edge-by-edge treatment.
+            box = (
+                slice(top + NEIGHBOUR_EDGE, top + int(pitch) - NEIGHBOUR_EDGE),
+                slice(x0 + NEIGHBOUR_EDGE, x0 + width - NEIGHBOUR_EDGE),
+            )
+            crop, piece = bgr[box], solid[box]
+            if crop.size == 0:
+                continue
+            source = f"green{index + 1}" if label == BACK else "green"
+            write_variant(label, source, crop, piece > 0)
+            cells.append((f"{label}/{source}", crop))
+    return cells
+
+
 def main() -> None:
     bgr = cv2.imread(str(CALIBRATION))
     if bgr is None:
@@ -232,11 +326,11 @@ def main() -> None:
                 light, mask, nominal_x0, int(left + (j + 1) * step), top, bottom
             )
             crop = bgr[y0:y1, x0:x1]
-            cv2.imwrite(str(faces / f"{label}.png"), crop)
-            cv2.imwrite(str(masks / f"{label}.png"), mask[y0:y1, x0:x1].astype(np.uint8) * 255)
+            write_variant(label, "brown", crop, mask[y0:y1, x0:x1])
             cells.append((label, crop))
         print(f"row {i + 1}: y {top}-{bottom}, x {left}-{right}, {len(labels)} tiles")
 
+    cells += slice_second_set()
     print(f"wrote {len(cells)} crops to {faces} and masks to {masks}")
     audit(cells)
     contact_sheet(cells)

--- a/ml/synthesize.py
+++ b/ml/synthesize.py
@@ -36,20 +36,37 @@ SIZE = 64  # what the classifier sees; a tile face is a simple shape and this is
 # scored higher than the hand — and it would quietly write invented tiles into the score sheet.
 NOT_A_TILE = "none"
 
+# The face-down tile. Its own label rather than part of NOT_A_TILE, because it is what separates a
+# 暗杠 from a 明杠: four tiles with two of them turned over is concealed, does not count as 副露, and
+# does not break 门前清 — which changes the score. Folded into "not a tile" that is unrecoverable.
+BACK = "back"
+
 # A tile is not always upright in a photo, and the classifier is asked to name the face, not the
 # orientation, so all four quarter turns are the same class.
 QUARTER_TURNS = (0, 1, 2, 3)
 
 
-def load_tiles() -> tuple[list[str], list[np.ndarray], list[np.ndarray]]:
-    """Every face crop with its cut-out mask, labels taken from the filenames."""
-    labels = sorted(p.stem for p in FACES.glob("*.png"))
+def load_tiles() -> tuple[list[str], list[list[np.ndarray]], list[list[np.ndarray]]]:
+    """Every label with each of its appearances and their cut-out masks.
+
+    A label can have more than one appearance because there are two sets of tiles, on two tables. They
+    are near-identical in design and quite different in finish and lighting, and holding both under one
+    label is what pushes the classifier towards the pattern rather than towards the look of one set.
+    """
+    labels = sorted(d.name for d in FACES.iterdir() if d.is_dir())
     if not labels:
         raise SystemExit(f"no crops in {FACES} — run slice_calibration.py first")
-    faces = [cv2.imread(str(FACES / f"{label}.png")) for label in labels]
-    masks = [cv2.imread(str(MASKS / f"{label}.png"), cv2.IMREAD_GRAYSCALE) for label in labels]
-    if any(f is None or m is None for f, m in zip(faces, masks)):
-        raise SystemExit(f"a crop in {FACES} has no matching mask in {MASKS}")
+    faces, masks = [], []
+    for label in labels:
+        variants = sorted(p.name for p in (FACES / label).glob("*.png"))
+        if not variants:
+            raise SystemExit(f"{FACES / label} has no crops")
+        face = [cv2.imread(str(FACES / label / v)) for v in variants]
+        mask = [cv2.imread(str(MASKS / label / v), cv2.IMREAD_GRAYSCALE) for v in variants]
+        if any(f is None or m is None for f, m in zip(face, mask)):
+            raise SystemExit(f"a crop in {FACES / label} has no matching mask")
+        faces.append(face)
+        masks.append(mask)
     return labels, faces, masks
 
 
@@ -58,8 +75,8 @@ class Synthesiser:
 
     def __init__(
         self,
-        faces: list[np.ndarray],
-        masks: list[np.ndarray],
+        faces: list[list[np.ndarray]],
+        masks: list[list[np.ndarray]],
         seed: int,
         hard: bool,
         size: int = SIZE,
@@ -88,6 +105,11 @@ class Synthesiser:
             high = middle + (high - middle) * stretch
         return float(self.rng.uniform(low, high))
 
+    def _variant(self, index: int) -> tuple[np.ndarray, np.ndarray]:
+        """One of the label's appearances, chosen per sample so both sets are seen equally often."""
+        pick = int(self.rng.integers(0, len(self.faces[index])))
+        return self.faces[index][pick], self.masks[index][pick]
+
     def _background(self, height: int, width: int, exclude: int, tiles: bool = True) -> np.ndarray:
         """Whatever surrounds a tile: another tile, the table, or something plain.
 
@@ -98,10 +120,11 @@ class Synthesiser:
         if tiles and choice < 5:
             # A neighbouring tile, which is what a hand actually looks like. Blurred and dimmed a
             # little so it reads as out of frame rather than as a second subject.
-            other = self.faces[int(self.rng.integers(0, len(self.faces)))]
+            index = int(self.rng.integers(0, len(self.faces)))
             if len(self.faces) > 1:
-                while other is self.faces[exclude]:
-                    other = self.faces[int(self.rng.integers(0, len(self.faces)))]
+                while index == exclude:
+                    index = int(self.rng.integers(0, len(self.faces)))
+            other, _ = self._variant(index)
             tiled = cv2.resize(other, (width, height))
             tiled = cv2.GaussianBlur(tiled, (0, 0), max(self._uniform(1.0, 3.0), 0.1))
             return np.clip(tiled * self._uniform(0.75, 1.0), 0, 255).astype(np.uint8)
@@ -210,14 +233,14 @@ class Synthesiser:
             # Two tiles meeting, which is what a misaligned grid produces.
             first, second = (int(self.rng.integers(0, len(self.faces))) for _ in range(2))
             split = int(pad * self._uniform(0.25, 0.75))
-            top = cv2.resize(self.faces[first], (pad, max(split, 1)))
-            bottom = cv2.resize(self.faces[second], (pad, max(pad - split, 1)))
+            top = cv2.resize(self._variant(first)[0], (pad, max(split, 1)))
+            bottom = cv2.resize(self._variant(second)[0], (pad, max(pad - split, 1)))
             canvas = np.vstack([top, bottom])[:pad]
             if self.rng.random() < 0.5:
                 canvas = np.rot90(canvas).copy()
         elif choice == 1:
             # A sliver of one tile against its surroundings, or a tile seen edge-on.
-            face = self.faces[int(self.rng.integers(0, len(self.faces)))]
+            face, _ = self._variant(int(self.rng.integers(0, len(self.faces))))
             # Floored: the widened ranges can stretch this fraction to zero, and an empty slice
             # takes cv2.resize down with it mid-training.
             keep = max(int(face.shape[1] * self._uniform(0.05, 0.3)), 3)
@@ -226,7 +249,7 @@ class Synthesiser:
 
     def sample(self, index: int) -> np.ndarray:
         """One augmented square BGR image of the tile at `index`."""
-        face, mask = self._warp(self.faces[index], self.masks[index])
+        face, mask = self._warp(*self._variant(index))
         height, width = mask.shape
 
         # Pad so the tile can sit anywhere in the frame with background all around it.

--- a/ml/try_real_photo.py
+++ b/ml/try_real_photo.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 
 from grid_fit import fit_grid
-from synthesize import DATA, SIZE
+from synthesize import BACK, DATA, NOT_A_TILE, SIZE
 from train_classifier import RUNS, TileNet
 
 # A tile face is near-white: bright, and far less coloured than green felt or a brown table.
@@ -41,6 +41,10 @@ MIN_RUN_ASPECT = 2.0  # below this a blob is a single tile, not a line of them
 PITCH_NUDGE = (0.99, 1.0, 1.01)
 OFFSET_NUDGE = (-0.04, 0.0, 0.04)
 COUNT_NUDGE = (-1, 0, 1)  # the run's box can clip a tile at either end
+
+# What a run of this length is. Three or four tiles set aside is a meld; the long run is the standing
+# hand. Nothing else is part of the hand — a discard pile is neither.
+MELD_SIZES = (3, 4)
 CONFIDENT = 0.8  # hand back anything under this rather than guess
 
 # Mean confidence alone is an exploitable objective. A 272x110 blob cut into fifteen 17px slivers
@@ -212,18 +216,20 @@ def main() -> None:
     runs = candidate_runs(bgr)
     print(f"{args.photo.name} at {bgr.shape[1]}x{bgr.shape[0]}, {len(runs)} candidate runs")
 
-    # One pass each to pick the run, then the neighbourhood search on the winner alone.
-    scored = []
+    # The standing hand and the melds are separate runs — the melds are set aside on the right with a
+    # gap, so the mask gives them their own blobs. Read every run that could be either.
+    hand_candidates, melds = [], []
     for box in runs:
-        fit = read_line(model, bgr, light, box, size, refine=False, counts=counts)
-        if fit is None:
-            print(f"  {box}: no grid fits")
-            continue
-        print(f"  {box}: {fit[1]} tiles at pitch {fit[2]:.1f}px, confidence {fit[0]:.3f}")
-        scored.append((fit[0], box))
-    if not scored:
-        raise SystemExit("no run could be read")
-    box = max(scored)[1]
+        for sizes, bucket in ((counts, hand_candidates), (MELD_SIZES, melds)):
+            fit = read_line(model, bgr, light, box, size, refine=False, counts=sizes)
+            if fit is None:
+                continue
+            print(f"  {box}: {fit[1]} tiles at pitch {fit[2]:.1f}px, confidence {fit[0]:.3f}")
+            bucket.append((fit[0], box))
+            break
+    if not hand_candidates:
+        raise SystemExit("no run long enough to be a hand")
+    box = max(hand_candidates)[1]
 
     refined = read_line(model, bgr, light, box, size, refine=True, counts=counts)
     if refined is None:
@@ -232,9 +238,11 @@ def main() -> None:
     print(f"\nchose {box}: {count} tiles, pitch {pitch:.1f}px, mean confidence {score:.3f}\n")
     for i, (guess, sure) in enumerate(zip(predicted.tolist(), confidence.tolist()), 1):
         mark = "" if sure >= CONFIDENT else "   <- hand this one back"
-        print(f"  {i:2d}. {labels[guess]:3s} {sure:.2f}{mark}")
-    kept = sum(1 for s in confidence.tolist() if s >= CONFIDENT)
-    print(f"\n{kept}/{count} at confidence >= {CONFIDENT}")
+        print(f"  {i:2d}. {labels[guess]:4s} {sure:.2f}{mark}")
+    kept = sum(1 for c in confidence.tolist() if c >= CONFIDENT)
+    print(f"\n{kept}/{count} at confidence >= {CONFIDENT}\n")
+
+    read_melds(model, bgr, light, melds, box, size, labels)
 
     x, y, w, h = box
     vertical = h >= w
@@ -242,6 +250,66 @@ def main() -> None:
     out = args.output or DATA / f"{args.photo.stem}_read.png"
     out.parent.mkdir(parents=True, exist_ok=True)
     sheet(crops, labels, predicted, confidence, out)
+
+
+def meld_kind(tiles: list[str]) -> str:
+    """From the tiles alone. Four is a gang, three alike is a ke, anything else a shun."""
+    if len(tiles) >= 4:
+        return "gang"
+    return "ke" if len(set(tiles)) == 1 else "shun"
+
+
+def read_melds(
+    model: torch.nn.Module,
+    bgr: np.ndarray,
+    light: np.ndarray,
+    melds: list[tuple[float, tuple[int, int, int, int]]],
+    hand_box: tuple[int, int, int, int],
+    size: int,
+    labels: list[str],
+) -> None:
+    """Reads the runs of three or four set aside beside the hand.
+
+    Two distinctions here decide the score rather than just the display:
+
+    A 暗杠 is four tiles with two of them turned face down. It is *not* 副露 — it leaves the hand
+    concealed and 门前清 intact — so it carries isOpen false, while 吃, 碰 and 明杠 all carry true.
+    That is the whole reason the face-down tile is its own class instead of part of "not a tile".
+
+    The two turned-over tiles of a 暗杠 cannot be read, and do not need to be: a gang is four of one
+    tile, so the pair that is face up names all four.
+    """
+    for _, box in melds:
+        if box == hand_box:
+            continue
+        fit = read_line(model, bgr, light, box, size, refine=True, counts=range(3, 5))
+        if fit is None:
+            continue
+        _, count, _, _, confidence, predicted = fit
+        tiles = [labels[int(g)] for g in predicted]
+        lowest = min(float(c) for c in confidence)
+        # A meld has to be read outright. Three or four tiles is a short run and the geometry alone is
+        # weak evidence — on the first photo tried, a corner of the discard pile fitted four cells and
+        # came back as a gang of 1p at 0.00 confidence. There is no partial credit for a meld: get one
+        # tile of it wrong and the hand is a different hand.
+        if lowest < CONFIDENT:
+            print(f"  meld at {box}: {tiles} — lowest confidence {lowest:.2f}, not read")
+            continue
+        backs = [t for t in tiles if t == BACK]
+        faces = [t for t in tiles if t not in (BACK, NOT_A_TILE)]
+        if backs:
+            # A 暗杠: name it from the tiles that are face up, which must agree with each other.
+            if len(set(faces)) != 1 or count != 4:
+                print(f"  meld at {box}: {tiles} — face-down tiles but not a readable 暗杠, skipped")
+                continue
+            tiles = [faces[0]] * 4
+        elif NOT_A_TILE in tiles:
+            print(f"  meld at {box}: {tiles} — contains something that is not a tile, skipped")
+            continue
+        print(
+            f"  meld at {box}: {meld_kind(tiles)} {tiles}"
+            f" isOpen={not backs} (lowest confidence {lowest:.2f})"
+        )
 
 
 def sheet(

--- a/ml/try_real_photo.py
+++ b/ml/try_real_photo.py
@@ -91,6 +91,7 @@ def read_line(
     box: tuple[int, int, int, int],
     size: int,
     refine: bool,
+    counts: range,
 ) -> tuple[float, int, float, float, torch.Tensor, torch.Tensor] | None:
     """Reads one run, starting from its geometric fit.
 
@@ -103,6 +104,10 @@ def read_line(
     if fit is None:
         return None
     pitch, offset, count = fit
+    # A geometric fit knows nothing about mahjong, so it will happily describe the table's plastic
+    # housing as eighteen tiles. Anything outside the range of a hand is not a hand.
+    if count not in counts:
+        return None
 
     combinations = (
         [
@@ -117,7 +122,7 @@ def read_line(
 
     best = None
     for candidate_pitch, candidate_offset, candidate_count in combinations:
-        if candidate_count < 1:
+        if candidate_count not in counts:
             continue
         crops = slice_line(
             bgr, box, vertical, candidate_offset, candidate_pitch, candidate_count, size
@@ -203,13 +208,14 @@ def main() -> None:
     model.eval()
 
     light = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB)[:, :, 0].astype(float)
+    counts = range(args.min_tiles, args.max_tiles + 1)
     runs = candidate_runs(bgr)
     print(f"{args.photo.name} at {bgr.shape[1]}x{bgr.shape[0]}, {len(runs)} candidate runs")
 
     # One pass each to pick the run, then the neighbourhood search on the winner alone.
     scored = []
     for box in runs:
-        fit = read_line(model, bgr, light, box, size, refine=False)
+        fit = read_line(model, bgr, light, box, size, refine=False, counts=counts)
         if fit is None:
             print(f"  {box}: no grid fits")
             continue
@@ -219,7 +225,7 @@ def main() -> None:
         raise SystemExit("no run could be read")
     box = max(scored)[1]
 
-    refined = read_line(model, bgr, light, box, size, refine=True)
+    refined = read_line(model, bgr, light, box, size, refine=True, counts=counts)
     if refined is None:
         raise SystemExit("no run could be read")
     score, count, pitch, start, confidence, predicted = refined

--- a/ml/try_real_photo.py
+++ b/ml/try_real_photo.py
@@ -45,6 +45,17 @@ COUNT_NUDGE = (-1, 0, 1)  # the run's box can clip a tile at either end
 # What a run of this length is. Three or four tiles set aside is a meld; the long run is the standing
 # hand. Nothing else is part of the hand — a discard pile is neither.
 MELD_SIZES = (3, 4)
+
+# A meld is made of the same physical tiles as the hand, photographed from the same distance, so the
+# spacing along it has to match the hand's. This is checked before the classifier is asked anything:
+# on the first photo tried, a corner of the discard pile fitted four cells at a pitch of 63 against the
+# hand's 87 — 72%, which no tile of that set can be — and it was still read (as a gang of 1p, at 0.00
+# confidence) before being thrown out on confidence alone.
+#
+# Framing the photo to exclude the discards would also have removed that candidate, and is worth doing.
+# It is not relied on: a rule the photographer maintains is not a guarantee the code can hold.
+MIN_PITCH_MATCH = 0.8
+MAX_PITCH_MATCH = 1.25
 CONFIDENT = 0.8  # hand back anything under this rather than guess
 
 # Mean confidence alone is an exploitable objective. A 272x110 blob cut into fifteen 17px slivers
@@ -242,7 +253,7 @@ def main() -> None:
     kept = sum(1 for c in confidence.tolist() if c >= CONFIDENT)
     print(f"\n{kept}/{count} at confidence >= {CONFIDENT}\n")
 
-    read_melds(model, bgr, light, melds, box, size, labels)
+    read_melds(model, bgr, light, melds, box, pitch, size, labels)
 
     x, y, w, h = box
     vertical = h >= w
@@ -265,6 +276,7 @@ def read_melds(
     light: np.ndarray,
     melds: list[tuple[float, tuple[int, int, int, int]]],
     hand_box: tuple[int, int, int, int],
+    hand_pitch: float,
     size: int,
     labels: list[str],
 ) -> None:
@@ -284,6 +296,13 @@ def read_melds(
             continue
         fit = read_line(model, bgr, light, box, size, refine=True, counts=range(3, 5))
         if fit is None:
+            continue
+        ratio = fit[2] / hand_pitch
+        if not MIN_PITCH_MATCH <= ratio <= MAX_PITCH_MATCH:
+            print(
+                f"  meld at {box}: pitch {fit[2]:.1f}px is {ratio:.0%} of the hand's"
+                f" {hand_pitch:.1f}px, not the same tiles"
+            )
             continue
         _, count, _, _, confidence, predicted = fit
         tiles = [labels[int(g)] for g in predicted]

--- a/ml/try_real_photo.py
+++ b/ml/try_real_photo.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 
 from grid_fit import fit_grid
-from synthesize import BACK, DATA, NOT_A_TILE, SIZE
+from synthesize import BACK, DATA, SIZE
 from train_classifier import RUNS, TileNet
 
 # A tile face is near-white: bright, and far less coloured than green felt or a brown table.
@@ -56,6 +56,10 @@ MELD_SIZES = (3, 4)
 # It is not relied on: a rule the photographer maintains is not a guarantee the code can hold.
 MIN_PITCH_MATCH = 0.8
 MAX_PITCH_MATCH = 1.25
+
+# A crop this sure it is not a tile disqualifies the whole meld. Melds have no partial credit: one
+# wrong tile is a different hand.
+NOTHING_LIMIT = 0.3
 CONFIDENT = 0.8  # hand back anything under this rather than guess
 
 # Mean confidence alone is an exploitable objective. A 272x110 blob cut into fifteen 17px slivers
@@ -107,13 +111,13 @@ def read_line(
     size: int,
     refine: bool,
     counts: range,
-) -> tuple[float, int, float, float, torch.Tensor, torch.Tensor] | None:
+) -> tuple[float, int, float, float, torch.Tensor, torch.Tensor, torch.Tensor] | None:
     """Reads one run, starting from its geometric fit.
 
     With `refine` false this costs a single forward pass, which is all that is needed to tell a row of
     tiles from a strip of the table's plastic housing. The winner is then read again with `refine` on.
     """
-    x, y, w, h = box
+    _, _, w, h = box
     vertical = h >= w
     fit = fit_grid(light, box, vertical)
     if fit is None:
@@ -144,7 +148,7 @@ def read_line(
         )
         if crops is None:
             continue
-        confidence, predicted = classify(model, crops)
+        confidence, predicted, nothing = classify(model, crops)
         score = float(confidence.mean())
         if best is None or score > best[0]:
             best = (
@@ -154,6 +158,7 @@ def read_line(
                 candidate_offset,
                 confidence,
                 predicted,
+                nothing,
             )
     return best
 
@@ -184,18 +189,24 @@ def slice_line(
     return np.stack(crops)
 
 
-def classify(model: torch.nn.Module, crops: np.ndarray) -> tuple[torch.Tensor, torch.Tensor]:
-    """Best tile class per crop, with its probability. The none class is reported separately."""
+def classify(
+    model: torch.nn.Module, crops: np.ndarray
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Best tile class per crop with its probability, and separately the probability of `none`.
+
+    Kept apart because the two are wanted for different things. Ranking candidate runs by plain top-1
+    confidence picked the table's plastic housing over the hand: read as fifteen crops of nothing it
+    scored 0.844 of confident "none" against the hand's 0.731, so selection has to score confidence
+    that something is *a tile*. But whether a crop is nothing at all is still worth knowing, and if
+    `none` is simply excluded it becomes unreachable — the check for it downstream was dead code.
+    """
     rgb = (crops[:, :, :, ::-1].astype(np.float32) / 255.0) - 0.5
     with torch.no_grad():
         probabilities = torch.softmax(
             model(torch.from_numpy(np.ascontiguousarray(rgb.transpose(0, 3, 1, 2)))), 1
         )
-    # Score on the tile classes only. Ranking candidate runs by plain top-1 confidence picked the
-    # table's plastic housing over the hand: read as fifteen crops of nothing, it scored 0.844 of
-    # confident "none" against the hand's 0.731. Confidence that something is *a tile* is the
-    # quantity that was wanted all along.
-    return probabilities[:, :-1].max(1)
+    confidence, predicted = probabilities[:, :-1].max(1)
+    return confidence, predicted, probabilities[:, -1]
 
 
 def main() -> None:
@@ -245,7 +256,7 @@ def main() -> None:
     refined = read_line(model, bgr, light, box, size, refine=True, counts=counts)
     if refined is None:
         raise SystemExit("no run could be read")
-    score, count, pitch, start, confidence, predicted = refined
+    score, count, pitch, start, confidence, predicted, _ = refined
     print(f"\nchose {box}: {count} tiles, pitch {pitch:.1f}px, mean confidence {score:.3f}\n")
     for i, (guess, sure) in enumerate(zip(predicted.tolist(), confidence.tolist()), 1):
         mark = "" if sure >= CONFIDENT else "   <- hand this one back"
@@ -263,11 +274,26 @@ def main() -> None:
     sheet(crops, labels, predicted, confidence, out)
 
 
-def meld_kind(tiles: list[str]) -> str:
-    """From the tiles alone. Four is a gang, three alike is a ke, anything else a shun."""
-    if len(tiles) >= 4:
-        return "gang"
-    return "ke" if len(set(tiles)) == 1 else "shun"
+NUMBERED_SUITS = ("m", "p", "s")
+
+
+def meld_kind(tiles: list[str]) -> str | None:
+    """From the tiles alone, or None when they do not form a meld at all.
+
+    "Anything that is not three alike is a 吃" was the first version and it is wrong in a way that
+    matters: three tiles that merely passed the confidence floor — a corner of the discard pile, say —
+    would be reported as a 吃 and scored as one. A 吃 is three consecutive numbers in one suit, and
+    nothing else. A run that cannot be named is not a meld, and saying so is the only safe answer.
+    """
+    if len(set(tiles)) == 1:
+        return "gang" if len(tiles) == 4 else "ke" if len(tiles) == 3 else None
+    if len(tiles) != 3:
+        return None
+    suits = {tile[-1] for tile in tiles}
+    if len(suits) != 1 or suits.pop() not in NUMBERED_SUITS:
+        return None
+    ranks = sorted(int(tile[0]) for tile in tiles)
+    return "shun" if ranks[2] - ranks[0] == 2 and len(set(ranks)) == 3 else None
 
 
 def read_melds(
@@ -304,8 +330,14 @@ def read_melds(
                 f" {hand_pitch:.1f}px, not the same tiles"
             )
             continue
-        _, count, _, _, confidence, predicted = fit
+        _, count, _, _, confidence, predicted, nothing = fit
         tiles = [labels[int(g)] for g in predicted]
+        # The none class is checked on its own probability, not by looking for it among `tiles`:
+        # classify ranks the tile classes only, so it can never be the argmax there.
+        emptiest = float(nothing.max())
+        if emptiest >= NOTHING_LIMIT:
+            print(f"  meld at {box}: a crop is {emptiest:.0%} not-a-tile, skipped")
+            continue
         lowest = min(float(c) for c in confidence)
         # A meld has to be read outright. Three or four tiles is a short run and the geometry alone is
         # weak evidence — on the first photo tried, a corner of the discard pile fitted four cells and
@@ -315,20 +347,19 @@ def read_melds(
             print(f"  meld at {box}: {tiles} — lowest confidence {lowest:.2f}, not read")
             continue
         backs = [t for t in tiles if t == BACK]
-        faces = [t for t in tiles if t not in (BACK, NOT_A_TILE)]
+        faces = [t for t in tiles if t != BACK]
         if backs:
             # A 暗杠: name it from the tiles that are face up, which must agree with each other.
             if len(set(faces)) != 1 or count != 4:
                 print(f"  meld at {box}: {tiles} — face-down tiles but not a readable 暗杠, skipped")
                 continue
             tiles = [faces[0]] * 4
-        elif NOT_A_TILE in tiles:
-            print(f"  meld at {box}: {tiles} — contains something that is not a tile, skipped")
+
+        kind = meld_kind(tiles)
+        if kind is None:
+            print(f"  meld at {box}: {tiles} — not a 吃, 碰 or 杠, skipped")
             continue
-        print(
-            f"  meld at {box}: {meld_kind(tiles)} {tiles}"
-            f" isOpen={not backs} (lowest confidence {lowest:.2f})"
-        )
+        print(f"  meld at {box}: {kind} {tiles} isOpen={not backs} (lowest confidence {lowest:.2f})")
 
 
 def sheet(

--- a/ml/try_real_photo.py
+++ b/ml/try_real_photo.py
@@ -5,12 +5,15 @@ of butted tiles, bright and nearly colourless against strongly coloured felt, so
 a thresholding problem rather than a detection problem — no trained detector, and none of the labelled
 photos that would need.
 
-Splitting the line is the part that needs care. The tiles touch, so the line comes back as one blob,
-and a brightness profile along it does not show the seams reliably: the engraved characters dip just
-as deep. What works instead is to let the classifier find its own alignment. Sweep the start and the
-pitch, score each candidate by the mean confidence over the tiles it produces, and keep the best. A
-misaligned crop is half of one tile and half of the next, which the classifier is not confident about
-— so confidence is exactly the signal that says the grid is wrong.
+Splitting the line is the part that needs care. The tiles touch, so the line comes back as one blob.
+The grid is found geometrically first — see grid_fit.py — and the classifier is then used only to
+choose between runs and to nudge the fit by a pixel or two. Confidence is the right signal for that
+nudging: a misaligned crop is half of one tile and half of the next, which the classifier is not
+confident about.
+
+Doing it the other way round was the first version and it was far too slow to ship: brute-forcing
+count, pitch and offset cost 1,680 grid hypotheses and 22,680 tile classifications on one photo, some
+21 seconds of inference. The geometry was in the pixels the whole time.
 
 On one real photo, from a table the model has never seen and felt a different colour from the
 calibration photo, this reads 13 of 13 tiles correctly, ten of them above 0.85.
@@ -23,6 +26,7 @@ import cv2
 import numpy as np
 import torch
 
+from grid_fit import fit_grid
 from synthesize import DATA, SIZE
 from train_classifier import RUNS, TileNet
 
@@ -31,6 +35,12 @@ MIN_LIGHTNESS = 150
 MAX_CHROMA = 26
 
 MIN_RUN_ASPECT = 2.0  # below this a blob is a single tile, not a line of them
+
+# How far the classifier is allowed to move the geometric fit. Small on purpose: the fit is already
+# within a pixel of the brute-force answer, and every step here costs a forward pass per tile.
+PITCH_NUDGE = (0.99, 1.0, 1.01)
+OFFSET_NUDGE = (-0.04, 0.0, 0.04)
+COUNT_NUDGE = (-1, 0, 1)  # the run's box can clip a tile at either end
 CONFIDENT = 0.8  # hand back anything under this rather than guess
 
 # Mean confidence alone is an exploitable objective. A 272x110 blob cut into fifteen 17px slivers
@@ -77,31 +87,54 @@ def candidate_runs(bgr: np.ndarray) -> list[tuple[int, int, int, int]]:
 def read_line(
     model: torch.nn.Module,
     bgr: np.ndarray,
+    light: np.ndarray,
     box: tuple[int, int, int, int],
     size: int,
-    counts: range,
-) -> tuple[float, int, float, torch.Tensor, torch.Tensor]:
-    """Best (start, pitch, count) for the line, chosen by the classifier's own mean confidence."""
+    refine: bool,
+) -> tuple[float, int, float, float, torch.Tensor, torch.Tensor] | None:
+    """Reads one run, starting from its geometric fit.
+
+    With `refine` false this costs a single forward pass, which is all that is needed to tell a row of
+    tiles from a strip of the table's plastic housing. The winner is then read again with `refine` on.
+    """
     x, y, w, h = box
     vertical = h >= w
-    length = h if vertical else w
+    fit = fit_grid(light, box, vertical)
+    if fit is None:
+        return None
+    pitch, offset, count = fit
+
+    combinations = (
+        [
+            (pitch * p, offset + pitch * o, count + c)
+            for p in PITCH_NUDGE
+            for o in OFFSET_NUDGE
+            for c in COUNT_NUDGE
+        ]
+        if refine
+        else [(pitch, offset, count)]
+    )
+
     best = None
-    across = w if vertical else h
-    for count in counts:
-        nominal = length / count
-        if not MIN_TILE_RATIO <= nominal / across <= MAX_TILE_RATIO:
+    for candidate_pitch, candidate_offset, candidate_count in combinations:
+        if candidate_count < 1:
             continue
-        for pitch in np.arange(nominal * 0.94, nominal * 1.07, nominal * 0.01):
-            for start in np.arange(-nominal * 0.3, nominal * 0.3, nominal * 0.04):
-                crops = slice_line(bgr, box, vertical, start, float(pitch), count, size)
-                if crops is None:
-                    continue
-                confidence, predicted = classify(model, crops)
-                score = float(confidence.mean())
-                if best is None or score > best[0]:
-                    best = (score, count, float(pitch), float(start), confidence, predicted)
-    if best is None:
-        raise SystemExit("could not fit a grid to the line")
+        crops = slice_line(
+            bgr, box, vertical, candidate_offset, candidate_pitch, candidate_count, size
+        )
+        if crops is None:
+            continue
+        confidence, predicted = classify(model, crops)
+        score = float(confidence.mean())
+        if best is None or score > best[0]:
+            best = (
+                score,
+                candidate_count,
+                candidate_pitch,
+                candidate_offset,
+                confidence,
+                predicted,
+            )
     return best
 
 
@@ -169,20 +202,27 @@ def main() -> None:
     model.load_state_dict(checkpoint["state"])
     model.eval()
 
+    light = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB)[:, :, 0].astype(float)
     runs = candidate_runs(bgr)
     print(f"{args.photo.name} at {bgr.shape[1]}x{bgr.shape[0]}, {len(runs)} candidate runs")
-    best = None
+
+    # One pass each to pick the run, then the neighbourhood search on the winner alone.
+    scored = []
     for box in runs:
-        try:
-            fit = read_line(model, bgr, box, size, range(args.min_tiles, args.max_tiles + 1))
-        except SystemExit:
+        fit = read_line(model, bgr, light, box, size, refine=False)
+        if fit is None:
+            print(f"  {box}: no grid fits")
             continue
-        print(f"  {box}: mean confidence {fit[0]:.3f} over {fit[1]} tiles")
-        if best is None or fit[0] > best[0][0]:
-            best = (fit, box)
-    if best is None:
+        print(f"  {box}: {fit[1]} tiles at pitch {fit[2]:.1f}px, confidence {fit[0]:.3f}")
+        scored.append((fit[0], box))
+    if not scored:
         raise SystemExit("no run could be read")
-    (score, count, pitch, start, confidence, predicted), box = best
+    box = max(scored)[1]
+
+    refined = read_line(model, bgr, light, box, size, refine=True)
+    if refined is None:
+        raise SystemExit("no run could be read")
+    score, count, pitch, start, confidence, predicted = refined
     print(f"\nchose {box}: {count} tiles, pitch {pitch:.1f}px, mean confidence {score:.3f}\n")
     for i, (guess, sure) in enumerate(zip(predicted.tolist(), confidence.tolist()), 1):
         mark = "" if sure >= CONFIDENT else "   <- hand this one back"

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -81,6 +81,18 @@ public class TileRecognitionService {
          - An-Gang (暗杠): 4 tiles (2 face-UP, 2 face-DOWN backs) -> { "type": "gang", "tiles": ["8s","8s","8s","8s"], "isOpen": false }
          - DO NOT mix right-side exposed melds into the left-side concealed hand!
 
+      3. **ORDER OF "concealed" CARRIES THE WINNING TILE (和牌张)**:
+         - The players place the winning tile at the END of the standing hand, deliberately, when they
+           arrange it. The last standing tile in the photo is therefore the winning tile.
+         - **List "concealed" in the order the tiles appear, left to right. NEVER sort it.** The app
+           reads the last element as the winning tile and scores from it — the winning tile decides
+           fu, whether the hand counts as self-drawn concealed, and the wait shape. Sorting the array
+           moves the winning tile into the middle and the score comes out wrong with nothing to show
+           that it did.
+         - Also repeat that tile in "winningTile". Leave it in "concealed" as well.
+         - If the standing tiles do not read as one row, or you cannot tell which end is the end, keep
+           the order you see, set "winningTile" to null, and say so in "notes".
+
       ### Critical Tile Pattern Audit Rules (防错识别自查规则):
       1. **5s (五条) vs 4s (四条)**:
          - **5s (五条)**: Has 4 corner bamboo sticks PLUS ONE DISTINCT RED BAMBOO STICK IN THE EXACT CENTER!

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -681,16 +681,28 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
           {/* Main Upload Area */}
           <div>
             {!imagePreview ? (
-              <label className="upload-dropzone">
-                {/* No capture attribute: it would force the camera and hide the photo library,
-                    contradicting the label below. */}
-                <input type="file" accept="image/*" onChange={handleFileChange} style={{ display: 'none' }} />
-                <div className="dropzone-content">
-                  <div className="upload-icon">📸</div>
-                  <p className="upload-main-text">点击选择照片 或 拍照</p>
-                  <p className="upload-sub-text">支持桌面或手机拍摄的麻将手牌</p>
-                </div>
-              </label>
+              <>
+                <label className="upload-dropzone">
+                  {/* No capture attribute: it would force the camera and hide the photo library,
+                      contradicting the label below. */}
+                  <input type="file" accept="image/*" onChange={handleFileChange} style={{ display: 'none' }} />
+                  <div className="dropzone-content">
+                    <div className="upload-icon">📸</div>
+                    <p className="upload-main-text">点击选择照片 或 拍照</p>
+                    <p className="upload-sub-text">支持桌面或手机拍摄的麻将手牌</p>
+                  </div>
+                </label>
+                {/* Only the conventions that change the result. Left/right is how the hand is split
+                    into concealed and melds; the last standing tile is the one scored as the winning
+                    tile; two tiles turned over is what makes a 杠 concealed and keeps 门前清. */}
+                <ul className="photo-rec-tips">
+                  <li>立牌摆左边，副露摆右边，中间留一点空隙</li>
+                  <li>和牌张放在立牌最右边 —— 算番按最后一张算</li>
+                  <li>暗杠把 4 张里的 2 张扣过来，明杠全部朝上</li>
+                  <li>只拍手牌，尽量别带进弃牌和牌墙</li>
+                  <li>从正上方拍，光线足一点；拍歪了可以在下一步转正</li>
+                </ul>
+              </>
             ) : (
               <div className="image-preview-wrapper">
                 {previewFailed ? (

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -692,15 +692,15 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
                     <p className="upload-sub-text">支持桌面或手机拍摄的麻将手牌</p>
                   </div>
                 </label>
-                {/* Only the conventions that change the result. Left/right is how the hand is split
-                    into concealed and melds; the last standing tile is the one scored as the winning
-                    tile; two tiles turned over is what makes a 杠 concealed and keeps 门前清. */}
+                {/* Only what changes the result, and each of these is something the pipeline relies
+                    on. Left/right is how the prompt splits the hand into concealed and melds. Two
+                    tiles turned over is what makes a 杠 concealed, which keeps 门前清 and so changes
+                    the score. The rightmost standing tile is the winning tile: the prompt requires
+                    that order to be preserved and both calculators score from the last element. */}
                 <ul className="photo-rec-tips">
-                  <li>立牌摆左边，副露摆右边，中间留一点空隙</li>
-                  <li>和牌张放在立牌最右边 —— 算番按最后一张算</li>
-                  <li>暗杠把 4 张里的 2 张扣过来，明杠全部朝上</li>
-                  <li>只拍手牌，尽量别带进弃牌和牌墙</li>
-                  <li>从正上方拍，光线足一点；拍歪了可以在下一步转正</li>
+                  <li>立牌在左、副露在右，中间留空；和牌张放立牌最右边</li>
+                  <li>暗杠扣两张，明杠全朝上</li>
+                  <li>从正上方拍，只拍手牌，别带进弃牌和牌墙</li>
                 </ul>
               </>
             ) : (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3634,6 +3634,14 @@ table.auto-table {
   margin: 0;
 }
 
+.photo-rec-tips {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  font-size: 0.75rem;
+  line-height: 1.7;
+  color: var(--text-light);
+}
+
 .image-preview-wrapper {
   position: relative;
   display: flex;


### PR DESCRIPTION
只改 `ml/`，零线上影响。

## 起因

上一版的对齐是暴力搜的：每个可能的张数 × 一段间距 × 一段起点，每个假设都跑一遍分类器打分。在那张真实照片上是 **1680 个网格假设、22680 次单张推理 —— 21 秒纯推理只为读一手牌**。脚本能忍，手机不可能。

我之前报的「单张 0.93ms、一手 15ms」是**单次推理**的速度，那是对的；但整条流程做了两万多次推理。这两个数字我之前没放在一起看。

## 做法

这些搜索几乎全是在还原**像素本来就说清了的东西**：一排紧贴的牌是周期性的，边界落在等间隔上，拟合一个规则栅格就直接得到间距和起点，张数由长度推出。**零推理。**

分类器现在只做两件事：从各候选段里选出手牌（每段一次推理），把拟合结果微调一两个像素（27 次）。

| | 原来 | 现在 |
|---|---|---|
| 网格假设 | 1680 | **32** |
| 单张推理 | 22,680 | **416** |
| 全过程 | 21s 纯推理 | **699ms** |
| 读数 | 13/13 全对 | **13/13 全对**（不变） |

副产品：候选段的区分度也变干净了 —— 手牌 0.669，其他全部 0.002–0.075（原来 0.711 vs 0.095）。因为非牌的段拿到的是无意义的栅格，模型于是自信地答 `none`。

## 三个先做错才搞明白的点

都写进 `grid_fit.py` 的 docstring 了。第一版在已知张数上只对 5/9。

**1. 边界不一定是暗的。** 棕色桌那张校准图里牌压得极紧，分隔两张牌的是**下一张被照亮的倒角**，比旁边的牌面更亮。只找暗谷会把它四排里的三排读错。现在同时收极小和极大。

> 这个坑我在切校准图时踩过一次、还写进了那个 docstring，**结果又踩了一次**。

**2. 自相关不够准。** 看起来是最顺手的工具，但在真实照片上给出 81 而真值 86.9 —— 6% 的误差乘以 13 张累积成接近一整张牌。必须逐个定位边界再拟合。

**3. 粗三倍的栅格能解释比正确栅格更多的标记。** 条子本身就是一排竖条纹，在 9 张牌上产生了 **31 个标记点**；容差按间距缩放时，3 张的栅格容差 36px、4 条栅格线抓到 13 个标记，和真正的 9 张栅格**打平**。所以有 `MAX_MARKS_PER_LINE`：一个边界应该只对应大约一个标记，一条线摊到三个的栅格不是在描述牌。

## 加了自检，而且它立刻救了一次

```bash
python grid_fit.py
```

拿两张校准图的已知张数做回归：4 排 **9/9/9/7** + 4 列 9。第 4 排那个 **7** 是关键 —— 它是唯一张数不同的案例，能抓住「悄悄学会一律答 9」的拟合。

写完向量化提速（450ms → 40ms）之后自检立刻报**第 1 排从 9 变成 14** —— 候选间距量化到 0.5px 太粗。改成 0.1px，8/8 恢复，耗时 65ms。

**没有这个自检这次回归会直接混过去**，因为那张真实照片仍然读对。

## review 时值得看的

1. **`grid_fit.py` 的 docstring** —— 上面那三条，以及为什么 `MAX_MARKS_PER_LINE = 1.4` 而不是 1.5（1.5 是 8/9，1.4 是 9/9，边界很窄，有过拟合这 8 个案例的味道，所以才要自检）
2. **`try_real_photo.py` 的 `read_line`** —— `refine=False` 时只花一次前向，这是「选段」和「微调」分成两步的原因
3. `PITCH_QUANTUM` 那段注释 —— 记录了这次自检抓到的回归

## 还没解决的

- **只测了一张真实照片。** n=1
- **副露还没读** —— 不是产不出，是 `try_real_photo.py` 只留了最高分那一段、其余丢掉。补齐要 ~100 行，加把牌背从 `none` 里拆出来当独立类别（暗杠需要）
- **`isSelfDraw` 照片里没有这个信息** —— Gemini 也没有
- **發（6z）置信度只有 0.56–0.57** —— 认对但会被任何合理阈值退回

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic geometric detection of tile-grid pitch, alignment, and tile count.
  - Added optional classifier-assisted grid refinement and grid details in readable output.
  - Added support for face-down tiles, meld-size handling, and open/closed meld reporting.
  - Added calibration support for green-felt tile sets and multiple image variants.
  - Added randomized face, mask, neighboring-tile, and negative-example variants for generated samples.

- **Bug Fixes**
  - Improved handling of unreadable images, invalid crops, and undetectable grids.

- **Tests**
  - Added calibration checks across representative table and felt surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->