### PR TITLE
fix: 识别请求卡死按钮 + Gemini 读超时漏网直接 500

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -17,8 +17,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
 /**
@@ -284,9 +284,10 @@ public class TileRecognitionService {
           }
           log.info("Falling back to model {}", models.get(modelIndex));
         }
-      } catch (ResourceAccessException e) {
-        // A timeout says nothing about which model or key is at fault, so treat it like the key
-        // being unusable and move on rather than hammering the same one.
+      } catch (RestClientException e) {
+        // Covers connection failures and read timeouts alike (RestClientResponseException, an HTTP
+        // error status, is caught above and never reaches here) — a timeout says nothing about
+        // which key or model is at fault, so treat it like the key being unusable and move on.
         log.warn("Gemini request failed on key #{} with {}: {}", keyIndex, model, e.getMessage());
         // Coalesced because a null would reach Map.of("message", ...) in the controller and NPE
         // into a 500, hiding the timeout behind "An unexpected error occurred".

--- a/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/TileRecognitionServiceTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -65,6 +66,30 @@ class TileRecognitionServiceTest {
     f.server()
         .expect(header("x-goog-api-key", "key-a"))
         .andRespond(withStatus(HttpStatus.TOO_MANY_REQUESTS).body(quotaBody()));
+    f.server()
+        .expect(header("x-goog-api-key", "key-b"))
+        .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));
+
+    assertThat(f.service().recognize("BASE64", "image/jpeg").rawJson()).contains("1m");
+    f.server().verify();
+  }
+
+  /**
+   * A connection-level failure must rotate to the next key like a quota error does. Guards against
+   * the catch clause being narrowed back to {@code ResourceAccessException} — the production
+   * incident (a read timeout surfacing as the plainer {@code RestClientException}) isn't
+   * reproducible here since {@code MockRestServiceServer} wraps any thrown IOException as {@code
+   * ResourceAccessException} regardless of which step raised it.
+   */
+  @Test
+  void rotatesToNextKeyOnATransportFailure() {
+    Fixture f = build("key-a,key-b");
+    f.server()
+        .expect(header("x-goog-api-key", "key-a"))
+        .andRespond(
+            request -> {
+              throw new IOException("Read timed out");
+            });
     f.server()
         .expect(header("x-goog-api-key", "key-b"))
         .andRespond(withSuccess(OK_BODY, MediaType.APPLICATION_JSON));

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -240,20 +240,29 @@ export async function recognizeHandPhoto(
   mimeType: string,
   engine: 'local' | 'gemini' = 'local'
 ): Promise<{ rawJson: string; warning?: string; sampleId?: string }> {
-  const res = await fetch(`${API}/recognize`, {
-    method: 'POST',
-    headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify({ imageBase64, mimeType, engine }),
-  })
-  const data = await handleResponse<{ rawJson: string; warning?: string; sampleId?: string } | undefined>(res)
-  // handleResponse yields undefined for an empty body; don't hand that to the parser.
-  if (!data || typeof data.rawJson !== 'string' || !data.rawJson.trim()) {
-    throw new Error('识别服务未返回内容，请重试')
-  }
-  return {
-    rawJson: data.rawJson,
-    warning: data.warning || undefined,
-    sampleId: data.sampleId || undefined,
+  try {
+    const res = await fetch(`${API}/recognize`, {
+      method: 'POST',
+      headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ imageBase64, mimeType, engine }),
+      // Gemini retries can take upward of a minute; without this, a stalled connection leaves the
+      // recognize button disabled forever instead of surfacing an error.
+      signal: AbortSignal.timeout(90_000),
+    })
+    const data = await handleResponse<{ rawJson: string; warning?: string; sampleId?: string } | undefined>(res)
+    if (!data || typeof data.rawJson !== 'string' || !data.rawJson.trim()) {
+      throw new Error('识别服务未返回内容，请重试')
+    }
+    return {
+      rawJson: data.rawJson,
+      warning: data.warning || undefined,
+      sampleId: data.sampleId || undefined,
+    }
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'TimeoutError') {
+      throw new Error('识别超时，请重试')
+    }
+    throw err
   }
 }
 


### PR DESCRIPTION
从服务器 `mahjong-omakase.mv.db` 拉出来的生产日志里查出的两个真问题，都在同一次事故（2026-08-14 00:36:26）里。

## 1. 前端：识别请求没有客户端超时，手机网络一抖就永久卡死按钮

那次事故里，浏览器的 `/api/recognize` 请求整整卡了 66 秒才拿到响应（服务端这边 Gemini 主模型 503 过载，切到备用模型又读超时 60s）。这次运气好，最终还是收到了响应。

但 `recognizeHandPhoto` 发这个请求时**没有任何客户端超时**：

```ts
const res = await fetch(`${API}/recognize`, { ... })   // 无 signal
```

手机网络稍微抖一下（信号切换、App 切后台被系统冻住连接），这个 `fetch` 就可能永远 pending——`PhotoRecognitionModal` 的 `loading` 状态和识别按钮跟着永远卡在禁用态，除非刷新页面。这正是"识别完了按钮按不下去，会卡住"的根因。

修法：加 `AbortSignal.timeout(90_000)`。90 秒卡在"服务端已知最坏情况"（读超时 60s + 重试预算 60s 之间取较大值再加余量）和"Cloudflare 免费版 100s 硬上限"之间，让 app 自己的错误提示"识别超时，请重试"先出现，而不是等到网关的 524。超时被现有的 `catch/finally` 接住，机制早就在，只是原来永远等不到这个信号。

## 2. 服务端：读超时的异常类型漏网，直接 500 而不是换下一个 key/模型重试

同一次事故的另一半。`TileRecognitionService.recognize()` 的重试循环：

```java
} catch (RestClientResponseException e) { ... }   // HTTP 错误状态 (429/503)
} catch (ResourceAccessException e)     { ... }   // 连接失败, 走"换key继续试"
```

**读超时**发生在 `RestClient` 内部"惰性读响应体"那一步，走的是另一条包装路径，抛出的是更宽泛的 **`RestClientException`**，不是 `ResourceAccessException`——原来的 catch 接不住，异常直接漏到 `GlobalExceptionHandler` 的兜底 handler，变成一个毫无信息量的 `"An unexpected error occurred"` 500，而不是像设计的那样换下一个 key/模型继续试。日志里那条 `Caused by: java.net.SocketTimeoutException: Read timed out` 就是这个漏洞的直接证据。

修法：把 `catch (ResourceAccessException e)` 改成 `catch (RestClientException e)`（它的父类）。`RestClientResponseException`（HTTP 错误状态）已经在前一个 catch 接住，不会漏到这里，所以只是让"连接失败"和"读超时失败"走同一段"key 不可用, 换下一个继续试"的逻辑。

**这条大概率也是"识别功能总是错"感觉的一部分来源**——之前这种情况用户看到的是一次毫无信息量的报错，得自己手动重试，而不是系统自动换模型悄悄补上。

## 测试的诚实说明

给第 2 条加了一条回归测试，但坦白说它**没法精确复现日志里那个异常子类型**：`MockRestServiceServer` 把 `ResponseCreator` 抛出的 `IOException` 统一包装成 `ResourceAccessException`，不管概念上应该发生在哪个阶段——所以这条测试新旧代码都能过，我验证过（临时切回旧的 `ResourceAccessException` catch 重跑，测试照样绿）。测试的 javadoc 里写清楚了这一点：它是防止以后又把 catch 收窄回去的回归测试，不是这次修复本身的证明；修复的依据是生产日志里那行真实的 stack trace。

## 没动的

日志里 `/index.php?...think\app...`、`../etc/passwd`、`.aws/credentials` 这些是网上扫描器在探测常见漏洞，Spring 已经正确拒绝，不是这个 app 的问题。识别准确率本身（本地模型 6 次里 4 次因"找不到成排的牌"拒绝）没有基线可比对，不确定是不是回归，没有瞎猜着改任何识别逻辑。

## 验证

`./gradlew spotlessApply pmdMain test`、`tsc --noEmit`、`stylelint`、1381 个 UI 测试全过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tile recognition reliability by automatically retrying with another available service key when connection or request failures occur.
  * Added a 90-second limit for hand-photo recognition requests.
  * Timeout errors now display a clear message in Chinese, while other errors continue to be reported normally.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->