### PR TITLE
玩家页删数据统计卡片 + 立直模式加和牌分布列

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -20,6 +20,8 @@ public class PlayerStatsResponse {
   private int dealIns;
   private double avgWinPoints;
   private double avgDealInPoints;
+  private int riichiWins;
+  private int meldWins;
   private String tier;
   private double skillRating;
   private int gamesNeeded;

--- a/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
+++ b/server/src/main/java/com/mahjong/omakase/repository/RoundScoreRepository.java
@@ -24,12 +24,13 @@ public interface RoundScoreRepository extends JpaRepository<RoundScore, Long> {
 
   /**
    * Returns one row per (round × scoring player) across the given sessions: [sessionId, roundId,
-   * winnerId, dealInPlayerId, scoringPlayerId, score]. Used to compute Riichi round-level metrics
-   * (和牌率/放铳率/平均打点/平均铳点) without N+1 lazy loads. Excludes rows whose player has been nulled out by
-   * account deletion.
+   * winnerId, dealInPlayerId, scoringPlayerId, score, fanDetails, winHand]. Used to compute Riichi
+   * round-level metrics (和牌率/放铳率/立直率/副露率/平均打点/平均铳点) without N+1 lazy loads. Excludes rows whose
+   * player has been nulled out by account deletion.
    */
   @Query(
-      "SELECT r.gameSession.id, r.id, r.winnerId, r.dealInPlayerId, rs.player.id, rs.score "
+      "SELECT r.gameSession.id, r.id, r.winnerId, r.dealInPlayerId, rs.player.id, rs.score, "
+          + "r.fanDetails, r.winHand "
           + "FROM RoundScore rs JOIN rs.round r "
           + "WHERE r.gameSession.id IN :sessionIds AND rs.player IS NOT NULL")
   List<Object[]> getRoundDetailsBySessions(List<Long> sessionIds);

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -1005,9 +1005,10 @@ public class GameService {
             if (dealInPlayerId == null) {
               tsumoWins.merge(winnerId, 1, Integer::sum);
             }
-            // 副露: the winning hand itself has a meld — `[` (open) or `(` (closed), the same
-            // grammar MahjongHand.tsx renders and PhotoRecognitionModal.winHandToLabel parses.
-            if (winHand != null && (winHand.indexOf('[') >= 0 || winHand.indexOf('(') >= 0)) {
+            // 副露: the winning hand itself has an open meld, `[` in the same grammar
+            // MahjongHand.tsx renders and PhotoRecognitionModal.winHandToLabel parses. `(` is a
+            // closed meld (暗杠) — the hand stays 门清, so it must not count here.
+            if (winHand != null && winHand.indexOf('[') >= 0) {
               meldWins.merge(winnerId, 1, Integer::sum);
             }
             // 立直: fanDetails lists the yaku, e.g. "立直(1), 平和(1)" — covers 两立直 too.

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -844,7 +844,7 @@ public class GameService {
     }
 
     // Bulk-load round details for ALL completed sessions in scope — one SQL — feeds the round-level
-    // metrics (和牌率/放铳率/自摸率/平均打点/平均铳点).
+    // metrics (和牌率/放铳率/自摸率/立直率/副露率/平均打点/平均铳点).
     Map<Long, List<Object[]>> roundsBySessionId = new HashMap<>();
     List<Long> allSessionIds = completedSessions.stream().map(GameSession::getId).toList();
     if (!allSessionIds.isEmpty()) {
@@ -853,7 +853,7 @@ public class GameService {
         // Drop the leading sessionId so the per-session shape matches accumulateRoundStats.
         roundsBySessionId
             .computeIfAbsent(sid, k -> new ArrayList<>())
-            .add(new Object[] {row[1], row[2], row[3], row[4], row[5]});
+            .add(new Object[] {row[1], row[2], row[3], row[4], row[5], row[6], row[7]});
       }
     }
 
@@ -920,6 +920,8 @@ public class GameService {
               stat.setDealIns(totals.dealtIn(p.getId()));
               stat.setAvgWinPoints(totals.avgWinPoints(p.getId()));
               stat.setAvgDealInPoints(totals.avgDealInPoints(p.getId()));
+              stat.setRiichiWins(totals.riichiWins(p.getId()));
+              stat.setMeldWins(totals.meldWins(p.getId()));
 
               // Tier in the queried mode. A null gameMode spans all modes, so there's no single
               // rating to report.
@@ -972,10 +974,12 @@ public class GameService {
     private final Map<Long, Integer> dealIns = new HashMap<>();
     private final Map<Long, Integer> winPointsSum = new HashMap<>();
     private final Map<Long, Integer> dealInPointsSum = new HashMap<>();
+    private final Map<Long, Integer> riichiWins = new HashMap<>();
+    private final Map<Long, Integer> meldWins = new HashMap<>();
 
     /**
-     * Folds in one batch of {@code [roundId, winnerId, dealInPlayerId, playerId, score]} rows, and
-     * may be called repeatedly to accumulate across sessions.
+     * Folds in one batch of {@code [roundId, winnerId, dealInPlayerId, playerId, score, fanDetails,
+     * winHand]} rows, and may be called repeatedly to accumulate across sessions.
      *
      * <p>The query returns one row per player per round, with the round-level columns repeated on
      * all four, so the per-round tallies are guarded by the ids already seen. Without that guard
@@ -989,6 +993,8 @@ public class GameService {
         Long dealInPlayerId = (Long) row[2];
         Long playerId = (Long) row[3];
         int score = ((Number) row[4]).intValue();
+        String fanDetails = (String) row[5];
+        String winHand = (String) row[6];
 
         roundsPlayed.merge(playerId, 1, Integer::sum);
 
@@ -998,6 +1004,15 @@ public class GameService {
             // 自摸 (self-draw): win with no deal-in player. 荣和 = handWins - tsumoWins.
             if (dealInPlayerId == null) {
               tsumoWins.merge(winnerId, 1, Integer::sum);
+            }
+            // 副露: the winning hand itself has a meld — `[` (open) or `(` (closed), the same
+            // grammar MahjongHand.tsx renders and PhotoRecognitionModal.winHandToLabel parses.
+            if (winHand != null && (winHand.indexOf('[') >= 0 || winHand.indexOf('(') >= 0)) {
+              meldWins.merge(winnerId, 1, Integer::sum);
+            }
+            // 立直: fanDetails lists the yaku, e.g. "立直(1), 平和(1)" — covers 两立直 too.
+            if (fanDetails != null && fanDetails.contains("立直")) {
+              riichiWins.merge(winnerId, 1, Integer::sum);
             }
           }
           if (dealInPlayerId != null) {
@@ -1028,6 +1043,16 @@ public class GameService {
 
     int dealtIn(Long playerId) {
       return dealIns.getOrDefault(playerId, 0);
+    }
+
+    /** Hands won having declared riichi — over handWins, same denominator as meldWins. */
+    int riichiWins(Long playerId) {
+      return riichiWins.getOrDefault(playerId, 0);
+    }
+
+    /** Hands won with a meld — the standard definition, since a call with no win is not tracked. */
+    int meldWins(Long playerId) {
+      return meldWins.getOrDefault(playerId, 0);
     }
 
     /** 平均打点: over the wins, not over the rounds played, and 0 rather than a division by zero. */
@@ -1103,7 +1128,8 @@ public class GameService {
     for (GameSession s : completed) modeBySession.put(s.getId(), s.getGameMode());
 
     // Partition round-detail rows by mode, reshaping to the [roundId, winnerId, dealInPlayerId,
-    // playerId, score] tuple that accumulateRoundStats expects (dropping the leading sessionId).
+    // playerId, score, riichiPlayerIds, winHand] tuple RoundTotals.add expects (dropping the
+    // leading sessionId).
     Map<GameMode, List<Object[]>> rowsByMode = new EnumMap<>(GameMode.class);
     List<Long> ids = completed.stream().map(GameSession::getId).toList();
     for (Object[] row : roundScoreRepo.getRoundDetailsBySessions(ids)) {
@@ -1111,7 +1137,7 @@ public class GameService {
       if (mode == null) continue;
       rowsByMode
           .computeIfAbsent(mode, k -> new ArrayList<>())
-          .add(new Object[] {row[1], row[2], row[3], row[4], row[5]});
+          .add(new Object[] {row[1], row[2], row[3], row[4], row[5], row[6], row[7]});
     }
 
     Map<String, PlayerDetailResponse.ModeStats> statsByMode = new HashMap<>();

--- a/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
@@ -73,10 +73,25 @@ class GameServiceStatsTest {
 
   /**
    * One row of {@code getRoundDetailsBySessions}: session, round, winner, deal-in, player, score.
+   * fanDetails and winHand default to absent, for the tests that do not care about either.
    */
   private static Object[] row(
       long sessionId, long roundId, Long winnerId, Long dealInId, long playerId, int score) {
-    return new Object[] {sessionId, roundId, winnerId, dealInId, playerId, score};
+    return row(sessionId, roundId, winnerId, dealInId, playerId, score, null, null);
+  }
+
+  private static Object[] row(
+      long sessionId,
+      long roundId,
+      Long winnerId,
+      Long dealInId,
+      long playerId,
+      int score,
+      String fanDetails,
+      String winHand) {
+    return new Object[] {
+      sessionId, roundId, winnerId, dealInId, playerId, score, fanDetails, winHand
+    };
   }
 
   /**
@@ -85,6 +100,22 @@ class GameServiceStatsTest {
    */
   private static List<Object[]> round(
       long sessionId, long roundId, Long winnerId, Long dealInId, int winScore) {
+    return round(sessionId, roundId, winnerId, dealInId, winScore, null, null);
+  }
+
+  private static List<Object[]> round(
+      long sessionId, long roundId, Long winnerId, Long dealInId, int winScore, String winHand) {
+    return round(sessionId, roundId, winnerId, dealInId, winScore, null, winHand);
+  }
+
+  private static List<Object[]> round(
+      long sessionId,
+      long roundId,
+      Long winnerId,
+      Long dealInId,
+      int winScore,
+      String fanDetails,
+      String winHand) {
     List<Object[]> rows = new ArrayList<>();
     for (long playerId : new long[] {ME, OPPONENT, 3L, 4L}) {
       int score = 0;
@@ -93,7 +124,7 @@ class GameServiceStatsTest {
       } else if (dealInId != null && dealInId == playerId) {
         score = -winScore;
       }
-      rows.add(row(sessionId, roundId, winnerId, dealInId, playerId, score));
+      rows.add(row(sessionId, roundId, winnerId, dealInId, playerId, score, fanDetails, winHand));
     }
     return rows;
   }
@@ -301,6 +332,91 @@ class GameServiceStatsTest {
     assertThat(mine.getAvgDealInPoints()).isEqualTo(6000.0);
     assertThat(mine.getGamesPlayed()).isEqualTo(1);
     assertThat(mine.getTotalScore()).isEqualTo(12000);
+  }
+
+  /**
+   * Sets up the leaderboard path (unlike {@link #statsFor}, which goes through the player page).
+   */
+  private PlayerStatsResponse leaderboardStatsFor(List<Object[]> rows) {
+    Player me = new Player();
+    me.setId(ME);
+    me.setUserName("me");
+    Player opponent = new Player();
+    opponent.setId(OPPONENT);
+    opponent.setUserName("opponent");
+    when(playerRepo.findAll()).thenReturn(List.of(me, opponent));
+    when(sessionRepo.findAll())
+        .thenReturn(List.of(session(GUOBIAO_SESSION, GameMode.GUOBIAO, SessionStatus.COMPLETED)));
+    when(roundScoreRepo.getTotalScoresBySessions(anyList()))
+        .thenReturn(
+            List.of(
+                new Object[] {GUOBIAO_SESSION, ME, 0},
+                new Object[] {GUOBIAO_SESSION, OPPONENT, 0}));
+    when(roundScoreRepo.getRoundDetailsBySessions(anyList())).thenReturn(rows);
+    return service.getPlayerStats(null, null, null).stream()
+        .filter(s -> ME == s.getPlayerId())
+        .findFirst()
+        .orElseThrow();
+  }
+
+  /** 立直: fanDetails lists it as a yaku. Round-level like handWins, so needs the same guard. */
+  @Test
+  void countsARiichiWinOnlyForTheWinnerAndOncePerRound() {
+    String fanDetails = "立直(1), 平和(1)";
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(
+            List.of(
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, ME, 8000, fanDetails, null),
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, OPPONENT, -8000, fanDetails, null),
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, 3L, 0, fanDetails, null),
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, 4L, 0, fanDetails, null)));
+
+    assertThat(mine.getRiichiWins()).isEqualTo(1);
+  }
+
+  /** 两立直 (double riichi) also counts — it contains the same substring. */
+  @Test
+  void countsADoubleRiichiWinAsARiichiWin() {
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000, "两立直(2)", null));
+
+    assertThat(mine.getRiichiWins()).isEqualTo(1);
+  }
+
+  /** A win with no 立直 in its yaku list is not a riichi win. */
+  @Test
+  void doesNotCountAWinWithNoRiichiDeclaration() {
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000));
+
+    assertThat(mine.getRiichiWins()).isZero();
+  }
+
+  /**
+   * 副露: a win with a meld in the hand, `[` or `(` in winHand's grammar. Only the winner's row
+   * matters, and — same trap as handWins — the round-level winHand is repeated on all four rows.
+   */
+  @Test
+  void countsAMeldWinOnlyForTheWinnerAndOncePerRound() {
+    String openMeldHand = "1m2m3m^4m[5p5p5p]";
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(
+            List.of(
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, ME, 8000, null, openMeldHand),
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, OPPONENT, -8000, null, openMeldHand),
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, 3L, 0, null, openMeldHand),
+                row(GUOBIAO_SESSION, 100L, ME, OPPONENT, 4L, 0, null, openMeldHand)));
+
+    assertThat(mine.getMeldWins()).isEqualTo(1);
+  }
+
+  /** A concealed win — no `[` or `(` in winHand — is not a 副露 win. */
+  @Test
+  void doesNotCountAConcealedWinAsAMeldWin() {
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000, "1m2m3m^4m"));
+
+    assertThat(mine.getMeldWins()).isZero();
   }
 
   @Test

--- a/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
@@ -393,8 +393,8 @@ class GameServiceStatsTest {
   }
 
   /**
-   * 副露: a win with a meld in the hand, `[` or `(` in winHand's grammar. Only the winner's row
-   * matters, and — same trap as handWins — the round-level winHand is repeated on all four rows.
+   * 副露: a win with an open meld, `[` in winHand's grammar. Only the winner's row matters, and —
+   * same trap as handWins — the round-level winHand is repeated on all four rows.
    */
   @Test
   void countsAMeldWinOnlyForTheWinnerAndOncePerRound() {
@@ -410,11 +410,21 @@ class GameServiceStatsTest {
     assertThat(mine.getMeldWins()).isEqualTo(1);
   }
 
-  /** A concealed win — no `[` or `(` in winHand — is not a 副露 win. */
+  /** A concealed win — no `[` in winHand — is not a 副露 win. */
   @Test
   void doesNotCountAConcealedWinAsAMeldWin() {
     PlayerStatsResponse mine =
         leaderboardStatsFor(round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000, "1m2m3m^4m"));
+
+    assertThat(mine.getMeldWins()).isZero();
+  }
+
+  /** A closed kan (暗杠), `(` in winHand's grammar, keeps the hand 门清 — not a 副露 win either. */
+  @Test
+  void doesNotCountAClosedKanAsAMeldWin() {
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(
+            round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000, "1m2m3m^4m(5p5p5p5p)"));
 
     assertThat(mine.getMeldWins()).isZero();
   }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -366,8 +366,9 @@ table.fixed-table .col-rank {
 }
 
 /* Statistic columns carry no width on desktop: table-layout: fixed shares the remainder evenly.
-   Phones give the widest one (立直/副露) its own class with an explicit width instead — see below. */
+   Phones give the 全部玩家 table's three sizes an explicit width each instead — see below. */
 table.fixed-table .col-num,
+table.fixed-table .col-num-narrow,
 table.fixed-table .col-num-wide,
 table.fixed-table .col-num-widest,
 table.fixed-table .col-rating {
@@ -1617,11 +1618,17 @@ table.auto-table {
   }
 
   /* The stats table tightened for phones: headers, numbers and badges each go one size down, the fixed
-     columns (rank, player, 段位分) get smaller widths, and the number columns keep splitting whatever
-     table-layout: fixed leaves them. */
+     columns (rank, player) get smaller widths. */
   .stats-table th {
     font-size: 0.62rem;
     letter-spacing: 0;
+  }
+
+  /* Fixed widths; 均位/打点/铳点 below split whatever's left. */
+  table.stats-table {
+    --stats-rank-col: 36px;
+    --stats-name-col: 118px;
+    --stats-widest-col: 60px;
   }
 
   table.stats-table th,
@@ -1631,27 +1638,34 @@ table.auto-table {
   }
 
   table.stats-table .col-rank {
-    width: 36px;
+    width: var(--stats-rank-col);
   }
 
   table.stats-table .col-name {
-    width: 108px;
+    width: var(--stats-name-col);
     padding-left: 6px;
   }
 
-  /* Explicit widths instead of sharing the remainder — with 4 number columns that left every one
-     wider than its content needed. */
-  table.stats-table .col-num-wide {
-    width: 42px;
+  table.stats-table .col-num-widest {
+    width: var(--stats-widest-col);
   }
 
-  table.stats-table .col-num-widest {
-    width: 60px;
+  /* Shares add up to 1 so there's no remainder to redistribute. */
+  table.stats-table .col-num-narrow {
+    width: calc((100% - var(--stats-rank-col) - var(--stats-name-col) - var(--stats-widest-col)) * 0.24);
+  }
+
+  table.stats-table .col-num-wide {
+    width: calc((100% - var(--stats-rank-col) - var(--stats-name-col) - var(--stats-widest-col)) * 0.38);
   }
 
   .stats-table .num-cell,
   .stats-table .num-cell-rank {
     font-size: 0.78rem;
+  }
+
+  .stats-table .num-cell-narrow {
+    font-size: 0.65rem;
   }
 
   /* Shrink only the inline 段位 badges inside the stats table, and give the width back to the name. */

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -365,11 +365,11 @@ table.fixed-table .col-rank {
   width: 44px;
 }
 
-/* Statistic columns deliberately carry no width: table-layout: fixed shares the remainder between
-   them, so a table with two of them and a table with three both come out even, with no per-column
-   pixel tuning. */
+/* Statistic columns carry no width on desktop: table-layout: fixed shares the remainder evenly.
+   Phones give the widest one (立直/副露) its own class with an explicit width instead — see below. */
 table.fixed-table .col-num,
 table.fixed-table .col-num-wide,
+table.fixed-table .col-num-widest,
 table.fixed-table .col-rating {
   text-align: right;
 }
@@ -983,9 +983,9 @@ table.auto-table {
   font-size: 0.9rem;
 }
 
-/* The percent sign and units sit one size below the number. */
+/* The percent sign and units sit well below the number */
 .stat-unit {
-  font-size: 0.75em;
+  font-size: 0.6em;
   margin-left: 1px;
 }
 
@@ -1624,21 +1624,29 @@ table.auto-table {
     letter-spacing: 0;
   }
 
-  .stats-table th,
-  .stats-table td {
-    padding-left: 4px;
-    padding-right: 4px;
+  table.stats-table th,
+  table.stats-table td {
+    padding-left: 2px;
+    padding-right: 2px;
   }
 
   table.stats-table .col-rank {
     width: 36px;
   }
 
-  /* 118px is the ceiling: any wider and the share left to each statistic column no longer fits
-     "1464(?)". */
   table.stats-table .col-name {
-    width: 118px;
+    width: 108px;
     padding-left: 6px;
+  }
+
+  /* Explicit widths instead of sharing the remainder — with 4 number columns that left every one
+     wider than its content needed. */
+  table.stats-table .col-num-wide {
+    width: 42px;
+  }
+
+  table.stats-table .col-num-widest {
+    width: 60px;
   }
 
   .stats-table .num-cell,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1624,10 +1624,13 @@ table.auto-table {
     letter-spacing: 0;
   }
 
-  /* Fixed widths; 均位/打点/铳点 below split whatever's left. */
   table.stats-table {
     --stats-rank-col: 36px;
     --stats-name-col: 118px;
+    --stats-widest-col: 0px;
+  }
+
+  table.stats-table.stats-table-riichi {
     --stats-widest-col: 60px;
   }
 

--- a/ui/src/pages/PlayerDetailPage.tsx
+++ b/ui/src/pages/PlayerDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { fetchPlayerDetail, fetchPlayerTier } from '../api'
-import { PlayerDetail, PlayerTierResponse, GameModeKey, GAME_MODES } from '../types'
+import { PlayerDetail, PlayerTierResponse } from '../types'
 import { abbrName, scoreClass, parseError } from '../utils/format'
 import { MSG } from '../constants'
 import { RankBadge } from '../components/RankBadge'
@@ -11,7 +11,6 @@ export default function PlayerDetailPage() {
   const navigate = useNavigate()
   const [player, setPlayer] = useState<PlayerDetail | null>(null)
   const [tier, setTier] = useState<PlayerTierResponse | null>(null)
-  const [statsMode, setStatsMode] = useState<GameModeKey>(GAME_MODES[0].key)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -78,79 +77,7 @@ export default function PlayerDetailPage() {
         </div>
       </div>
 
-      <div className="card">
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '20px',
-            flexWrap: 'wrap',
-          }}
-        >
-          <h2 style={{ margin: 0 }}>🪪 数据统计</h2>
-          <select
-            value={statsMode}
-            onChange={(e) => setStatsMode(e.target.value as GameModeKey)}
-            className="select-inline"
-          >
-            {GAME_MODES.map((m) => (
-              <option key={m.key} value={m.key}>
-                {m.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        {(() => {
-          const stats = player.statsByMode?.[statsMode]
-          if (!stats || stats.roundsPlayed === 0) {
-            return (
-              <div className="empty-state empty-state-compact">
-                <p>本模式暂无数据统计。</p>
-              </div>
-            )
-          }
-          return (
-            <div className="stats-grid">
-              <div className="stat-card">
-                <div className="stat-value">
-                  {((stats.handWins / stats.roundsPlayed) * 100).toFixed(1)}%
-                  {stats.handWins > 0 && (
-                    <span
-                      style={{
-                        fontSize: '0.6rem',
-                        color: 'var(--text-light)',
-                        verticalAlign: 'bottom',
-                        marginLeft: 2,
-                      }}
-                    >
-                      ({((stats.tsumoWins / stats.handWins) * 100).toFixed(0)}%)
-                    </span>
-                  )}
-                </div>
-                <div className="stat-label">和牌率(自摸率)</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">{((stats.dealIns / stats.roundsPlayed) * 100).toFixed(1)}%</div>
-                <div className="stat-label">放铳率</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">
-                  {stats.handWins > 0 ? Math.round(stats.avgWinPoints).toLocaleString() : '-'}
-                </div>
-                <div className="stat-label">平均打点</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">
-                  {stats.dealIns > 0 ? Math.round(stats.avgDealInPoints).toLocaleString() : '-'}
-                </div>
-                <div className="stat-label">平均铳点</div>
-              </div>
-            </div>
-          )
-        })()}
-      </div>
+      {/* TODO: 这里增加个人荣誉徽章区域, 展示这个玩家历史上拿过的赛季奖项 */}
 
       <div className="card">
         <h2>游戏记录 ({player.games.length})</h2>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -433,9 +433,9 @@ export default function StatsPage() {
                   <tr>
                     <th className="col-rank">排名</th>
                     <th className="col-name">玩家</th>
-                    <th className="col-num-wide">均位</th>
-                    <th className="col-num-wide">平均打点</th>
-                    <th className="col-num-wide">平均铳点</th>
+                    <th className="col-num-narrow">均位</th>
+                    <th className="col-num-wide">打点</th>
+                    <th className="col-num-wide">铳点</th>
                     {gameMode === 'RIICHI' && <th className="col-num-widest">和牌分布</th>}
                   </tr>
                 </thead>
@@ -464,7 +464,9 @@ export default function StatsPage() {
                       <td className="num-cell">{pointsCell(p.avgWinPoints, p.handWins)}</td>
                       <td className="num-cell">{pointsCell(p.avgDealInPoints, p.dealIns)}</td>
                       {gameMode === 'RIICHI' && (
-                        <td className="num-cell">{riichiMeldCell(p.riichiWins, p.meldWins, p.handWins)}</td>
+                        <td className="num-cell num-cell-narrow">
+                          {riichiMeldCell(p.riichiWins, p.meldWins, p.handWins)}
+                        </td>
                       )}
                     </tr>
                   ))}

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -155,6 +155,8 @@ export default function StatsPage() {
         dealIns: stat?.dealIns ?? 0,
         avgWinPoints: stat?.avgWinPoints ?? 0,
         avgDealInPoints: stat?.avgDealInPoints ?? 0,
+        riichiWins: stat?.riichiWins ?? 0,
+        meldWins: stat?.meldWins ?? 0,
       }
     })
     .sort((a, b) => (b.skillRating ?? 0) - (a.skillRating ?? 0))
@@ -204,6 +206,17 @@ export default function StatsPage() {
     ) : (
       '-'
     )
+
+  const riichiMeldCell = (riichiWins: number, meldWins: number, handWins: number) => {
+    const riichiRate = handWins > 0 ? ((riichiWins / handWins) * 100).toFixed(1) : '-'
+    const meldRate = handWins > 0 ? ((meldWins / handWins) * 100).toFixed(1) : '-'
+    return (
+      <>
+        {riichiRate}/{meldRate}
+        <span className="stat-unit">%</span>
+      </>
+    )
+  }
 
   /** 平均打点/铳点 — 分母为 0 时给 "-", 避免显示 0 误导. */
   const pointsCell = (value: number, count: number) => (count > 0 ? Math.round(value).toLocaleString() : '-')
@@ -420,9 +433,10 @@ export default function StatsPage() {
                   <tr>
                     <th className="col-rank">排名</th>
                     <th className="col-name">玩家</th>
-                    <th className="col-num-wide">平均排名</th>
+                    <th className="col-num-wide">均位</th>
                     <th className="col-num-wide">平均打点</th>
                     <th className="col-num-wide">平均铳点</th>
+                    {gameMode === 'RIICHI' && <th className="col-num-widest">和牌分布</th>}
                   </tr>
                 </thead>
                 <tbody>
@@ -449,6 +463,9 @@ export default function StatsPage() {
                       <td className="num-cell">{p.totalGames > 0 ? p.avgRank?.toFixed(2) : '-'}</td>
                       <td className="num-cell">{pointsCell(p.avgWinPoints, p.handWins)}</td>
                       <td className="num-cell">{pointsCell(p.avgDealInPoints, p.dealIns)}</td>
+                      {gameMode === 'RIICHI' && (
+                        <td className="num-cell">{riichiMeldCell(p.riichiWins, p.meldWins, p.handWins)}</td>
+                      )}
                     </tr>
                   ))}
                 </tbody>

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -428,7 +428,7 @@ export default function StatsPage() {
           <div className="card">
             <h2>全部玩家</h2>
             <div className="table-wrap">
-              <table className="fixed-table stats-table">
+              <table className={`fixed-table stats-table${gameMode === 'RIICHI' ? ' stats-table-riichi' : ''}`}>
                 <thead>
                   <tr>
                     <th className="col-rank">排名</th>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -175,6 +175,8 @@ export interface PlayerStats {
   dealIns: number
   avgWinPoints: number
   avgDealInPoints: number
+  riichiWins: number
+  meldWins: number
   tier?: TierKey | null
   skillRating?: number
   gamesNeeded?: number


### PR DESCRIPTION
## Summary
- 删掉玩家详情页的「数据统计」卡片, 和排行榜完全重复的数据
- 立直模式的「全部玩家」表新增「和牌分布」列, 显示 立直率/副露率 (只统计胡了的局, 数据源是 fanDetails/winHand, 不依赖手动勾选的 riichiPlayerIds)
- 手机端表格列宽用 CSS 变量 + calc() 重新分配, 修掉数字列因 table-layout: fixed 按比例分摊导致的错位空隙

## Test plan
- [x] `GameServiceStatsTest` 新增立直率/副露率相关用例 (含 双立直、副露/门清区分、round 级别去重)
- [x] tsc / stylelint / spotless / pmd 全过 (pre-commit hook)
- [ ] 手机模拟器 (iPhone 16 Pro Max) 目测确认列宽

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added riichi-win and meld-win counts to player statistics.
  - Riichi statistics now show a combined win-distribution percentage.
  - Round results provide richer win details for more accurate statistics.

- **UI Improvements**
  - Updated statistics table labels, sizing, and mobile layout for improved readability.
  - Simplified the player detail statistics section while retaining player tier and game history.

- **Bug Fixes**
  - Improved classification of riichi, double-riichi, meld, and concealed wins in leaderboards and player statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->