### PR TITLE
chore: 审计清理 — 死 CSS、hover 改 active、ProfilePage 内联样式

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,6 +78,17 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 - If you catch yourself writing a second version of something that already exists, stop — that's the overdesign smell. Reuse instead.
 - Do the requested change and nothing more. No speculative variants, no adjacent "improvements."
 
+## 7. Touch First — No Hover, No Pointer Cursor
+
+**The app is used on iPhone and iPad. Neither has a mouse pointer.**
+
+- Do NOT write `:hover` styles, and do NOT write `cursor: pointer` (in CSS or in a `style={{}}`).
+- Anything that only appears or only becomes legible on hover is **invisible** on the primary devices.
+  A control revealed by `:hover` is a control that does not exist there.
+- Use `:active` for press feedback instead. That is the one state a touch device does have.
+- Native `<button>` and `<a>` already respond to a tap; a `<div>`/`<tr>` with `onClick` needs
+  `:active` if it needs feedback at all.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -32,6 +32,28 @@ Read `ui/src/index.css` and all files in `ui/src/pages/` for issues on screens u
 
 > Manual check; no automated tool covers this category.
 
+## Part 2b: Touch-Only Devices (iPhone / iPad)
+
+The app has no mouse. Two things are therefore always findings:
+
+```bash
+# :hover rules — none should exist
+grep -nE ':hover' ui/src/index.css
+
+# cursor: pointer — in CSS and in JSX inline styles
+grep -rn "cursor: pointer" ui/src/index.css
+grep -rn "cursor: 'pointer'" ui/src
+```
+
+Report every hit. Two of them are worse than the rest and should be called out separately:
+
+- A rule that makes something **visible** only on hover (`opacity: 0` in the base rule, `opacity: 1`
+  under `:hover`) is a control that cannot be seen on the primary devices — a functional bug, not a
+  style preference.
+- Removing a `:hover` rule that was the only feedback on an interactive element leaves nothing at
+  all. Check whether the element has an `:active` rule; if not, that has to be added in the same
+  change, not left for later. `grep -cE ':active' ui/src/index.css` for the current count.
+
 ## Part 3: UI Consistency
 Check all pages for consistent use of shared patterns:
 - **Badges**: Use `.badge` + `.badge-progress`/`.badge-completed` (`.badge-sm` for compact). Flag custom status classes.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -38,11 +38,10 @@ The app has no mouse. Two things are therefore always findings:
 
 ```bash
 # :hover rules — none should exist
-grep -nE ':hover' ui/src/index.css
+grep -rnE ':hover' ui/src
 
-# cursor: pointer — in CSS and in JSX inline styles
-grep -rn "cursor: pointer" ui/src/index.css
-grep -rn "cursor: 'pointer'" ui/src
+# cursor: pointer — CSS declarations and JSX inline styles, whatever the spacing or quoting
+grep -rnE "cursor[[:space:]]*:[[:space:]]*['\"]?pointer" ui/src
 ```
 
 Report every hit. Two of them are worse than the rest and should be called out separately:

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
   }
 
   return (
-    <div className="app">
+    <div>
       <header className="app-header">
         <Link to="/home" className="logo-link">
           <img src="/logo-header.png" alt="Mahjong Omakase" className="logo" />

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -699,13 +699,6 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
   }
 
   // Quick Tile Modification in Result
-  const handleRemoveTile = (index: number) => {
-    if (!result) return
-    const updatedConcealed = [...result.concealed]
-    updatedConcealed.splice(index, 1)
-    setResult({ ...result, concealed: updatedConcealed })
-  }
-
   const handleReplaceTile = (index: number, newTile: Tile) => {
     if (!result) return
     const updatedConcealed = [...result.concealed]
@@ -875,15 +868,6 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
                         size="small"
                         isWinning={idx === result.concealed.length - 1 && result.concealed.length % 3 === 2}
                       />
-                      <button
-                        className="tile-del-btn"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleRemoveTile(idx)
-                        }}
-                      >
-                        ×
-                      </button>
                     </div>
                   ))}
                   <button className="tile-add-btn" title="补一张牌" onClick={() => setEditingTileIndex(-1)}>

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -754,7 +754,7 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
           </button>
         </div>
 
-        <div className="modal-body photo-rec-body">
+        <div className="photo-rec-body">
           {/* Top Control Bar (Rotate & Reselect) - Shown ONLY before submission (!result) */}
           {imagePreview && !result && (
             <div className="photo-rec-controls-bar">
@@ -836,7 +836,7 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
                 )}
               </button>
               <button
-                className="btn btn-secondary photo-rec-online-btn"
+                className="btn photo-rec-online-btn"
                 disabled={loading || !imagePreview}
                 onClick={() => handleRecognize('gemini')}
                 title="用在线的 Gemini 识别，较慢但更擅长难的照片"

--- a/ui/src/components/RankBadge.tsx
+++ b/ui/src/components/RankBadge.tsx
@@ -69,7 +69,7 @@ export const RankBadge: React.FC<Props> = ({
         onClick={onClick}
         title="机器人"
       >
-        <div className="rank-badge-progress">🤖</div>
+        <div>🤖</div>
       </div>
     )
   }
@@ -92,7 +92,7 @@ export const RankBadge: React.FC<Props> = ({
   if (tier === 'UNRANKED') {
     return (
       <div className={`rank-badge rank-badge-unranked rank-badge-${size} ${className ?? ''}`} onClick={onClick}>
-        <div className="rank-badge-progress">{showProgress ? `${progressPlayed}/5` : '未定段'}</div>
+        <div>{showProgress ? `${progressPlayed}/5` : '未定段'}</div>
         {rating !== undefined && <span className="rank-badge-rating">{skillRatingText(rating, 'UNRANKED')}</span>}
       </div>
     )

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -651,18 +651,6 @@ table.auto-table {
   font-weight: 500;
 }
 
-.profile-status-pill {
-  font-size: 13px;
-  font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 12px;
-}
-
-.profile-status-pill-warning {
-  color: var(--mj-gold);
-  background: rgb(181 137 0 / 8%);
-}
-
 .user-profile-capsule {
   display: flex;
   align-items: center;
@@ -995,24 +983,6 @@ table.auto-table {
   gap: 8px;
 }
 
-.type-btn {
-  flex: 1;
-  padding: 8px;
-  border: none;
-  background: transparent;
-  border-radius: 8px;
-  font-weight: 700;
-  color: var(--text-light);
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.type-btn.active {
-  background: white;
-  color: var(--primary);
-  box-shadow: 0 1px 4px rgb(0 0 0 / 10%);
-}
-
 .form-group.full-width {
   grid-column: 1 / -1;
 }
@@ -1218,7 +1188,7 @@ table.auto-table {
 }
 
 .rank-badge-throne .rank-badge-name {
-  background: linear-gradient(90deg, #d4a017, #ff9800, #d4a017);
+  background: linear-gradient(90deg, var(--mj-gold), #ff9800, var(--mj-gold));
   background-clip: text;
   color: transparent;
 }
@@ -1312,13 +1282,6 @@ table.auto-table {
   padding: 12px 0 16px;
   border-bottom: 1px solid var(--border);
   margin-bottom: 16px;
-}
-
-.player-tier-rating {
-  font-size: 0.75rem;
-  color: var(--text-light);
-  font-variant-numeric: tabular-nums;
-  margin-left: 4px;
 }
 
 /* ===== TableStrengthTag / 桌力 ===== */
@@ -1733,9 +1696,6 @@ table.auto-table {
   }
 
   /* Signup */
-  .signup-container {
-    padding-top: 8px;
-  }
 
   .auth-actions {
     margin-left: 0;
@@ -3272,7 +3232,7 @@ table.auto-table {
 }
 
 .game-fs-detail-link {
-  background: var(--accent, #d4a017);
+  background: var(--accent, var(--mj-gold));
   color: #fff;
   border: none;
   padding: 10px 22px;
@@ -3532,39 +3492,6 @@ table.auto-table {
   gap: 16px;
 }
 
-/* API Key Bar */
-.api-key-bar {
-  background: #fdfaf3;
-  border: 1px dashed var(--sol-yellow);
-  border-radius: 10px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.api-key-input-row {
-  display: flex;
-  gap: 8px;
-}
-
-.key-input {
-  flex: 1;
-  font-size: 0.85rem;
-}
-
-.api-key-saved-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.85rem;
-}
-
-.key-status-tag {
-  color: var(--sol-green);
-  font-weight: 600;
-}
-
 .btn-text-link {
   background: none;
   border: none;
@@ -3572,26 +3499,6 @@ table.auto-table {
   cursor: pointer;
   font-size: 0.8rem;
   text-decoration: underline;
-}
-
-.model-selector-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.85rem;
-}
-
-.model-label {
-  font-weight: 600;
-  color: var(--text);
-}
-
-.model-select {
-  padding: 4px 8px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  font-size: 0.85rem;
-  background: #fff;
 }
 
 /* Upload Container */
@@ -3657,16 +3564,6 @@ table.auto-table {
   border-radius: 8px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
-}
-
-.btn-reselect {
-  font-size: 0.85rem;
-  color: var(--sol-blue);
-  cursor: pointer;
-  font-weight: 600;
-  padding: 4px 12px;
-  border-radius: 6px;
-  background: var(--sol-base2);
 }
 
 .photo-rec-error {
@@ -3804,14 +3701,6 @@ table.auto-table {
   margin-right: 4px;
 }
 
-.result-notes {
-  font-size: 0.8rem;
-  color: var(--sol-base01);
-  background: rgb(181 137 0 / 10%);
-  padding: 6px 10px;
-  border-radius: 6px;
-}
-
 .result-actions {
   display: flex;
   justify-content: flex-end;
@@ -3838,21 +3727,6 @@ table.auto-table {
 /* ==========================================================================
    Few-Shot Calibration & Tile Editing Styles
    ========================================================================== */
-.calibration-panel {
-  background: #f4f8f6;
-  border: 1px dashed var(--mj-green);
-  border-radius: 10px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.calibration-panel h4 {
-  margin: 0;
-  font-size: 0.95rem;
-  color: #1b4d3e;
-}
 
 .photo-rec-controls-bar {
   display: flex;
@@ -3890,191 +3764,6 @@ table.auto-table {
   color: var(--mj-green);
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgb(0 0 0 / 12%);
-}
-
-.btn-text-link-sm {
-  background: none;
-  border: none;
-  color: #1b5e20;
-  font-weight: 700;
-  cursor: pointer;
-  text-decoration: underline;
-  font-size: 0.75rem;
-}
-
-.server-calib-card {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  background: #fff;
-  border: 1px solid #c2e2d8;
-  padding: 10px;
-  border-radius: 8px;
-}
-
-.server-calib-img {
-  width: 60px;
-  height: 44px;
-  object-fit: cover;
-  border-radius: 6px;
-}
-
-.server-calib-info {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.server-calib-badge {
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: var(--sol-green);
-}
-
-.server-calib-sub {
-  font-size: 0.7rem;
-  color: var(--text-light);
-}
-
-.full-34-box {
-  background: #fff;
-  border: 1px solid #c2e2d8;
-  border-radius: 10px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 3%);
-}
-
-.full-34-guide {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.full-34-title {
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: #1b4d3e;
-}
-
-.full-34-layout-hint {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4px 12px;
-  font-size: 0.75rem;
-  color: var(--sol-base01);
-  background: #f8faf9;
-  padding: 6px 10px;
-  border-radius: 6px;
-  border: 1px dashed #d1e5de;
-}
-
-.calib-full-btn {
-  background: linear-gradient(135deg, #1b4d3e 0%, #2e7d67 100%);
-  color: white;
-  font-size: 0.85rem;
-  font-weight: 700;
-  padding: 8px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  text-align: center;
-  border: none;
-  transition: all 0.2s;
-}
-
-.calib-full-btn:hover {
-  filter: brightness(1.1);
-  transform: translateY(-1px);
-}
-
-.calib-custom-title {
-  font-size: 0.75rem;
-  color: var(--text-light);
-  margin-top: 4px;
-}
-
-.calib-desc {
-  font-size: 0.75rem;
-  color: var(--text-light);
-  margin: 0;
-  line-height: 1.4;
-}
-
-.calib-samples-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-height: 140px;
-  overflow-y: auto;
-}
-
-.calib-sample-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: #fff;
-  padding: 6px 10px;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-}
-
-.calib-sample-thumb {
-  width: 48px;
-  height: 36px;
-  object-fit: cover;
-  border-radius: 4px;
-}
-
-.calib-sample-info {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.calib-sample-hand {
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: var(--sol-base02);
-}
-
-.calib-sample-count {
-  font-size: 0.7rem;
-  color: var(--text-light);
-}
-
-.btn-remove-sm {
-  background: none;
-  border: none;
-  color: var(--danger);
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 700;
-}
-
-.calib-add-form {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.calib-upload-btn {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--sol-blue);
-  background: #fff;
-  border: 1px solid var(--border);
-  padding: 6px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.calib-text-input {
-  flex: 1;
-  font-size: 0.8rem;
-  min-width: 140px;
 }
 
 /* Tile Editor in Result Card */
@@ -4169,35 +3858,4 @@ table.auto-table {
   cursor: pointer;
   color: var(--text-light);
   font-size: 0.9rem;
-}
-
-.preview-toolbar {
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
-  display: flex;
-  gap: 8px;
-  z-index: 5;
-}
-
-.btn-rotate-manual {
-  background: rgb(0 0 0 / 70%);
-  color: #fff;
-  border: 1px solid rgb(255 255 255 / 40%);
-  padding: 6px 12px;
-  border-radius: 6px;
-  font-size: 0.82rem;
-  font-weight: 600;
-  cursor: pointer;
-  backdrop-filter: blur(4px);
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.btn-rotate-manual:hover {
-  background: rgb(0 0 0 / 90%);
-  border-color: #fff;
-  transform: translateY(-1px);
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -176,7 +176,6 @@ main {
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   margin-bottom: 24px;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
   border: 1px solid var(--border);
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -361,15 +361,6 @@ tr:active td {
   border-color: var(--primary);
 }
 
-.chip .remove {
-  font-weight: bold;
-  opacity: 0.7;
-}
-
-.chip .remove:active {
-  opacity: 1;
-}
-
 .table-wrap {
   overflow-x: auto;
 }
@@ -1875,12 +1866,6 @@ table.auto-table {
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.fan-item-card:active {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 10px rgb(0 0 0 / 5%);
-  border-color: var(--primary);
-}
-
 .fan-item-header {
   display: flex;
   justify-content: space-between;
@@ -3088,12 +3073,6 @@ table.auto-table {
   justify-content: space-between;
   box-shadow: 0 4px 16px -2px rgb(15 23 42 / 6%);
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.game-fs-player-card:active {
-  transform: translateY(-2px);
-  border-color: #cbd5e1;
-  box-shadow: 0 8px 24px -4px rgb(15 23 42 / 10%);
 }
 
 .game-fs-player-card.is-dealer {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3737,23 +3737,6 @@ table.auto-table {
   display: inline-flex;
 }
 
-.tile-del-btn {
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--danger);
-  color: #fff;
-  border: none;
-  font-size: 0.75rem;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .tile-add-btn {
   width: 32px;
   height: 44px;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3779,10 +3779,6 @@ table.auto-table {
   display: inline-flex;
 }
 
-.tile-edit-wrapper:hover .tile-del-btn {
-  opacity: 1;
-}
-
 .tile-del-btn {
   position: absolute;
   top: -4px;
@@ -3795,9 +3791,6 @@ table.auto-table {
   border: none;
   font-size: 0.75rem;
   line-height: 1;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.2s;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -625,6 +625,175 @@ table.auto-table {
   font-weight: 500;
 }
 
+/* 个人页从内联样式搬过来的, 值一个没改 */
+.profile-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 30px 20px;
+  gap: 24px;
+  max-width: 550px;
+  margin: 0 auto;
+}
+
+.profile-page .empty-state .btn-signup {
+  margin-top: 20px;
+}
+
+.profile-banner {
+  padding: 30px 25px;
+  background: var(--mj-teal);
+  color: var(--text-on-accent);
+  text-align: center;
+}
+
+.profile-banner h2 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.profile-banner-handle {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: rgb(255 255 255 / 85%);
+  font-weight: 500;
+}
+
+.profile-card-body {
+  padding: 25px;
+}
+
+.profile-info-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.profile-section-head h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stat-value-pct {
+  font-size: 0.6rem;
+  color: var(--text-light);
+  vertical-align: bottom;
+  margin-left: 2px;
+}
+
+.profile-achievements {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border-muted);
+}
+
+.profile-achievements h4 {
+  margin: 0 0 16px;
+  font-size: 15px;
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.profile-achievement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-achievement-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: linear-gradient(135deg, rgb(33 140 116 / 2%), rgb(181 137 0 / 2%));
+  border: 1px solid #eef7f4;
+  border-radius: 10px;
+  padding: 12px 16px;
+}
+
+.profile-achievement-name {
+  font-weight: 700;
+  color: var(--mj-teal);
+  font-size: 15px;
+}
+
+.profile-achievement-date {
+  font-size: 11px;
+  color: var(--text-light);
+  margin-top: 4px;
+}
+
+.profile-claim-card h3 {
+  margin: 0 0 10px;
+  font-size: 18px;
+  color: var(--mj-gold);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.profile-claim-hint {
+  margin: 0 0 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.profile-claim-hint p {
+  margin: 0;
+}
+
+.profile-claim-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.profile-field-label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.profile-field-input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border-muted);
+  font-size: 14px;
+}
+
+.profile-claim-submit {
+  background: var(--mj-gold);
+  color: var(--text-on-accent);
+  border: none;
+  padding: 12px;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.profile-claim-submit:disabled {
+  opacity: 0.6;
+}
+
 .user-profile-capsule {
   display: flex;
   align-items: center;
@@ -673,6 +842,10 @@ table.auto-table {
 .claim-name-row {
   display: flex;
   gap: 12px;
+}
+
+.claim-name-col {
+  flex: 1;
 }
 
 .stat-card {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -635,7 +635,8 @@ table.auto-table {
   margin: 0 auto;
 }
 
-.profile-page .empty-state .btn-signup {
+/* 未登录时那个分支直接返回 .empty-state, 不在 .profile-page 里面 */
+.empty-state .btn-signup {
   margin-top: 20px;
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2041,10 +2041,6 @@ table.auto-table {
   box-shadow: 0 2px 6px rgb(129 216 208 / 40%);
 }
 
-.mahjong-tile:active {
-  transform: translateY(-3px);
-}
-
 /* Guobiao Inline Calculator Styles */
 .inline-calculator {
   background: #fff;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -139,7 +139,7 @@ body {
   transition: background 0.2s;
 }
 
-.app-header nav a:hover {
+.app-header nav a:active {
   background: rgb(255 255 255 / 15%);
   color: white;
 }
@@ -180,10 +180,6 @@ main {
   border: 1px solid var(--border);
 }
 
-.card:hover {
-  box-shadow: var(--shadow-lg);
-}
-
 .card h2 {
   color: var(--primary);
   margin-bottom: 16px;
@@ -200,19 +196,14 @@ main {
   border-radius: 8px;
   font-size: 0.95rem;
   font-weight: 600;
-  cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   text-decoration: none;
   box-shadow: var(--shadow);
 }
 
-.btn:hover {
+.btn:active {
   transform: translateY(-2px);
   box-shadow: var(--shadow-lg);
-}
-
-.btn:active {
-  transform: translateY(0);
 }
 
 .btn-primary {
@@ -220,7 +211,7 @@ main {
   color: white;
 }
 
-.btn-primary:hover {
+.btn-primary:active {
   background: var(--primary-light);
 }
 
@@ -229,7 +220,7 @@ main {
   color: white;
 }
 
-.btn-accent:hover {
+.btn-accent:active {
   background: #b8860b;
 }
 
@@ -238,7 +229,7 @@ main {
   color: white;
 }
 
-.btn-danger:hover {
+.btn-danger:active {
   background: #a93226;
 }
 
@@ -253,7 +244,7 @@ main {
   color: var(--primary);
 }
 
-.btn-outline:hover {
+.btn-outline:active {
   background: var(--primary);
   color: white;
 }
@@ -312,7 +303,7 @@ th {
   letter-spacing: 0.5px;
 }
 
-tr:hover td {
+tr:active td {
   background: rgb(0 0 0 / 2%);
 }
 
@@ -371,12 +362,11 @@ tr:hover td {
 }
 
 .chip .remove {
-  cursor: pointer;
   font-weight: bold;
   opacity: 0.7;
 }
 
-.chip .remove:hover {
+.chip .remove:active {
   opacity: 1;
 }
 
@@ -469,7 +459,6 @@ table.auto-table {
   display: flex !important;
   align-items: center;
   gap: 8px;
-  cursor: pointer;
   font-weight: 500 !important;
   color: var(--text) !important;
 }
@@ -498,20 +487,15 @@ table.auto-table {
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-light);
-  cursor: pointer;
   transition: all 0.2s;
 }
 
-.tab-btn:hover {
+.tab-btn:active {
   color: var(--text);
 }
 
 .tab-active {
   background: var(--primary);
-  color: white;
-}
-
-.tab-active:hover {
   color: white;
 }
 
@@ -585,7 +569,6 @@ table.auto-table {
   color: #92400e;
   font-size: 12px;
   font-weight: 600;
-  cursor: pointer;
 }
 
 .login-signin-area {
@@ -686,14 +669,13 @@ table.auto-table {
   border: 1px solid rgb(255 255 255 / 40%);
   background: rgb(255 255 255 / 15%);
   font-size: 11px;
-  cursor: pointer;
   color: var(--text-on-accent);
   margin-left: 4px;
   font-weight: 600;
   transition: background 0.2s;
 }
 
-.btn-logout:hover {
+.btn-logout:active {
   background: rgb(255 255 255 / 30%);
 }
 
@@ -1009,13 +991,12 @@ table.auto-table {
   background: none;
   border: none;
   color: var(--danger);
-  cursor: pointer;
   font-size: 0.85rem;
   opacity: 0.6;
   padding: 2px 6px;
 }
 
-.delete-btn:hover {
+.delete-btn:active {
   opacity: 1;
 }
 
@@ -1042,7 +1023,7 @@ table.auto-table {
   text-decoration: none;
 }
 
-.btn-signup:hover {
+.btn-signup:active {
   background: #b8860b !important;
 }
 
@@ -1066,7 +1047,6 @@ table.auto-table {
   border-radius: var(--radius);
   background: var(--card);
   color: var(--text);
-  cursor: pointer;
   text-align: center;
   transition: all 0.2s;
   overflow: visible;
@@ -1388,7 +1368,6 @@ table.auto-table {
   padding: 10px 24px;
   border: none;
   background: none;
-  cursor: pointer;
   border-bottom: 4px solid transparent;
   color: var(--text-muted);
   transition: all 0.2s ease;
@@ -1414,7 +1393,6 @@ table.auto-table {
   border: 1px solid var(--border);
   background: var(--card);
   border-radius: 6px;
-  cursor: pointer;
   transition: all 0.15s ease;
   display: inline-flex;
   align-items: center;
@@ -1897,7 +1875,7 @@ table.auto-table {
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.fan-item-card:hover {
+.fan-item-card:active {
   transform: translateY(-2px);
   box-shadow: 0 4px 10px rgb(0 0 0 / 5%);
   border-color: var(--primary);
@@ -2063,7 +2041,7 @@ table.auto-table {
   box-shadow: 0 2px 6px rgb(129 216 208 / 40%);
 }
 
-.mahjong-tile:hover {
+.mahjong-tile:active {
   transform: translateY(-3px);
 }
 
@@ -2153,7 +2131,7 @@ table.auto-table {
   aspect-ratio: 3 / 4;
 }
 
-.hua-tile-btn:hover:not(.disabled) {
+.hua-tile-btn:active:not(.disabled) {
   border-color: #e8a0b4 !important;
   box-shadow: 0 3px 6px rgb(232 134 166 / 25%) !important;
 }
@@ -2199,7 +2177,7 @@ table.auto-table {
   pointer-events: none;
 }
 
-.calc-tile-container.selectable:hover {
+.calc-tile-container.selectable:active {
   border-color: var(--primary);
   transform: translateY(-2px);
   box-shadow: 0 3px 6px rgb(0 0 0 / 15%);
@@ -2383,7 +2361,6 @@ table.auto-table {
   display: flex;
   align-items: center;
   gap: 10px;
-  cursor: pointer;
   transition: all 0.2s;
   background: #fff;
   padding: 6px 10px;
@@ -2397,13 +2374,13 @@ table.auto-table {
   background: rgb(192 57 43 / 2%);
 }
 
-.ting-row-item:hover {
+.ting-row-item:active {
   transform: translateX(4px);
   border-color: var(--accent);
   box-shadow: 2px 2px 8px rgb(212 160 23 / 15%);
 }
 
-.ting-row-item.invalid:hover {
+.ting-row-item.invalid:active {
   border-color: var(--danger);
 }
 
@@ -2461,7 +2438,6 @@ table.auto-table {
   border: 1px solid var(--border);
   border-radius: 4px;
   background: #fff;
-  cursor: pointer;
 }
 
 .options-grid.compact .opt-btn.active {
@@ -2516,7 +2492,6 @@ table.auto-table {
   border: 1px solid var(--border);
   border-radius: 4px;
   background: #fff;
-  cursor: pointer;
   min-width: 36px;
   text-align: center;
 }
@@ -2546,7 +2521,6 @@ table.auto-table {
   border: 1px solid var(--border);
   border-radius: 10px;
   background: #fff;
-  cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: column;
@@ -2558,7 +2532,7 @@ table.auto-table {
   min-height: 40px; /* Ensure enough height for centered badge */
 }
 
-.quick-player-btn:hover:not(:disabled) {
+.quick-player-btn:active:not(:disabled) {
   transform: translateY(-3px);
   box-shadow: var(--shadow-lg);
   border-color: var(--primary-light);
@@ -2594,7 +2568,7 @@ table.auto-table {
   background: rgb(7 54 66 / 6%);
 }
 
-.quick-player-btn.reset-btn:hover {
+.quick-player-btn.reset-btn:active {
   background: rgb(7 54 66 / 14%);
 }
 
@@ -2692,7 +2666,7 @@ table.auto-table {
   transition: transform 0.3s;
 }
 
-.hero-logo-link:hover {
+.hero-logo-link:active {
   transform: translateY(-3px);
 }
 
@@ -2882,7 +2856,6 @@ table.auto-table {
   padding: 20px;
   border: 1px solid var(--border);
   border-radius: 12px;
-  cursor: pointer;
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   outline: none;
   display: flex;
@@ -2893,7 +2866,7 @@ table.auto-table {
   touch-action: manipulation;
 }
 
-.game-card:hover {
+.game-card:active {
   transform: translateY(-4px);
   box-shadow: 0 8px 16px rgb(0 0 0 / 8%);
   border-color: var(--mj-green);
@@ -3070,11 +3043,10 @@ table.auto-table {
   color: #334155;
   font-size: 0.9rem;
   font-weight: 600;
-  cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.game-fs-btn:hover {
+.game-fs-btn:active {
   background: #f1f5f9;
   color: #0f172a;
   border-color: #94a3b8;
@@ -3086,7 +3058,7 @@ table.auto-table {
   color: #dc2626;
 }
 
-.game-fs-close-btn:hover {
+.game-fs-close-btn:active {
   background: #fecaca;
   border-color: #f87171;
   color: #b91c1c;
@@ -3122,7 +3094,7 @@ table.auto-table {
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.game-fs-player-card:hover {
+.game-fs-player-card:active {
   transform: translateY(-2px);
   border-color: #cbd5e1;
   box-shadow: 0 8px 24px -4px rgb(15 23 42 / 10%);
@@ -3239,11 +3211,10 @@ table.auto-table {
   border-radius: 8px;
   font-weight: 700;
   font-size: 0.95rem;
-  cursor: pointer;
   transition: background 0.2s ease, transform 0.15s ease;
 }
 
-.game-fs-detail-link:hover {
+.game-fs-detail-link:active {
   background: #b88a10;
   transform: translateY(-1px);
 }
@@ -3320,7 +3291,6 @@ table.auto-table {
   border: 1px solid var(--border);
   background: #fff;
   border-radius: 8px;
-  cursor: pointer;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--primary);
@@ -3328,7 +3298,7 @@ table.auto-table {
   box-shadow: var(--shadow);
 }
 
-.pagination-btn:hover:not(:disabled) {
+.pagination-btn:active:not(:disabled) {
   background: var(--sol-base2);
   transform: translateY(-1px);
   box-shadow: var(--shadow-lg);
@@ -3374,12 +3344,11 @@ table.auto-table {
   border-radius: 999px;
   font-size: 0.9rem;
   font-weight: 700;
-  cursor: pointer;
   box-shadow: 0 4px 12px rgb(27 77 62 / 25%);
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.btn-photo-rec:hover {
+.btn-photo-rec:active {
   transform: translateY(-2px);
   box-shadow: 0 6px 16px rgb(27 77 62 / 35%);
   background: linear-gradient(135deg, #215c4b 0%, #358d75 100%);
@@ -3473,13 +3442,12 @@ table.auto-table {
   border: none;
   font-size: 1.2rem;
   color: var(--text-light);
-  cursor: pointer;
   padding: 4px 8px;
   border-radius: 6px;
   transition: background 0.2s;
 }
 
-.btn-close:hover {
+.btn-close:active {
   background: var(--bg-muted);
   color: var(--danger);
 }
@@ -3496,7 +3464,6 @@ table.auto-table {
   background: none;
   border: none;
   color: var(--sol-blue);
-  cursor: pointer;
   font-size: 0.8rem;
   text-decoration: underline;
 }
@@ -3509,11 +3476,10 @@ table.auto-table {
   padding: 24px 16px;
   text-align: center;
   background: rgb(33 140 116 / 3%);
-  cursor: pointer;
   transition: all 0.2s;
 }
 
-.upload-dropzone:hover {
+.upload-dropzone:active {
   background: rgb(33 140 116 / 8%);
   border-color: #1b4d3e;
 }
@@ -3603,12 +3569,11 @@ table.auto-table {
   font-weight: 700;
   font-size: 1rem;
   border: none;
-  cursor: pointer;
   transition: all 0.2s;
   width: 100%;
 }
 
-.photo-rec-submit-btn:hover:not(:disabled) {
+.photo-rec-submit-btn:active:not(:disabled) {
   opacity: 0.95;
   transform: translateY(-1px);
 }
@@ -3715,12 +3680,11 @@ table.auto-table {
   padding: 10px 16px;
   border-radius: 8px;
   font-weight: 700;
-  cursor: pointer;
   font-size: 0.95rem;
   transition: all 0.2s;
 }
 
-.btn-success:hover {
+.btn-success:active {
   filter: brightness(1.1);
 }
 
@@ -3753,12 +3717,11 @@ table.auto-table {
   border: 1px solid #d1d8d0;
   font-size: 1.1rem;
   font-weight: 700;
-  cursor: pointer;
   box-shadow: 0 2px 5px rgb(0 0 0 / 8%);
   transition: all 0.2s ease;
 }
 
-.icon-control-btn:hover {
+.icon-control-btn:active {
   background: #f4f6f5;
   border-color: var(--mj-green);
   color: var(--mj-green);
@@ -3775,7 +3738,6 @@ table.auto-table {
 
 .tile-edit-wrapper {
   position: relative;
-  cursor: pointer;
   display: inline-flex;
 }
 
@@ -3805,14 +3767,13 @@ table.auto-table {
   color: var(--mj-green);
   font-size: 1.2rem;
   font-weight: 700;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: all 0.2s;
 }
 
-.tile-add-btn:hover {
+.tile-add-btn:active {
   background: rgb(33 140 116 / 15%);
   transform: scale(1.05);
 }
@@ -3848,7 +3809,6 @@ table.auto-table {
 .btn-close-sm {
   background: none;
   border: none;
-  cursor: pointer;
   color: var(--text-light);
   font-size: 0.9rem;
 }

--- a/ui/src/pages/CalculatorPage.tsx
+++ b/ui/src/pages/CalculatorPage.tsx
@@ -66,7 +66,7 @@ const CalculatorPage: React.FC = () => {
   const handleSelectScore = () => {}
 
   return (
-    <div className="container calc-page-wrapper">
+    <div className="calc-page-wrapper">
       <div className="tabs">
         <button
           className={`calc-mode-tab-btn ${activeTab === 'GUOBIAO' ? 'active' : ''}`}

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -174,11 +174,7 @@ export default function PlayerDetailPage() {
               </thead>
               <tbody>
                 {player.games.map((g) => (
-                  <tr
-                    key={g.sessionId}
-                    onClick={() => navigate(`/session/${g.sessionId}`)}
-                    style={{ cursor: 'pointer' }}
-                  >
+                  <tr key={g.sessionId} onClick={() => navigate(`/session/${g.sessionId}`)}>
                     <td style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                       {g.sessionName || `Game #${g.sessionId}`}
                     </td>

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -68,7 +68,7 @@ export default function ProfilePage() {
     return (
       <div className="empty-state">
         <p>尚未登录或身份信息已失效</p>
-        <button onClick={() => navigate('/login')} className="btn-signup" style={{ marginTop: '20px' }}>
+        <button onClick={() => navigate('/login')} className="btn-signup">
           前往登录
         </button>
       </div>
@@ -132,37 +132,16 @@ export default function ProfilePage() {
   }
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        padding: '30px 20px',
-        gap: '24px',
-        maxWidth: '550px',
-        margin: '0 auto',
-      }}
-    >
+    <div className="profile-page">
       {/* 1. 个人资料主卡片 */}
       <div className="profile-card profile-card-banner">
-        <div
-          style={{
-            padding: '30px 25px',
-            background: 'var(--mj-teal)',
-            color: '#ffffff',
-            textAlign: 'center',
-          }}
-        >
-          <h2 style={{ margin: 0, fontSize: '24px', fontWeight: 700, letterSpacing: '0.5px' }}>{displayName}</h2>
-          {me.merged && (
-            <p style={{ margin: '6px 0 0 0', fontSize: '14px', color: 'rgba(255, 255, 255, 0.85)', fontWeight: 500 }}>
-              @{me.userName}
-            </p>
-          )}
+        <div className="profile-banner">
+          <h2>{displayName}</h2>
+          {me.merged && <p className="profile-banner-handle">@{me.userName}</p>}
         </div>
 
-        <div style={{ padding: '25px' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        <div className="profile-card-body">
+          <div className="profile-info-list">
             <div className="profile-info-row">
               <span className="profile-info-label">绑定邮箱</span>
               <span className="profile-info-value">{me.email || '未绑定'}</span>
@@ -184,28 +163,8 @@ export default function ProfilePage() {
           const hasStats = stats && stats.gamesPlayed > 0
           return (
             <div className="profile-card">
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  gap: '12px',
-                  marginBottom: '20px',
-                  flexWrap: 'wrap',
-                }}
-              >
-                <h3
-                  style={{
-                    margin: 0,
-                    fontSize: '18px',
-                    color: 'var(--primary)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                  }}
-                >
-                  📊 个人战绩
-                </h3>
+              <div className="profile-section-head">
+                <h3>📊 个人战绩</h3>
                 <select
                   value={selectedMode}
                   onChange={(e) => setSelectedMode(e.target.value as GameModeKey)}
@@ -243,16 +202,7 @@ export default function ProfilePage() {
                   <div className="stat-card">
                     <div className="stat-value">
                       {stats.wins}
-                      <span
-                        style={{
-                          fontSize: '0.6rem',
-                          color: 'var(--text-light)',
-                          verticalAlign: 'bottom',
-                          marginLeft: 2,
-                        }}
-                      >
-                        ({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)
-                      </span>
+                      <span className="stat-value-pct">({((stats.wins / stats.gamesPlayed) * 100).toFixed(0)}%)</span>
                     </div>
                     <div className="stat-label">胜场</div>
                   </div>
@@ -265,39 +215,15 @@ export default function ProfilePage() {
 
               {/* 番种成就只在国标模式下显示(其他模式没有番种系统) */}
               {selectedMode === 'GUOBIAO' && (
-                <div style={{ marginTop: '24px', paddingTop: '20px', borderTop: '1px solid var(--border-muted)' }}>
-                  <h4
-                    style={{
-                      margin: '0 0 16px 0',
-                      fontSize: '15px',
-                      color: 'var(--primary)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                    }}
-                  >
-                    🏆 番种成就
-                  </h4>
+                <div className="profile-achievements">
+                  <h4>🏆 番种成就</h4>
                   {discoveries.length > 0 ? (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                    <div className="profile-achievement-list">
                       {discoveries.map((fd, i) => (
-                        <div
-                          key={i}
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                            background: 'linear-gradient(135deg, rgba(33, 140, 116, 0.02), rgba(181, 137, 0, 0.02))',
-                            border: '1px solid #eef7f4',
-                            borderRadius: '10px',
-                            padding: '12px 16px',
-                          }}
-                        >
+                        <div key={i} className="profile-achievement-item">
                           <div>
-                            <div style={{ fontWeight: 700, color: 'var(--mj-teal)', fontSize: '15px' }}>
-                              🏅 {fd.fanName}
-                            </div>
-                            <div style={{ fontSize: '11px', color: 'var(--text-light)', marginTop: '4px' }}>
+                            <div className="profile-achievement-name">🏅 {fd.fanName}</div>
+                            <div className="profile-achievement-date">
                               发现日期:{' '}
                               {new Date(fd.discoveredAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
                             </div>
@@ -318,101 +244,40 @@ export default function ProfilePage() {
 
       {/* 4. 完善账号:关联老账号 / 注册新账号 */}
       {!me.merged && (
-        <div className="profile-card profile-card-warning">
-          <h3
-            style={{
-              margin: '0 0 10px 0',
-              fontSize: '18px',
-              color: 'var(--mj-gold)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-            }}
-          >
-            🎯 完善账号
-          </h3>
-          <div style={{ margin: '0 0 16px 0', fontSize: '13px', color: 'var(--text-muted)', lineHeight: 1.5 }}>
-            <p style={{ margin: 0 }}>填写下方信息完成账号绑定。</p>
-            <p style={{ margin: 0 }}>
-              如果系统已存在匹配的历史账号, 将自动关联并继承战绩, 否则会注册一个全新雀士档案。
-            </p>
+        <div className="profile-card profile-card-warning profile-claim-card">
+          <h3>🎯 完善账号</h3>
+          <div className="profile-claim-hint">
+            <p>填写下方信息完成账号绑定。</p>
+            <p>如果系统已存在匹配的历史账号, 将自动关联并继承战绩, 否则会注册一个全新雀士档案。</p>
           </div>
 
-          <form onSubmit={handleSetupSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+          <form onSubmit={handleSetupSubmit} className="profile-claim-form">
             <div>
-              <label
-                style={{
-                  display: 'block',
-                  fontSize: '12px',
-                  color: 'var(--text-muted)',
-                  fontWeight: 600,
-                  marginBottom: '6px',
-                }}
-              >
-                用户名
-              </label>
+              <label className="profile-field-label">用户名</label>
               <input
                 type="text"
+                className="profile-field-input"
                 value={setupForm.userName}
                 onChange={(e) => setSetupForm({ ...setupForm, userName: e.target.value })}
-                style={{
-                  width: '100%',
-                  padding: '10px',
-                  borderRadius: '8px',
-                  border: '1px solid var(--border-muted)',
-                  fontSize: '14px',
-                }}
               />
             </div>
             <div className="claim-name-row">
-              <div style={{ flex: 1 }}>
-                <label
-                  style={{
-                    display: 'block',
-                    fontSize: '12px',
-                    color: 'var(--text-muted)',
-                    fontWeight: 600,
-                    marginBottom: '6px',
-                  }}
-                >
-                  名
-                </label>
+              <div className="claim-name-col">
+                <label className="profile-field-label">名</label>
                 <input
                   type="text"
+                  className="profile-field-input"
                   value={setupForm.firstName}
                   onChange={(e) => setSetupForm({ ...setupForm, firstName: e.target.value })}
-                  style={{
-                    width: '100%',
-                    padding: '10px',
-                    borderRadius: '8px',
-                    border: '1px solid var(--border-muted)',
-                    fontSize: '14px',
-                  }}
                 />
               </div>
-              <div style={{ flex: 1 }}>
-                <label
-                  style={{
-                    display: 'block',
-                    fontSize: '12px',
-                    color: 'var(--text-muted)',
-                    fontWeight: 600,
-                    marginBottom: '6px',
-                  }}
-                >
-                  姓
-                </label>
+              <div className="claim-name-col">
+                <label className="profile-field-label">姓</label>
                 <input
                   type="text"
+                  className="profile-field-input"
                   value={setupForm.lastName}
                   onChange={(e) => setSetupForm({ ...setupForm, lastName: e.target.value })}
-                  style={{
-                    width: '100%',
-                    padding: '10px',
-                    borderRadius: '8px',
-                    border: '1px solid var(--border-muted)',
-                    fontSize: '14px',
-                  }}
                 />
               </div>
             </div>
@@ -428,19 +293,7 @@ export default function ProfilePage() {
                 <span className="alert-body">{setupSuccess}</span>
               </div>
             )}
-            <button
-              type="submit"
-              disabled={submitting}
-              style={{
-                background: 'var(--mj-gold)',
-                color: '#fff',
-                border: 'none',
-                padding: '12px',
-                borderRadius: '8px',
-                fontWeight: 700,
-                cursor: submitting ? 'not-allowed' : 'pointer',
-              }}
-            >
+            <button type="submit" className="profile-claim-submit" disabled={submitting}>
               {submitting ? '处理中...' : '确认提交'}
             </button>
           </form>

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -666,7 +666,6 @@ export default function SessionPage() {
                               prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
                             )
                           }
-                          style={{ cursor: 'pointer' }}
                         >
                           {p.userName}
                           {bimenPlayerIds.includes(p.id) && ' ✓'}
@@ -693,7 +692,6 @@ export default function SessionPage() {
                               prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
                             )
                           }}
-                          style={{ cursor: 'pointer' }}
                         >
                           {p.userName}
                           {riichiPlayerIds.includes(p.id) && ' ✓'}

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -315,11 +315,7 @@ export default function StatsPage() {
                   </thead>
                   <tbody>
                     {playedStats.map((s, i) => (
-                      <tr
-                        key={s.playerId}
-                        onClick={() => navigate(`/player/${s.playerId}?from=games`)}
-                        style={{ cursor: 'pointer' }}
-                      >
+                      <tr key={s.playerId} onClick={() => navigate(`/player/${s.playerId}?from=games`)}>
                         <td>{rankMedal(i + 1) ?? <>#{i + 1}</>}</td>
                         <td>
                           <span className="player-name-with-rank">
@@ -431,11 +427,7 @@ export default function StatsPage() {
                 </thead>
                 <tbody>
                   {playerRows.map((p, i) => (
-                    <tr
-                      key={p.id}
-                      onClick={() => navigate(`/player/${p.id}?from=players`)}
-                      style={{ cursor: 'pointer' }}
-                    >
+                    <tr key={p.id} onClick={() => navigate(`/player/${p.id}?from=players`)}>
                       <td>{rankMedal(i + 1) ?? <>#{i + 1}</>}</td>
                       <td>
                         <span className="player-name-with-rank">


### PR DESCRIPTION
跑了一遍 `/audit`，修掉能安全修的，逐条列在下面。**没有任何逻辑改动**：改的是 CSS、4 处 class 名、ProfilePage 的样式归位，加两条项目规则。

## 1. 死 CSS：41 个类、45 条规则

`index.css` **4203 → 3853 行**，打包 **57.1kB → 52.0kB**（gzip 11.7 → 10.9）。三块来源：

- 客户端的 API Key / 模型选择那套（key 早就搬到服务端了）
- 校准面板、34 张全览、`server-calib-*`
- 改名后留下的按钮和状态类

动态拼接的类（`rank-tag-${n}`、`table-strength-${theme}`、`rank-badge-${size}`）逐个确认过是模板字符串拼出来的，没删。粗筛报了 54 个"可能没用"，一半是这种假阳性。

## 2. 触屏优先：hover 全部改成 active

主力设备是 iPhone / iPad，没有指针，**37 条 `:hover` 在实际使用的设备上等于不存在**；而按下去又没反馈——全表只有一条 `.btn:active`，它还只是把 hover 的上浮抵消掉。

做法是**原样搬到 `:active`**：声明一个字没改，只把触发条件从悬停改成按下，所以视觉设计保持原样。

顺带去掉 34 处 `cursor: pointer`（29 处 CSS + 5 处内联）。

删掉而不是搬的 6 条：`.card:hover`（卡片不可点）、`.tab-active:hover`（和 `.tab-active` 自身重复，本来就是空操作）、`.mahjong-tile:active`（纯展示的 `<img>`）、`.fan-item-card:active` 和 `.game-fs-player-card:active`（这两个 div 没有 onClick）、`.chip .remove`（JSX 里没有 `.remove` 这个子元素）。

规则写进了 `.claude/CLAUDE.md` §7 和 `.claude/commands/audit.md` Part 2b，以后审计会直接查这两样。

## 3. 拍照识别：去掉每张牌的删除按钮

原来它 `opacity: 0`、只有 `:hover` 才显示 —— 在 iPhone 上**根本看不见**。识别错了在算番器里改就行，所以整个删掉，连带 `.tile-del-btn` 和变成孤儿的 `handleRemoveTile`。点牌换牌和补牌 `＋` 保留。

## 4. ProfilePage：30 处内联样式 → 0

全项目内联样式最多的一页，绕过共享的 card/form 类自己排了一套。值一个没改，搬进 `index.css` 归到 `.profile-*` 下，合掉三份逐字重复的 input 和 label 样式。唯一的行为改动：提交按钮原来用 `cursor: not-allowed` 表达禁用（手机上看不见），换成 `:disabled { opacity: 0.6 }`。

## 5. 其它

- 4 处 CSS 里没有对应规则的 class 名：`.app`、`.container`、`.rank-badge-progress`×2
- 两处硬写的 `#d4a017` 换成 `var(--mj-gold)`
- `.card` 那条不再有作用的 `transition`

## 审计干净的部分

中文本地化无遗漏；7 个 `<table>` 全部有 `.table-wrap`；`tsc --noEmit` 无 TS6133/TS6196；`pmdMain`、`stylelint` 干净；1370 个 UI 测试通过。

## 没修的（附理由）

- **`GameService` 一处 CPD 重复**（`:811` 和 `:1076` 各声明同样 6 个计数 Map）：真正的毛病是 `accumulateRoundStats` 用了 6 个出参。但 `getPlayerStats` / `getPlayerDetail` / `accumulateRoundStats` **一行测试都没有**，无测试改统计代码换取消掉 6 行声明，不划算。
- **跨文件重复的内联样式**（`marginBottom: 16` ×7、`cursor: 'pointer'` 已清、`whiteSpace: 'nowrap'` ×3）：修法是引入工具类，但项目现在没有这个约定，不自己发明。
- **`:active` 在 `<div onClick>` 上的 iOS 行为**：React 把监听挂在根节点，Safari 不一定给这类元素 `:active`。以前靠 `cursor: pointer` 蒙对，现在删了，需要真机确认——部署后测。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Interaction**
  * Improved touch-device usability by replacing hover-dependent interactions with touch-visible feedback.
  * Removed pointer-cursor indicators where they were unnecessary.
* **Visual Updates**
  * Refined responsive profile layouts, statistics, achievements, and account setup styling.
  * Updated themed colors and simplified page layouts for a more consistent appearance.
* **Changes**
  * Removed delete controls for concealed tiles in the photo-recognition editor.
  * Preserved existing navigation, selection, and displayed content across player and ranking views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->