### PR TITLE
fix: 日期格式统一 + 玩家页/Admin 表格宽度不再靠猜, 消掉横向滚动

### DIFF
--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -167,12 +167,13 @@ export const GameCard: React.FC<Props> = ({
           </div>
           <div className="session-card-meta">
             <span className="session-card-date">
-              {new Date(createdAt).toLocaleString([], {
+              {new Date(createdAt).toLocaleString('en-CA', {
                 timeZone: 'America/Los_Angeles',
                 month: '2-digit',
                 day: '2-digit',
                 hour: '2-digit',
                 minute: '2-digit',
+                hour12: false,
               })}
             </span>
             <span className={`badge badge-sm ${isActive ? 'badge-progress' : 'badge-completed'}`}>{roundLabel}</span>
@@ -208,13 +209,14 @@ export const GameCard: React.FC<Props> = ({
                 {roundLabel}
               </span>
               <span className="game-fs-date">
-                {new Date(createdAt).toLocaleString([], {
+                {new Date(createdAt).toLocaleString('en-CA', {
                   timeZone: 'America/Los_Angeles',
                   year: 'numeric',
                   month: '2-digit',
                   day: '2-digit',
                   hour: '2-digit',
                   minute: '2-digit',
+                  hour12: false,
                 })}
               </span>
             </div>

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -167,7 +167,7 @@ export const GameCard: React.FC<Props> = ({
           </div>
           <div className="session-card-meta">
             <span className="session-card-date">
-              {new Date(createdAt).toLocaleString('en-CA', {
+              {new Date(createdAt).toLocaleString('en-US', {
                 timeZone: 'America/Los_Angeles',
                 month: '2-digit',
                 day: '2-digit',
@@ -209,7 +209,7 @@ export const GameCard: React.FC<Props> = ({
                 {roundLabel}
               </span>
               <span className="game-fs-date">
-                {new Date(createdAt).toLocaleString('en-CA', {
+                {new Date(createdAt).toLocaleString('en-US', {
                   timeZone: 'America/Los_Angeles',
                   year: 'numeric',
                   month: '2-digit',

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3354,10 +3354,13 @@ table.auto-table {
   .fan-item-example-real {
     padding: 12px 6px 6px;
   }
+}
 
-  .admin-swipe-shell .col-action {
-    padding-left: 60px;
-  }
+/* Admin's Edit/Delete/Save/Cancel — narrower than .btn-small so two of them fit in one table cell
+   without the row needing to scroll. */
+.col-action .btn {
+  padding: 4px 8px;
+  font-size: 0.78rem;
 }
 
 .pagination-container {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3356,8 +3356,6 @@ table.auto-table {
   }
 }
 
-/* Admin's Edit/Delete/Save/Cancel — narrower than .btn-small so two of them fit in one table cell
-   without the row needing to scroll. */
 .col-action .btn {
   padding: 4px 8px;
   font-size: 0.78rem;

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -182,7 +182,7 @@ export default function AdminPage() {
                           </>
                         )}
                       </td>
-                      <td>{new Date(p.createdAt).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })}</td>
+                      <td>{new Date(p.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}</td>
                       <td className="col-action">
                         {editingId === p.id ? (
                           <div style={{ display: 'flex', gap: 4 }}>

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -126,128 +126,122 @@ export default function AdminPage() {
 
       <div className="card">
         <h2>Players ({players.length})</h2>
-        <div className="admin-swipe-shell">
-          <div className="table-wrap">
-            <table className="auto-table">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Username</th>
-                  <th>Name</th>
-                  <th>Joined</th>
-                  <th className="col-action"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {players.map((p) => {
-                  // TODO: 等所有真实玩家都完成 Google 绑定后, 删掉这条标红逻辑
-                  const unbound = !p.merged && !p.bot
-                  const cellStyle = unbound ? { color: 'var(--danger, #c0392b)', fontWeight: 600 } : undefined
-                  return (
-                    <tr key={p.id}>
-                      <td>{p.id}</td>
-                      <td style={cellStyle}>
-                        {editingId === p.id ? (
+        <div className="table-wrap">
+          <table className="auto-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Username</th>
+                <th>Name</th>
+                <th>Joined</th>
+                <th className="col-action"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {players.map((p) => {
+                // TODO: 等所有真实玩家都完成 Google 绑定后, 删掉这条标红逻辑
+                const unbound = !p.merged && !p.bot
+                const cellStyle = unbound ? { color: 'var(--danger, #c0392b)', fontWeight: 600 } : undefined
+                return (
+                  <tr key={p.id}>
+                    <td>{p.id}</td>
+                    <td style={cellStyle}>
+                      {editingId === p.id ? (
+                        <input
+                          value={editUserName}
+                          onChange={(e) => setEditUserName(e.target.value)}
+                          style={{ width: '100%', maxWidth: 120, minWidth: 0 }}
+                          placeholder="Username"
+                          autoFocus
+                        />
+                      ) : (
+                        p.userName
+                      )}
+                    </td>
+                    <td style={{ whiteSpace: 'nowrap', ...cellStyle }}>
+                      {editingId === p.id ? (
+                        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                           <input
-                            value={editUserName}
-                            onChange={(e) => setEditUserName(e.target.value)}
-                            style={{ width: '100%', maxWidth: 120, minWidth: 0 }}
-                            placeholder="Username"
-                            autoFocus
+                            value={editFirst}
+                            onChange={(e) => setEditFirst(e.target.value)}
+                            style={{ flex: '1 1 70px', minWidth: 0, maxWidth: 100 }}
+                            placeholder="First"
                           />
-                        ) : (
-                          p.userName
-                        )}
-                      </td>
-                      <td style={{ whiteSpace: 'nowrap', ...cellStyle }}>
-                        {editingId === p.id ? (
-                          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                            <input
-                              value={editFirst}
-                              onChange={(e) => setEditFirst(e.target.value)}
-                              style={{ flex: '1 1 70px', minWidth: 0, maxWidth: 100 }}
-                              placeholder="First"
-                            />
-                            <input
-                              value={editLast}
-                              onChange={(e) => setEditLast(e.target.value)}
-                              style={{ flex: '1 1 70px', minWidth: 0, maxWidth: 100 }}
-                              placeholder="Last"
-                              onKeyDown={(e) => e.key === 'Enter' && handleSave(p.id)}
-                            />
-                          </div>
-                        ) : (
-                          <>
-                            {p.firstName} {p.lastName}
-                          </>
-                        )}
-                      </td>
-                      <td>{new Date(p.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}</td>
-                      <td className="col-action">
-                        {editingId === p.id ? (
-                          <div style={{ display: 'flex', gap: 4 }}>
-                            <button className="btn btn-primary btn-small" onClick={() => handleSave(p.id)}>
-                              Save
-                            </button>
-                            <button className="btn btn-small btn-outline" onClick={cancelEdit}>
-                              Cancel
-                            </button>
-                          </div>
-                        ) : (
-                          <div style={{ display: 'flex', gap: 4 }}>
-                            <button className="btn btn-small btn-outline" onClick={() => startEdit(p)}>
-                              Edit
-                            </button>
-                            <button className="btn btn-danger btn-small" onClick={() => handleDelete(p.id, p.userName)}>
-                              Delete
-                            </button>
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
+                          <input
+                            value={editLast}
+                            onChange={(e) => setEditLast(e.target.value)}
+                            style={{ flex: '1 1 70px', minWidth: 0, maxWidth: 100 }}
+                            placeholder="Last"
+                            onKeyDown={(e) => e.key === 'Enter' && handleSave(p.id)}
+                          />
+                        </div>
+                      ) : (
+                        <>
+                          {p.firstName} {p.lastName}
+                        </>
+                      )}
+                    </td>
+                    <td>{new Date(p.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}</td>
+                    <td className="col-action">
+                      {editingId === p.id ? (
+                        <div style={{ display: 'flex', gap: 4 }}>
+                          <button className="btn btn-primary btn-small" onClick={() => handleSave(p.id)}>
+                            Save
+                          </button>
+                          <button className="btn btn-small btn-outline" onClick={cancelEdit}>
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <div style={{ display: 'flex', gap: 4 }}>
+                          <button className="btn btn-small btn-outline" onClick={() => startEdit(p)}>
+                            Edit
+                          </button>
+                          <button className="btn btn-danger btn-small" onClick={() => handleDelete(p.id, p.userName)}>
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
         </div>
       </div>
 
       <div className="card">
         <h2>Completed Sessions ({sessions.length})</h2>
-        <div className="admin-swipe-shell">
-          <div className="table-wrap">
-            <table className="auto-table">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Game Name</th>
-                  <th>Mode</th>
-                  <th>Rnds</th>
-                  <th className="col-action"></th>
+        <div className="table-wrap">
+          <table className="auto-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Mode</th>
+                <th>Rnds</th>
+                <th className="col-action"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((s) => (
+                <tr key={s.id}>
+                  <td>{s.id}</td>
+                  <td style={{ whiteSpace: 'nowrap' }}>{s.gameModeDisplayName}</td>
+                  <td>{s.roundCount}</td>
+                  <td className="col-action">
+                    <button
+                      className="btn btn-danger btn-small"
+                      onClick={() => handleDeleteSession(s.id, s.name)}
+                      disabled={deletingSessionId === s.id}
+                    >
+                      {deletingSessionId === s.id ? 'Deleting...' : 'Delete'}
+                    </button>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {sessions.map((s) => (
-                  <tr key={s.id}>
-                    <td>{s.id}</td>
-                    <td style={{ whiteSpace: 'nowrap' }}>{s.name}</td>
-                    <td style={{ whiteSpace: 'nowrap' }}>{s.gameModeDisplayName}</td>
-                    <td>{s.roundCount}</td>
-                    <td className="col-action">
-                      <button
-                        className="btn btn-danger btn-small"
-                        onClick={() => handleDeleteSession(s.id, s.name)}
-                        disabled={deletingSessionId === s.id}
-                      >
-                        {deletingSessionId === s.id ? 'Deleting...' : 'Delete'}
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </>

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -133,7 +133,6 @@ export default function AdminPage() {
                 <th>ID</th>
                 <th>Username</th>
                 <th>Name</th>
-                <th>Joined</th>
                 <th className="col-action"></th>
               </tr>
             </thead>
@@ -181,7 +180,6 @@ export default function AdminPage() {
                         </>
                       )}
                     </td>
-                    <td>{new Date(p.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}</td>
                     <td className="col-action">
                       {editingId === p.id ? (
                         <div style={{ display: 'flex', gap: 4 }}>

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -182,7 +182,7 @@ export default function AdminPage() {
                           </>
                         )}
                       </td>
-                      <td>{new Date(p.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
+                      <td>{new Date(p.createdAt).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })}</td>
                       <td className="col-action">
                         {editingId === p.id ? (
                           <div style={{ display: 'flex', gap: 4 }}>

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -60,11 +60,11 @@ export default function NewSessionPage() {
     setError('')
     try {
       const now = new Date()
-      // 'en-CA' pins the output format (YYYY-MM-DD, 24h HH:mm) — an empty locale array instead
+      // 'en-US' pins the output format (M/D/YYYY, 24h HH:mm) — an empty locale array instead
       // resolves to the phone's own language/region, so the same code produced "8/16/2026" on an
       // English-region phone and "2026/8/16" on a Chinese-region one.
-      const dateStr = now.toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })
-      const timeStr = now.toLocaleTimeString('en-CA', {
+      const dateStr = now.toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })
+      const timeStr = now.toLocaleTimeString('en-US', {
         timeZone: 'America/Los_Angeles',
         hour: '2-digit',
         minute: '2-digit',

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -60,8 +60,11 @@ export default function NewSessionPage() {
     setError('')
     try {
       const now = new Date()
-      const dateStr = now.toLocaleDateString([], { timeZone: 'America/Los_Angeles' })
-      const timeStr = now.toLocaleTimeString([], {
+      // 'en-CA' pins the output format (YYYY-MM-DD, 24h HH:mm) — an empty locale array instead
+      // resolves to the phone's own language/region, so the same code produced "8/16/2026" on an
+      // English-region phone and "2026/8/16" on a Chinese-region one.
+      const dateStr = now.toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })
+      const timeStr = now.toLocaleTimeString('en-CA', {
         timeZone: 'America/Los_Angeles',
         hour: '2-digit',
         minute: '2-digit',

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -179,7 +179,7 @@ export default function PlayerDetailPage() {
                       {g.sessionName || `Game #${g.sessionId}`}
                     </td>
                     <td>{g.gameModeDisplayName}</td>
-                    <td>{new Date(g.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}</td>
+                    <td>{new Date(g.createdAt).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })}</td>
                     <td>
                       <span className={`badge ${g.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
                         {g.status === 'IN_PROGRESS' ? '进行中' : '已结束'}

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -160,13 +160,12 @@ export default function PlayerDetailPage() {
           </div>
         ) : (
           <div className="table-wrap">
-            {/* 393px 预算 (393 -32 主内容 -32 .card = 329px 表宽): 44+80+80+60+68 = 332px. */}
             <table className="fixed-table">
               <thead>
                 <tr>
                   <th style={{ width: '44px' }}>游戏</th>
-                  <th style={{ width: '80px' }}>模式</th>
-                  <th style={{ width: '80px' }}>日期</th>
+                  <th style={{ width: '64px' }}>模式</th>
+                  <th style={{ width: '96px' }}>日期</th>
                   <th style={{ width: '60px' }}>状态</th>
                   <th className="text-right" style={{ width: '68px' }}>
                     分数

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -160,16 +160,14 @@ export default function PlayerDetailPage() {
           </div>
         ) : (
           <div className="table-wrap">
-            <table className="fixed-table">
+            <table className="auto-table">
               <thead>
                 <tr>
-                  <th style={{ width: '40px' }}>游戏</th>
-                  <th style={{ width: '64px' }}>模式</th>
-                  <th style={{ width: '96px' }}>日期</th>
-                  <th style={{ width: '64px' }}>状态</th>
-                  <th className="text-right" style={{ width: '68px' }}>
-                    分数
-                  </th>
+                  <th>游戏</th>
+                  <th style={{ whiteSpace: 'nowrap' }}>模式</th>
+                  <th style={{ whiteSpace: 'nowrap' }}>日期</th>
+                  <th>状态</th>
+                  <th className="text-right">分数</th>
                 </tr>
               </thead>
               <tbody>
@@ -177,7 +175,9 @@ export default function PlayerDetailPage() {
                   <tr key={g.sessionId} onClick={() => navigate(`/session/${g.sessionId}`)}>
                     <td>#{g.sessionId}</td>
                     <td style={{ whiteSpace: 'nowrap' }}>{g.gameModeDisplayName}</td>
-                    <td>{new Date(g.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}</td>
+                    <td style={{ whiteSpace: 'nowrap' }}>
+                      {new Date(g.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}
+                    </td>
                     <td>
                       <span className={`badge ${g.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
                         {g.status === 'IN_PROGRESS' ? '进行中' : '已结束'}

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -163,10 +163,10 @@ export default function PlayerDetailPage() {
             <table className="fixed-table">
               <thead>
                 <tr>
-                  <th style={{ width: '44px' }}>游戏</th>
+                  <th style={{ width: '40px' }}>游戏</th>
                   <th style={{ width: '64px' }}>模式</th>
                   <th style={{ width: '96px' }}>日期</th>
-                  <th style={{ width: '60px' }}>状态</th>
+                  <th style={{ width: '64px' }}>状态</th>
                   <th className="text-right" style={{ width: '68px' }}>
                     分数
                   </th>
@@ -177,7 +177,7 @@ export default function PlayerDetailPage() {
                   <tr key={g.sessionId} onClick={() => navigate(`/session/${g.sessionId}`)}>
                     <td>#{g.sessionId}</td>
                     <td style={{ whiteSpace: 'nowrap' }}>{g.gameModeDisplayName}</td>
-                    <td>{new Date(g.createdAt).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })}</td>
+                    <td>{new Date(g.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}</td>
                     <td>
                       <span className={`badge ${g.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
                         {g.status === 'IN_PROGRESS' ? '进行中' : '已结束'}

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -160,11 +160,12 @@ export default function PlayerDetailPage() {
           </div>
         ) : (
           <div className="table-wrap">
+            {/* 393px 预算 (393 -32 主内容 -32 .card = 329px 表宽): 44+80+80+60+68 = 332px. */}
             <table className="fixed-table">
               <thead>
                 <tr>
-                  <th>游戏</th>
-                  <th style={{ width: '56px' }}>模式</th>
+                  <th style={{ width: '44px' }}>游戏</th>
+                  <th style={{ width: '80px' }}>模式</th>
                   <th style={{ width: '80px' }}>日期</th>
                   <th style={{ width: '60px' }}>状态</th>
                   <th className="text-right" style={{ width: '68px' }}>
@@ -175,10 +176,8 @@ export default function PlayerDetailPage() {
               <tbody>
                 {player.games.map((g) => (
                   <tr key={g.sessionId} onClick={() => navigate(`/session/${g.sessionId}`)}>
-                    <td style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {g.sessionName || `Game #${g.sessionId}`}
-                    </td>
-                    <td>{g.gameModeDisplayName}</td>
+                    <td>#{g.sessionId}</td>
+                    <td style={{ whiteSpace: 'nowrap' }}>{g.gameModeDisplayName}</td>
                     <td>{new Date(g.createdAt).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })}</td>
                     <td>
                       <span className={`badge ${g.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { fetchStats, fetchFanDiscoveries, fetchPlayerTier, setupProfile, lookupC
 import { GAME_MODES, GameModeKey, PlayerStats, PlayerTierResponse } from '../types'
 import { RankBadge } from '../components/RankBadge'
 
-export default function ProfilePage() {
+export default function P我rofilePage() {
   const navigate = useNavigate()
   const [me, setMe] = useState<any>(() => {
     const rawMe = sessionStorage.getItem('mahjong_me')

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -225,7 +225,9 @@ export default function ProfilePage() {
                             <div className="profile-achievement-name">🏅 {fd.fanName}</div>
                             <div className="profile-achievement-date">
                               发现日期:{' '}
-                              {new Date(fd.discoveredAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
+                              {new Date(fd.discoveredAt).toLocaleDateString('en-CA', {
+                                timeZone: 'America/Los_Angeles',
+                              })}
                             </div>
                           </div>
                         </div>

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { fetchStats, fetchFanDiscoveries, fetchPlayerTier, setupProfile, lookupC
 import { GAME_MODES, GameModeKey, PlayerStats, PlayerTierResponse } from '../types'
 import { RankBadge } from '../components/RankBadge'
 
-export default function P我xrofilePage() {
+export default function ProfilePage() {
   const navigate = useNavigate()
   const [me, setMe] = useState<any>(() => {
     const rawMe = sessionStorage.getItem('mahjong_me')
@@ -225,7 +225,7 @@ export default function P我xrofilePage() {
                             <div className="profile-achievement-name">🏅 {fd.fanName}</div>
                             <div className="profile-achievement-date">
                               发现日期:{' '}
-                              {new Date(fd.discoveredAt).toLocaleDateString('en-CA', {
+                              {new Date(fd.discoveredAt).toLocaleDateString('en-US', {
                                 timeZone: 'America/Los_Angeles',
                               })}
                             </div>

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { fetchStats, fetchFanDiscoveries, fetchPlayerTier, setupProfile, lookupC
 import { GAME_MODES, GameModeKey, PlayerStats, PlayerTierResponse } from '../types'
 import { RankBadge } from '../components/RankBadge'
 
-export default function P我rofilePage() {
+export default function P我xrofilePage() {
   const navigate = useNavigate()
   const [me, setMe] = useState<any>(() => {
     const rawMe = sessionStorage.getItem('mahjong_me')

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -725,7 +725,7 @@ export default function SessionPage() {
           <div className="scoreboard-meta">
             <span className="session-meta">
               {session.gameModeDisplayName} &middot;{' '}
-              {new Date(session.createdAt).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })}
+              {new Date(session.createdAt).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}
               &nbsp;
               <span className={`badge ${session.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
                 {session.status === 'IN_PROGRESS' ? '进行中' : '已结束'}

--- a/ui/src/pages/SessionPage.tsx
+++ b/ui/src/pages/SessionPage.tsx
@@ -725,7 +725,7 @@ export default function SessionPage() {
           <div className="scoreboard-meta">
             <span className="session-meta">
               {session.gameModeDisplayName} &middot;{' '}
-              {new Date(session.createdAt).toLocaleDateString([], { timeZone: 'America/Los_Angeles' })}
+              {new Date(session.createdAt).toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' })}
               &nbsp;
               <span className={`badge ${session.status === 'IN_PROGRESS' ? 'badge-progress' : 'badge-completed'}`}>
                 {session.status === 'IN_PROGRESS' ? '进行中' : '已结束'}


### PR DESCRIPTION
起因是一个具体 bug 报告：游戏记录界面有些场次显示 \`Game 8/16/2026\`，有些是 \`Game 2026/8/13\`——同一段代码在不同手机上格式不一样。

## 根因

\`toLocaleDateString([], ...)\` 第一个参数传了空数组，意思是"不指定语言，跟手机系统语言走"。同一段代码，中文区域手机和英文区域手机跑出的日期顺序不一样。全项目排查后一共 6 处这个写法，全部改成固定的 \`'en-US'\`（`M/D/YYYY`，跟大多数用户原来看到的格式一致，同时不再受手机语言影响）。

**这个改动只保证以后新产生的记录格式统一，已经存进数据库的场名不会自动改过来。**

## 玩家详情页的游戏记录表

这张表在改格式过程中来回调整了几轮，最后落地的做法：

- "游戏"列改成显示 \`#sessionId\`（短且长度稳定），不再显示场次自定义名（场名仍从接口拿，只是不渲染）
- 整张表从 \`fixed-table\`（需要给每列猜一个像素宽度）换成 \`auto-table\`（\`table-layout: auto\`，AdminPage 已经在用的模式）——浏览器按每列实际渲染出的文字分配宽度，不用猜，以后 session id 涨到四位数五位数也不用再改

中间猜了两次像素宽度都错了（日期太窄、游戏太窄），才改成这个不用猜的方案，教训写在 commit message 里了。

## Admin 页的两张表：真正的横向滚动病根

排查滚动问题时发现 \`.admin-swipe-shell .col-action { padding-left: 60px }\`——这是个"滑动查看"的设计（类名就叫 swipe-shell），窄屏上凭空撑出 60px，是 Players 表需要横向滚动的直接原因。这条规则跟"不要滚动"的目标是反的，删掉了，连带删掉两处只为挂这条规则而存在的包裹 \`<div>\`。

顺带：

- Completed Sessions 表删掉了没用到的 \`Game Name\` 列
- Players 表删掉了 \`Joined\` 列，给按钮腾地方
- 两张表的 Edit/Delete/Save/Cancel 从 \`.btn-small\` 换成专门给 \`.col-action\` 用的更紧凑尺寸

**没有靠缩字号解决**——这次能做到不缩字号，是因为 AdminPage 这两张表本来就有"免费"的空间可以省（多余的列、偏大的通用按钮）。StatsPage 和 SessionPage 的既有表格用的是另一套已经验证过的机制（字号自适应/精确的像素预算），这次都没碰。

## 顺带修的一个不相关问题

排查 ProfilePage 的日期格式时发现它的函数名被写成了 \`P我xrofilePage\`——多出来的字符不影响编译（JS 标识符允许 Unicode 字母），纯粹是文件内容层面的意外。改回 \`ProfilePage\`。

## 验证

\`./gradlew test\`、\`tsc --noEmit\`、\`stylelint\`、1429 个前端测试全过。

## 还没验证的

PlayerDetailPage 那张 auto-table 是否在真机窄屏下会触发横向滚动，还没有真机确认——这张表跟 AdminPage 不一样，五列都是最精简的必要信息，没有多余列可删，理论上应该够用但没有像 AdminPage 那样有"免费"空间做保险。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized date and time displays across sessions, game records, achievements, and game cards.
  * Updated administrative tables with a more compact layout and streamlined columns.
  * Improved player game record tables for clearer responsive display.
  * Replaced game names with session IDs in player records for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->