### PR TITLE
fix(ml): 张数改由几何决定, 顺序按副露/画面朝向确定

### DIFF
--- a/ml/try_real_photo.py
+++ b/ml/try_real_photo.py
@@ -41,7 +41,16 @@ MIN_RUN_ASPECT = 2.0  # below this a blob is a single tile, not a line of them
 # within a pixel of the brute-force answer, and every step here costs a forward pass per tile.
 PITCH_NUDGE = (0.99, 1.0, 1.01)
 OFFSET_NUDGE = (-0.04, 0.0, 0.04)
-COUNT_NUDGE = (-1, 0, 1)  # the run's box can clip a tile at either end
+# The count is *not* nudged, and that is a fix rather than an omission. Mean confidence cannot compare
+# grids of different lengths: fewer cells means the worst tile can be left out, so the score rises every
+# time one is dropped. On the one real photo, rotated to landscape the way the upload path sends it, the
+# scores ran 11 tiles 0.880, 12 tiles 0.866, 13 tiles 0.840 — monotonically rewarding truncation. The
+# refiner duly returned twelve tiles and quietly lost a 發; only the ±1 bound stopped it at twelve rather
+# than eleven. The portrait version happened to answer thirteen, which is why this sat unnoticed.
+#
+# The run's length is an unbiased estimate of the count and fit_grid already uses it — 13 cells spanned
+# 1.00 of the run against 0.92 for 12. So the geometry decides how many tiles there are and the
+# classifier only moves the grid by a fraction of a pitch, which is all it was ever good for.
 
 # What a run of this length is. Three or four tiles set aside is a meld; the long run is the standing
 # hand. Nothing else is part of the hand — a discard pile is neither.
@@ -137,12 +146,7 @@ def read_line(
         return None
 
     combinations = (
-        [
-            (pitch * p, offset + pitch * o, count + c)
-            for p in PITCH_NUDGE
-            for o in OFFSET_NUDGE
-            for c in COUNT_NUDGE
-        ]
+        [(pitch * p, offset + pitch * o, count) for p in PITCH_NUDGE for o in OFFSET_NUDGE]
         if refine
         else [(pitch, offset, count)]
     )
@@ -288,18 +292,33 @@ def main() -> None:
     if refined is None:
         raise SystemExit("no run could be read")
     score, count, pitch, start, confidence, predicted, _ = refined
-    print(f"\nchose {box}: {count} tiles, pitch {pitch:.1f}px, mean confidence {score:.3f}\n")
-    for i, (guess, sure) in enumerate(zip(predicted.tolist(), confidence.tolist()), 1):
-        mark = "" if sure >= CONFIDENT else "   <- hand this one back"
-        print(f"  {i:2d}. {labels[guess]:4s} {sure:.2f}{mark}")
-    kept = sum(1 for c in confidence.tolist() if c >= CONFIDENT)
-    print(f"\n{kept}/{count} at confidence >= {CONFIDENT}\n")
-
-    read_melds(model, bgr, light, melds, box, pitch, size, labels)
+    print(f"\nchose {box}: {count} tiles, pitch {pitch:.1f}px, mean confidence {score:.3f}")
 
     x, y, w, h = box
     vertical = h >= w
     crops = slice_line(bgr, box, vertical, start, pitch, count, size)
+    direction = reading_order(box, [b for _, b in melds])
+    if direction.reverse:
+        crops = crops[::-1]
+        confidence, predicted = confidence.flip(0), predicted.flip(0)
+    print(
+        f"reading {'right to left' if direction.reverse else 'left to right'} along the run"
+        f" — {direction.why}\n"
+    )
+
+    for i, (guess, sure) in enumerate(zip(predicted.tolist(), confidence.tolist()), 1):
+        mark = "" if sure >= CONFIDENT else "   <- hand this one back"
+        last = "   <- winning tile" if direction.known and i == count else ""
+        print(f"  {i:2d}. {labels[guess]:4s} {sure:.2f}{mark}{last}")
+    kept = sum(1 for c in confidence.tolist() if c >= CONFIDENT)
+    print(f"\n{kept}/{count} at confidence >= {CONFIDENT}")
+    if not direction.known:
+        print("which end is the winning tile could not be established — leave it for the user\n")
+    else:
+        print()
+
+    read_melds(model, bgr, light, melds, box, pitch, size, labels)
+
     out = args.output or DATA / f"{args.photo.stem}_read.png"
     out.parent.mkdir(parents=True, exist_ok=True)
     sheet(crops, labels, predicted, confidence, out)
@@ -428,6 +447,58 @@ def choose_meld(candidates: list[Candidate], hand_pitch: float) -> Meld | str:
     if best is not None:
         return best[1]
     return "; ".join(reasons) if reasons else "no grid of three or four tiles fits it"
+
+
+class Direction(NamedTuple):
+    """Which way along the run the hand reads, and whether that was actually established."""
+
+    reverse: bool
+    known: bool
+    why: str
+
+
+def reading_order(
+    hand_box: tuple[int, int, int, int], meld_boxes: list[tuple[int, int, int, int]]
+) -> Direction:
+    """Whether the sliced tiles have to be reversed so the winning tile lands last.
+
+    The calculator takes the last element of the concealed array as the winning tile, and the
+    photographer's convention puts that tile at the right-hand end of the standing hand with the melds
+    beyond it. So the run has to be handed over finishing at whichever end is physically the right one.
+
+    Two independent ways to tell, because either alone has a hole:
+
+    The melds settle it whatever way the phone was held — they sit past the right end of the hand, so the
+    end they are nearer is the right end. Only the ones roughly in line with the hand count: in the one
+    real photo the discard pile is also a run of four, and it sits off to the side, so it would point the
+    wrong way if any blob were allowed to vote.
+
+    Failing that, the frame itself: a hand lying across the frame reads left to right, which is what
+    slicing along +x already gives. That needs the photo to be the right way up, and it is the weaker of
+    the two — a hand lying *up* the frame says nothing about which end is which, and rather than guess
+    there, this reports that it does not know. A wrong winning tile is a wrong score; an admitted unknown
+    is one tap in the review screen.
+    """
+    x, y, w, h = hand_box
+    vertical = h >= w
+    start, end = (y, y + h) if vertical else (x, x + w)
+    across_middle = (x + w / 2) if vertical else (y + h / 2)
+    across_span = w if vertical else h
+
+    in_line = []
+    for box_x, box_y, box_w, box_h in meld_boxes:
+        theirs_across = (box_x + box_w / 2) if vertical else (box_y + box_h / 2)
+        if abs(theirs_across - across_middle) <= across_span:
+            in_line.append((box_y + box_h / 2) if vertical else (box_x + box_w / 2))
+
+    if in_line:
+        melds_at = sum(in_line) / len(in_line)
+        at_start = abs(melds_at - start) < abs(melds_at - end)
+        upright = "" if vertical else f", and the frame {'disagrees' if at_start else 'agrees'}"
+        return Direction(at_start, True, f"{len(in_line)} meld(s) in line{upright}")
+    if not vertical:
+        return Direction(False, True, "no melds in line; the hand lies across the frame")
+    return Direction(False, False, "no melds in line and the hand lies up the frame")
 
 
 def read_melds(
@@ -586,7 +657,28 @@ def self_check() -> int:
         shown = got if not isinstance(got, str) else f"rejected: {got[:60]}"
         print(f"  {'ok  ' if ok else 'FAIL'} {name:26s} -> {shown}")
 
-    total = len(cases) + len(choices)
+    # And which way round the run reads. Boxes are (x, y, w, h). The hand is 700 long and 100 across.
+    across = (300, 100, 100, 700)   # lies up the frame
+    along = (100, 300, 700, 100)    # lies across the frame
+    orders = [
+        # A meld past the far end means the run already finishes at the right end.
+        ("melds past the end", across, [(300, 850, 100, 220)], (False, True)),
+        ("melds past the start", across, [(300, 30, 100, 220)], (True, True)),
+        # The discard pile in the real photo is also a run of four, sitting off to the side. Letting any
+        # blob vote would point the wrong way, so out-of-line boxes are ignored.
+        ("off to the side, ignored", across, [(900, 30, 100, 220)], (False, False)),
+        ("side blob plus a real meld", across, [(900, 30, 100, 220), (300, 850, 100, 220)], (False, True)),
+        # No melds: the frame decides, and only when the hand lies across it.
+        ("no melds, hand across frame", along, [], (False, True)),
+        ("no melds, hand up frame", across, [], (False, False)),
+    ]
+    for name, hand, meld_boxes, expected in orders:
+        got = reading_order(hand, meld_boxes)
+        ok = (got.reverse, got.known) == expected
+        failures += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:26s} -> reverse={got.reverse} known={got.known}")
+
+    total = len(cases) + len(choices) + len(orders)
     print(f"\n{total - failures}/{total} correct")
     return failures
 

--- a/ml/try_real_photo.py
+++ b/ml/try_real_photo.py
@@ -301,21 +301,22 @@ def main() -> None:
     if direction.reverse:
         crops = crops[::-1]
         confidence, predicted = confidence.flip(0), predicted.flip(0)
-    print(
-        f"reading {'right to left' if direction.reverse else 'left to right'} along the run"
-        f" — {direction.why}\n"
-    )
+    # What the caller actually needs is whether the last tile below is the winning tile, so say that
+    # rather than which way the slicing ran. "Left to right" was also simply wrong for a hand lying up
+    # the frame, where the slice order is top to bottom.
+    if direction.known:
+        turned = "reversed, so that " if direction.reverse else ""
+        print(f"{turned}the winning tile is the last one below — {direction.why}\n")
+    else:
+        print(f"which end holds the winning tile is unknown — {direction.why}")
+        print("the order below is as sliced, and may be the reverse of the hand's\n")
 
     for i, (guess, sure) in enumerate(zip(predicted.tolist(), confidence.tolist()), 1):
         mark = "" if sure >= CONFIDENT else "   <- hand this one back"
         last = "   <- winning tile" if direction.known and i == count else ""
         print(f"  {i:2d}. {labels[guess]:4s} {sure:.2f}{mark}{last}")
     kept = sum(1 for c in confidence.tolist() if c >= CONFIDENT)
-    print(f"\n{kept}/{count} at confidence >= {CONFIDENT}")
-    if not direction.known:
-        print("which end is the winning tile could not be established — leave it for the user\n")
-    else:
-        print()
+    print(f"\n{kept}/{count} at confidence >= {CONFIDENT}\n")
 
     read_melds(model, bgr, light, melds, box, pitch, size, labels)
 


### PR DESCRIPTION
接 #166。一个会静默丢牌的 bug，加一小段决定读牌方向的逻辑。只动 `ml/try_real_photo.py`。

## 主要的：精修会静默丢掉一张牌

之前一直用相机原始竖图测。按**上传路径实际送出的那一份**跑（`normalizeUploadedImage` 会把竖图转成横向），同一张照片读成 **12 张，少一张 發**。多重集错了，而多重集是唯一要紧的东西。

不是识别不准。是**平均置信度不能比较张数不同的网格**——格子越少越能把最难的那张排除掉，分数必然越高：

| 张数 | span | 平均置信度 |
|---|---|---|
| 11 | 0.84 | **0.880** ← 最高 |
| 12 | 0.92 | 0.866 ← refine 选了这个 |
| **13** | **1.00** | 0.840 ← `fit_grid` 的答案，正确 |
| 14 | 1.07 | 0.780 |

它停在 12 只是因为 `COUNT_NUDGE` 只允许减一；允许减二就会返回 11。竖版恰好答 13 是运气，所以这个 bug 一直潜伏着。

**修法是删代码**：去掉 `COUNT_NUDGE`。行的长度是张数的无偏估计，`fit_grid` 已经在用（13 格覆盖 1.00，12 格只有 0.92）。张数由几何定，分类器只挪不到一格的零头——那本来就是它唯一擅长的事。

## 次要的：`reading_order`

算分器取 `concealed` 最后一张当和牌张（`GuobiaoCalculator.tsx:186`），所以 run 要结束在物理上的右端。两个独立来源，各自都有洞：

- **副露**：在手牌右端之外，离哪端近那端就是右端；与手机怎么举无关。只算大致在手牌轴线上的——真实照片里**弃牌堆也是四张一行**，在侧面，让任意 blob 投票就会指反（自检有这个用例）。
- **画面**：手牌横在画面里就是从左到右，也正是沿 +x 切的顺序。需要照片是正的，较弱。

手牌竖在画面里又没副露时，**报「不知道」而不是猜**——猜错和牌张是错分数，承认不知道是确认界面里点一下。两者都在时会交叉验证，不一致会在输出里说出来（忘了转图时能发现）。

前端已经有 ↺ 按钮且识别用的是旋转后的图，所以正常流程下「画面」这条是可靠的，这段主要是安全网。

## 验证

- 横版（生产输入）和竖版原图**都读 13/13**，多重集一致，顺序在两版之间正确反转
- `--self-check` 22/22（加了 6 个方向用例）
- `grid_fit.py` 8/8

## 不在这个 PR 里

- 拍照约定**不用改**，现在的提示已经够了
- 發 仍然 0.41–0.63：读对但过不了阈值，原因查清了（绿墨在照片里洗成近中性灰，增强覆盖不到），没修
- 副露/暗杠仍然零真实验证——还缺那两张照片，而 `isOpen` 是唯一会静默改分数的东西


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tile layout detection for more consistent results.
  - Automatically determines tile reading direction and adjusts displayed crops and predictions accordingly.
  - Highlights the tile identified as the best match.
  - Reports when the reading direction cannot be determined.

- **Bug Fixes**
  - Reduced unnecessary variation in tile-count detection and refined geometric alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->