### PR TITLE
fix(ui): 字号函数修 iPad 旋转失效 + 中文名分档, 档位表一档没删

### DIFF
--- a/ui/src/pages/FanTablePage.tsx
+++ b/ui/src/pages/FanTablePage.tsx
@@ -7,6 +7,7 @@ import { FanDiscovery, getCurrentSeason, GAME_MODES, GameModeKey } from '../type
 import { MahjongHand } from '../components/MahjongHand'
 import { nameFontSize } from '../utils/fontSize'
 import { useActiveSeasons } from '../hooks/useActiveSeasons'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 const TAB_DATA_MAP: Record<GameModeKey, { data: () => FanItem[] }> = {
   GUOBIAO: { data: () => fanTableData },
@@ -30,6 +31,7 @@ function keyDiscoveriesByEarliest(discoveries: FanDiscovery[]): Record<string, F
 }
 
 const FanTablePage: React.FC = () => {
+  const isMobile = useIsMobile()
   const [search, setSearch] = useState('')
   const [activeTab, setActiveTab] = useState<GameModeKey>('GUOBIAO')
   // Current season discoveries (for the selected season key)
@@ -222,7 +224,7 @@ const FanTablePage: React.FC = () => {
                         {hasCurrent && (
                           <span
                             className="badge badge-discovery badge-sm"
-                            style={{ fontSize: nameFontSize(currentDiscovery.playerName) }}
+                            style={{ fontSize: nameFontSize(currentDiscovery.playerName, isMobile) }}
                             title={`首位达成者: ${currentDiscovery.playerName}`}
                           >
                             本月冠名: {currentDiscovery.playerName}
@@ -231,7 +233,7 @@ const FanTablePage: React.FC = () => {
                         {hasPrev && (
                           <span
                             className="badge badge-discovery-prev badge-sm"
-                            style={{ fontSize: nameFontSize(prevDiscovery.playerName) }}
+                            style={{ fontSize: nameFontSize(prevDiscovery.playerName, isMobile) }}
                             title={`历史冠名: ${prevDiscovery.playerName}（本月尚未被发现）`}
                           >
                             历史冠名: {prevDiscovery.playerName}

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -9,8 +9,10 @@ import { rankByScore } from '../logic/ranking'
 import { nameFontSize } from '../utils/fontSize'
 import { rankMedal, skillRatingText } from '../utils/format'
 import { MSG } from '../constants'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 export default function HomePage() {
+  const isMobile = useIsMobile()
   const [activeSessions, setActiveSessions] = useState<SessionDetail[]>([])
   const [rankings, setRankings] = useState<Record<string, { top: PlayerStats[]; best: BestRound | null }>>({})
   const [loading, setLoading] = useState(true)
@@ -141,7 +143,10 @@ export default function HomePage() {
                                 gamesNeeded={undefined}
                                 userName={player.userName}
                               />
-                              <span className="player-name" style={{ fontSize: nameFontSize(player.userName) }}>
+                              <span
+                                className="player-name"
+                                style={{ fontSize: nameFontSize(player.userName, isMobile) }}
+                              >
                                 {player.userName}
                               </span>
                             </span>

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -5,11 +5,13 @@ import { Player, GameModeKey, GAME_MODES } from '../types'
 import { cardFontSize } from '../utils/fontSize'
 import { MSG } from '../constants'
 import { abbrName, parseError } from '../utils/format'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 const MIN_PLAYERS = 3
 const MAX_PLAYERS = 4
 
 export default function NewSessionPage() {
+  const isMobile = useIsMobile()
   const navigate = useNavigate()
   const [players, setPlayers] = useState<Player[]>([])
   const [selectedIds, setSelectedIds] = useState<number[]>([])
@@ -127,7 +129,7 @@ export default function NewSessionPage() {
                   onClick={() => !isDisabled && togglePlayer(p.id)}
                   className={`player-select-card${isSelected ? ' selected' : ''}${isDisabled ? ' disabled' : ''}`}
                 >
-                  <div style={{ fontWeight: 600, fontSize: cardFontSize(p.userName), marginBottom: 4 }}>
+                  <div style={{ fontWeight: 600, fontSize: cardFontSize(p.userName, isMobile), marginBottom: 4 }}>
                     {p.userName}
                   </div>
                   <div style={{ fontSize: '0.85rem', opacity: isSelected ? 0.9 : 0.6 }}>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -217,7 +217,7 @@ export default function StatsPage() {
 
   const awardCard = (name: string, sub: string, winner: PlayerStats | null, rate?: number) => (
     <div className="stat-card">
-      <div className="stat-value" style={{ fontSize: statFontSize(winner?.userName || '-') }}>
+      <div className="stat-value" style={{ fontSize: statFontSize(winner?.userName || '-', isMobile) }}>
         {winner?.userName || '-'}
       </div>
       <div className="stat-label">{name}</div>

--- a/ui/src/utils/__tests__/fontSize.test.ts
+++ b/ui/src/utils/__tests__/fontSize.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { cardFontSize, nameFontSize, statFontSize, tableNameFontSize } from '../fontSize'
+
+/**
+ * These functions pick a font size from how wide the text draws, and the unit is easy to misread as
+ * "number of characters". It is not: a Chinese character counts 2 and a capital 1.4, so a 12-character
+ * user name — the registration maximum — can be anywhere from 12 to 24 units wide. That is why the
+ * tier tables run past 12, and why trimming them "because names are capped at 12" would give Chinese
+ * names a size that overflows the column.
+ */
+describe('visual width, not character count', () => {
+  it('treats one CJK character as two latin ones', () => {
+    // 四个汉字 = 8 units = 八个字母, so both land in the same tier.
+    expect(tableNameFontSize('王小明白', true)).toBe(tableNameFontSize('abcdefgh', true))
+  })
+
+  it('drops a Chinese name a tier below a latin name of the same length', () => {
+    // Six of each: 12 units against 6. Sizing by length would give them the same font.
+    expect(tableNameFontSize('王小明白日月', true)).not.toBe(tableNameFontSize('abcdef', true))
+  })
+
+  it('counts capitals as wider than lowercase', () => {
+    // 8 × 1.4 = 11.2 units, past the 10-unit tier that the lowercase form sits in.
+    expect(tableNameFontSize('ABCDEFGH', true)).not.toBe(tableNameFontSize('abcdefgh', true))
+  })
+
+  it('reaches the widest tiers within the 12-character registration cap', () => {
+    // Nine CJK characters is 18 units, twelve is 24 — both beyond the 12-unit tier.
+    const nine = tableNameFontSize('一二三四五六七八九', true)
+    const twelve = tableNameFontSize('一二三四五六七八九十百千', true)
+    expect(nine).toBe('0.48rem')
+    expect(twelve).toBe('0.44rem')
+    expect(twelve).not.toBe(nine)
+  })
+})
+
+describe('tiers per surface', () => {
+  it('gives a table cell a smaller size than a card for the same name', () => {
+    // The table cell shares its column with a 段位 badge; the card has the width to itself.
+    expect(tableNameFontSize('abcdefgh', true)).not.toBe(cardFontSize('abcdefgh', true))
+  })
+
+  it('separates desktop from mobile', () => {
+    expect(tableNameFontSize('abcdefghij', false)).toBe('0.95rem')
+    expect(tableNameFontSize('abcdefghij', true)).toBe('0.72rem')
+  })
+
+  it('falls back rather than returning undefined for anything wider than every tier', () => {
+    const wide = '一二三四五六七八九十百千万'
+    expect(statFontSize(wide, true)).toBe('0.5rem')
+    expect(nameFontSize(wide, true)).toBe('0.45rem')
+    expect(cardFontSize(wide, true)).toBe('0.7rem')
+    expect(tableNameFontSize(wide, true)).toBe('0.44rem')
+  })
+
+  it('sizes an empty string like the shortest name rather than crashing', () => {
+    expect(tableNameFontSize('', true)).toBe('0.85rem')
+  })
+})
+
+/**
+ * The tiers are unchanged from when they were resolved by `text.length`, so a lowercase latin name —
+ * where width and length are the same number — must come out at exactly the size it did before.
+ */
+describe('latin names keep the sizes they had', () => {
+  it.each([
+    ['abcdef', '1.4rem', '1rem', '1rem', '0.85rem'],
+    ['abcdefgh', '1.1rem', '0.8rem', '0.8rem', '0.85rem'],
+    ['abcdefghijkl', '0.9rem', '0.75rem', '0.8rem', '0.62rem'],
+  ])('%s', (name, stat, nameSize, card, table) => {
+    expect(statFontSize(name, true)).toBe(stat)
+    expect(nameFontSize(name, true)).toBe(nameSize)
+    expect(cardFontSize(name, true)).toBe(card)
+    expect(tableNameFontSize(name, true)).toBe(table)
+  })
+})

--- a/ui/src/utils/fontSize.ts
+++ b/ui/src/utils/fontSize.ts
@@ -7,8 +7,20 @@ interface FontSizeTier {
   mobile: string
 }
 
-/** CJK and other fullwidth characters take a whole em; a latin letter takes about half of one. */
-const FULLWIDTH = /[ᄀ-ᅟ⺀-〾ぁ-㏿㐀-䶿一-鿿ꀀ-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦]/
+/**
+ * Fullwidth characters take a whole em; a latin letter takes about half of one.
+ *
+ * Written as escapes rather than literal characters: the ranges are the point here and the literal
+ * form is unreadable. Block by block —
+ *   1100-115F  Hangul Jamo                  2E80-303E  CJK radicals, Kangxi, CJK punctuation
+ *   3041-33FF  Kana, Bopomofo, CJK compatibility
+ *   3400-4DBF  CJK Extension A              4E00-9FFF  CJK Unified Ideographs
+ *   A000-A4CF  Yi                           AC00-D7A3  Hangul syllables
+ *   F900-FAFF  CJK compatibility ideographs FE30-FE4F  CJK compatibility forms
+ *   FF00-FF60  Fullwidth ASCII              FFE0-FFE6  Fullwidth currency and signs
+ */
+const FULLWIDTH =
+  /[\u1100-\u115F\u2E80-\u303E\u3041-\u33FF\u3400-\u4DBF\u4E00-\u9FFF\uA000-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE4F\uFF00-\uFF60\uFFE0-\uFFE6]/
 
 /**
  * How wide the text actually draws, in half-character units: fullwidth counts 2, a capital 1.4,

--- a/ui/src/utils/fontSize.ts
+++ b/ui/src/utils/fontSize.ts
@@ -1,40 +1,39 @@
 export const MOBILE_BREAKPOINT = 640
 
 interface FontSizeTier {
-  maxLen: number
+  /** Upper bound in half-character units — see visualWidth. 8 = four CJK characters = eight letters. */
+  maxWidth: number
   desktop: string
   mobile: string
 }
 
-function resolve(text: string, tiers: FontSizeTier[], fallback: { desktop: string; mobile: string }) {
-  const len = text.length
-  const mobile = window.innerWidth <= MOBILE_BREAKPOINT
-  for (const t of tiers) {
-    if (len <= t.maxLen) return mobile ? t.mobile : t.desktop
-  }
-  return mobile ? fallback.mobile : fallback.desktop
-}
-
-/** CJK / 全角字符占两个字符宽 (1em), 拉丁字母只占约半个 (0.5em). */
-const FULLWIDTH =
-  /[\u1100-\u115F\u2E80-\u303E\u3041-\u33FF\u3400-\u4DBF\u4E00-\u9FFF\uA000-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE4F\uFF00-\uFF60\uFFE0-\uFFE6]/
+/** CJK and other fullwidth characters take a whole em; a latin letter takes about half of one. */
+const FULLWIDTH = /[ᄀ-ᅟ⺀-〾ぁ-㏿㐀-䶿一-鿿ꀀ-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦]/
 
 /**
- * 视觉宽度(以"半个字"为单位): 全角记 2, 大写字母记 1.4, 其他记 1.
+ * How wide the text actually draws, in half-character units: fullwidth counts 2, a capital 1.4,
+ * anything else 1.
+ *
+ * Character count is not a usable proxy here. A six-character Chinese name draws twice as wide as a
+ * six-letter one, and picking a size by `text.length` gives the Chinese name a font that overflows
+ * the column it has to fit.
  */
 function visualWidth(text: string) {
-  let w = 0
+  let width = 0
   for (const ch of text) {
-    if (FULLWIDTH.test(ch)) w += 2
-    else if (ch >= 'A' && ch <= 'Z') w += 1.4
-    else w += 1
+    if (FULLWIDTH.test(ch)) width += 2
+    else if (ch >= 'A' && ch <= 'Z') width += 1.4
+    else width += 1
   }
-  return w
+  return width
 }
 
 /**
- * 与 resolve 的区别: 按 visualWidth 分档, 且 mobile 由调用方传入(useIsMobile) 而不是现场读
- * window.innerWidth —— 后者不会触发重渲染, 旋转屏幕或缩放窗口跨过断点后字号会停在旧值.
+ * Picks the tier the text fits in.
+ *
+ * `mobile` is passed in rather than read from `window.innerWidth` here: reading it during render
+ * does not subscribe to anything, so rotating an iPad across the breakpoint left the size stuck at
+ * whatever it was on the previous orientation. `useIsMobile` subscribes to the media query instead.
  */
 function resolveByWidth(
   text: string,
@@ -43,66 +42,78 @@ function resolveByWidth(
   fallback: { desktop: string; mobile: string }
 ) {
   const width = visualWidth(text)
-  for (const t of tiers) {
-    if (width <= t.maxLen) return mobile ? t.mobile : t.desktop
+  for (const tier of tiers) {
+    if (width <= tier.maxWidth) return mobile ? tier.mobile : tier.desktop
   }
   return mobile ? fallback.mobile : fallback.desktop
 }
 
-export function statFontSize(text: string) {
-  return resolve(
+/**
+ * The single hero name on the stats page — one line to itself, so it can stay large.
+ *
+ * A user name is at most 12 characters (Player.MAX_USERNAME_LENGTH), which is a visual width of 24
+ * when every one of them is Chinese. That is why the tiers run past 12: the bound is on characters,
+ * not on how wide they draw.
+ */
+export function statFontSize(text: string, mobile: boolean) {
+  return resolveByWidth(
     text,
+    mobile,
     [
-      { maxLen: 6, desktop: '2rem', mobile: '1.4rem' },
-      { maxLen: 8, desktop: '2rem', mobile: '1.1rem' },
-      { maxLen: 12, desktop: '1.5rem', mobile: '0.9rem' },
-      { maxLen: 16, desktop: '1.2rem', mobile: '0.8rem' },
-      { maxLen: 22, desktop: '0.9rem', mobile: '0.6rem' },
+      { maxWidth: 6, desktop: '2rem', mobile: '1.4rem' },
+      { maxWidth: 8, desktop: '2rem', mobile: '1.1rem' },
+      { maxWidth: 12, desktop: '1.5rem', mobile: '0.9rem' },
+      { maxWidth: 16, desktop: '1.2rem', mobile: '0.8rem' },
+      { maxWidth: 22, desktop: '0.9rem', mobile: '0.6rem' },
     ],
     { desktop: '0.75rem', mobile: '0.5rem' }
   )
 }
 
-export function nameFontSize(text: string) {
-  return resolve(
+/** A name in a list or a card body, where it shares the row with a badge or a label. */
+export function nameFontSize(text: string, mobile: boolean) {
+  return resolveByWidth(
     text,
+    mobile,
     [
-      { maxLen: 6, desktop: '0.95rem', mobile: '1rem' },
-      { maxLen: 8, desktop: '0.95rem', mobile: '0.8rem' },
-      { maxLen: 12, desktop: '0.8rem', mobile: '0.75rem' },
-      { maxLen: 16, desktop: '0.7rem', mobile: '0.6rem' },
+      { maxWidth: 6, desktop: '0.95rem', mobile: '1rem' },
+      { maxWidth: 8, desktop: '0.95rem', mobile: '0.8rem' },
+      { maxWidth: 12, desktop: '0.8rem', mobile: '0.75rem' },
+      { maxWidth: 16, desktop: '0.7rem', mobile: '0.6rem' },
     ],
     { desktop: '0.65rem', mobile: '0.45rem' }
   )
 }
 
 /**
- * 统计页表格里的玩家名 — 手机上名字只剩 66px 左右(段位徽章占掉一半列宽), 所以按 visualWidth
- * 分档(中文名按两倍宽算), 尽量让完整 ID 显示出来而不是被省略号截掉.
- * maxLen 的单位是"半个字": 8 = 4 个汉字 = 8 个字母. 桌面端列宽充裕, 档位放宽.
+ * A player name in a table cell — the tightest case. On a phone the name has roughly 66px left once
+ * the 段位 badge has taken half the column, so the tiers drop faster than anywhere else, to get the
+ * whole name in rather than an ellipsis. Desktop columns are roomy, so those steps stay gentle.
  */
 export function tableNameFontSize(text: string, mobile: boolean) {
   return resolveByWidth(
     text,
     mobile,
     [
-      { maxLen: 8, desktop: '0.95rem', mobile: '0.85rem' },
-      { maxLen: 10, desktop: '0.95rem', mobile: '0.72rem' },
-      { maxLen: 12, desktop: '0.85rem', mobile: '0.62rem' },
-      { maxLen: 14, desktop: '0.8rem', mobile: '0.54rem' },
-      { maxLen: 18, desktop: '0.7rem', mobile: '0.48rem' },
+      { maxWidth: 8, desktop: '0.95rem', mobile: '0.85rem' },
+      { maxWidth: 10, desktop: '0.95rem', mobile: '0.72rem' },
+      { maxWidth: 12, desktop: '0.85rem', mobile: '0.62rem' },
+      { maxWidth: 14, desktop: '0.8rem', mobile: '0.54rem' },
+      { maxWidth: 18, desktop: '0.7rem', mobile: '0.48rem' },
     ],
     { desktop: '0.65rem', mobile: '0.44rem' }
   )
 }
 
-export function cardFontSize(text: string) {
-  return resolve(
+/** A name on a selectable player card, which has the whole card width to itself. */
+export function cardFontSize(text: string, mobile: boolean) {
+  return resolveByWidth(
     text,
+    mobile,
     [
-      { maxLen: 6, desktop: '1.05rem', mobile: '1rem' },
-      { maxLen: 8, desktop: '1.05rem', mobile: '0.8rem' },
-      { maxLen: 12, desktop: '0.85rem', mobile: '0.8rem' },
+      { maxWidth: 6, desktop: '1.05rem', mobile: '1rem' },
+      { maxWidth: 8, desktop: '1.05rem', mobile: '0.8rem' },
+      { maxWidth: 12, desktop: '0.85rem', mobile: '0.8rem' },
     ],
     { desktop: '0.75rem', mobile: '0.7rem' }
   )


### PR DESCRIPTION
## 一、为什么档位不能删

档位的 `maxLen` **单位不是字符数，是"半个字"的视觉宽度**：全角记 2、大写字母记 1.4、其他记 1。所以 12 字符的用户名换算过来是：

| 12 字符的用户名 | 视觉宽度 |
|---|---|
| 全小写拉丁 | 12 |
| 全大写 | 16.8 |
| **全汉字** | **24** |

上限是 **24** 而不是 12，那些看着"够不到"的高档位（`maxWidth: 18`、`22` 和 fallback）全都用得上。删掉会让中文名拿到偏大的字号、撑破它必须装进去的列宽。

**一档没删。** 字段名从 `maxLen` 改成 `maxWidth`，并把这个换算写进注释——防止下次（包括我自己）又想当然去精简。

## 二、修了 iPad 旋转字号失效

`statFontSize` / `nameFontSize` / `cardFontSize` 走的 `resolve()` 在 render 里直接读 `window.innerWidth`。这**不订阅任何东西**，所以横竖屏切换跨过 640px 断点后，字号停在上一个方向的值。

`useIsMobile`（`matchMedia` 的 `change` 事件）早就解决了这件事，但只接在 `tableNameFontSize` 上。现在三个函数都改成由调用方传 `useIsMobile()` 的结果，`resolve()` 删掉。加 hook 的三处：`HomePage`、`FanTablePage`、`NewSessionPage`；`StatsPage` 本来就有。

## 三、修了中文名字号偏大

同样这三个函数按 `text.length` 分档——六个汉字和六个字母被当成一样宽，而实际宽度差一倍，所以中文名一直拿偏大的字号。现在统一走 `resolveByWidth`，和 `tableNameFontSize` 一致。

---

## 档位数字一个没动

所以**小写拉丁名的字号和以前完全一样**（宽度和长度是同一个数）。会变的只有：

- 中文名 → 更小（这是修复）
- 全大写名 → 更小（大写确实更宽）

## 测试：从 0 到 11

`fontSize.ts` 之前零覆盖。其中一组专门钉住"拉丁名字号不变"：

```ts
it.each([
  ['abcdef', '1.4rem', '1rem', '1rem', '0.85rem'],
  ['abcdefgh', '1.1rem', '0.8rem', '0.8rem', '0.85rem'],
  ['abcdefghijkl', '0.9rem', '0.75rem', '0.8rem', '0.62rem'],
])
```

另外钉住：四个汉字 == 八个字母、六个汉字 ≠ 六个字母、大写比小写宽、12 字上限内确实能到最宽的档、空字符串不崩、四个函数的 fallback 各是多少。

## 顺带

`FULLWIDTH` 正则换回 `\uXXXX` 转义形式并注明每个 Unicode 区块——我在第一个 commit 里把它贴成了字面字符，覆盖码点完全一致（逐个比对 0x0000–0xFFFF 零差异，字符串 md5 与 main 相同），但那里重要的是覆盖了哪些区块，字面形式恰好把这个信息藏起来了。

注释按准则 §8 全部英文。

---

## 需要眼睛看的

**唯一的视觉变化：中文用户名和全大写用户名的字号变小。** 建议扫一眼统计页排行榜、牌局记分板、首页荣誉殿堂。拉丁小写名有测试保证不变。

顺便可以验一下旋转：iPad 上横竖屏切换，名字字号应该跟着变，以前会停在旧值。

## 验证

`+160 / -52`（其中 76 行是测试）。`tsc`、`stylelint`、1381 个测试、pre-commit 六步全过。