### PR TITLE
立直/副露率分母改用有记录的和牌局, 排除老局的空白数据

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -22,6 +22,7 @@ public class PlayerStatsResponse {
   private double avgDealInPoints;
   private int riichiWins;
   private int meldWins;
+  private int recordedHandWins;
   private String tier;
   private double skillRating;
   private int gamesNeeded;

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -922,6 +922,7 @@ public class GameService {
               stat.setAvgDealInPoints(totals.avgDealInPoints(p.getId()));
               stat.setRiichiWins(totals.riichiWins(p.getId()));
               stat.setMeldWins(totals.meldWins(p.getId()));
+              stat.setRecordedHandWins(totals.recordedHandWins(p.getId()));
 
               // Tier in the queried mode. A null gameMode spans all modes, so there's no single
               // rating to report.
@@ -976,6 +977,7 @@ public class GameService {
     private final Map<Long, Integer> dealInPointsSum = new HashMap<>();
     private final Map<Long, Integer> riichiWins = new HashMap<>();
     private final Map<Long, Integer> meldWins = new HashMap<>();
+    private final Map<Long, Integer> recordedHandWins = new HashMap<>();
 
     /**
      * Folds in one batch of {@code [roundId, winnerId, dealInPlayerId, playerId, score, fanDetails,
@@ -1015,6 +1017,12 @@ public class GameService {
             if (fanDetails != null && fanDetails.contains("立直")) {
               riichiWins.merge(winnerId, 1, Integer::sum);
             }
+            // Rounds from before fanDetails/winHand started being recorded have both null, so
+            // riichiWins and meldWins can't tell "not riichi/meld" apart from "unknown" — this is
+            // the denominator that leaves those rounds out instead of counting them as neither.
+            if (fanDetails != null || winHand != null) {
+              recordedHandWins.merge(winnerId, 1, Integer::sum);
+            }
           }
           if (dealInPlayerId != null) {
             dealIns.merge(dealInPlayerId, 1, Integer::sum);
@@ -1046,7 +1054,7 @@ public class GameService {
       return dealIns.getOrDefault(playerId, 0);
     }
 
-    /** Hands won having declared riichi — over handWins, same denominator as meldWins. */
+    /** Hands won having declared riichi — over recordedHandWins, same denominator as meldWins. */
     int riichiWins(Long playerId) {
       return riichiWins.getOrDefault(playerId, 0);
     }
@@ -1054,6 +1062,11 @@ public class GameService {
     /** Hands won with a meld — the standard definition, since a call with no win is not tracked. */
     int meldWins(Long playerId) {
       return meldWins.getOrDefault(playerId, 0);
+    }
+
+    /** riichiWins/meldWins' denominator: wins with fanDetails or winHand actually recorded. */
+    int recordedHandWins(Long playerId) {
+      return recordedHandWins.getOrDefault(playerId, 0);
     }
 
     /** 平均打点: over the wins, not over the rounds played, and 0 rather than a division by zero. */

--- a/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
@@ -429,6 +429,29 @@ class GameServiceStatsTest {
     assertThat(mine.getMeldWins()).isZero();
   }
 
+  /**
+   * Sessions from before fanDetails/winHand started being recorded have both null. riichiWins and
+   * meldWins can't tell that apart from "recorded, and neither" — recordedHandWins is the
+   * denominator that leaves these out instead of counting them as a hand won with neither.
+   */
+  @Test
+  void excludesAHandWithNoRecordedFanDataFromRecordedHandWins() {
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000));
+
+    assertThat(mine.getHandWins()).isEqualTo(1);
+    assertThat(mine.getRecordedHandWins()).isZero();
+  }
+
+  /** Either field recorded is enough for the hand to count toward the denominator. */
+  @Test
+  void countsAHandWithEitherFieldRecordedTowardRecordedHandWins() {
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000, "立直(1)", null));
+
+    assertThat(mine.getRecordedHandWins()).isEqualTo(1);
+  }
+
   @Test
   void hasNoModeStatsWithoutSessions() {
     assertThat(statsFor(List.of(), List.of())).isEmpty();

--- a/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/GameServiceStatsTest.java
@@ -452,6 +452,15 @@ class GameServiceStatsTest {
     assertThat(mine.getRecordedHandWins()).isEqualTo(1);
   }
 
+  /** Same as above, with only winHand recorded — the fanDetails branch is not the only path. */
+  @Test
+  void countsAHandWithWinHandOnlyRecordedTowardRecordedHandWins() {
+    PlayerStatsResponse mine =
+        leaderboardStatsFor(round(GUOBIAO_SESSION, 100L, ME, OPPONENT, 8000, null, "1m2m3m^4m"));
+
+    assertThat(mine.getRecordedHandWins()).isEqualTo(1);
+  }
+
   @Test
   void hasNoModeStatsWithoutSessions() {
     assertThat(statsFor(List.of(), List.of())).isEmpty();

--- a/ui/src/pages/StatsPage.tsx
+++ b/ui/src/pages/StatsPage.tsx
@@ -157,6 +157,7 @@ export default function StatsPage() {
         avgDealInPoints: stat?.avgDealInPoints ?? 0,
         riichiWins: stat?.riichiWins ?? 0,
         meldWins: stat?.meldWins ?? 0,
+        recordedHandWins: stat?.recordedHandWins ?? 0,
       }
     })
     .sort((a, b) => (b.skillRating ?? 0) - (a.skillRating ?? 0))
@@ -207,9 +208,9 @@ export default function StatsPage() {
       '-'
     )
 
-  const riichiMeldCell = (riichiWins: number, meldWins: number, handWins: number) => {
-    const riichiRate = handWins > 0 ? ((riichiWins / handWins) * 100).toFixed(1) : '-'
-    const meldRate = handWins > 0 ? ((meldWins / handWins) * 100).toFixed(1) : '-'
+  const riichiMeldCell = (riichiWins: number, meldWins: number, recordedHandWins: number) => {
+    const riichiRate = recordedHandWins > 0 ? ((riichiWins / recordedHandWins) * 100).toFixed(1) : '-'
+    const meldRate = recordedHandWins > 0 ? ((meldWins / recordedHandWins) * 100).toFixed(1) : '-'
     return (
       <>
         {riichiRate}/{meldRate}
@@ -465,7 +466,7 @@ export default function StatsPage() {
                       <td className="num-cell">{pointsCell(p.avgDealInPoints, p.dealIns)}</td>
                       {gameMode === 'RIICHI' && (
                         <td className="num-cell num-cell-narrow">
-                          {riichiMeldCell(p.riichiWins, p.meldWins, p.handWins)}
+                          {riichiMeldCell(p.riichiWins, p.meldWins, p.recordedHandWins)}
                         </td>
                       )}
                     </tr>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -177,6 +177,7 @@ export interface PlayerStats {
   avgDealInPoints: number
   riichiWins: number
   meldWins: number
+  recordedHandWins: number
   tier?: TierKey | null
   skillRating?: number
   gamesNeeded?: number


### PR DESCRIPTION
## Summary
- fanDetails/winHand 是后来才加的字段, 2026-05-15 之前的立直局两个字段全是 null (查了本地数据库确认: 458 局立直和牌里有 53 局属于这种情况, 占 11.6%)
- 之前立直率/副露率的判断 (`fanDetails.contains("立直")` / `winHand.indexOf('[')>=0`) 对 null 输入自然是假, 于是这些没数据的老局被当成"没立直没副露"算进了默听桶, 部分玩家的默听率被冲到 50% 以上 (例如 pichu 显示 55%, frog 显示 46.2%)
- 新增 `recordedHandWins` (fanDetails 或 winHand 至少一个不为 null 的和牌局数), 立直率/副露率改用它当分母, 完全没记录的老局排除在外而不是被当成默听。用本地数据库重算后 pichu 变成 0%, frog 变成 6.7%, 跟真实牌局数据对得上

## Test plan
- [x] 新增 `excludesAHandWithNoRecordedFanDataFromRecordedHandWins` / `countsAHandWithEitherFieldRecordedTowardRecordedHandWins` 两个单测
- [x] `GameServiceStatsTest` 全部通过
- [x] tsc / stylelint / spotless / pmd 全过 (pre-commit hook)
- [ ] 部署后用真实数据再看一眼各玩家的立直/副露/默听数字

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved riichi and meld win percentages by calculating them from recognized recorded hands.
  * Excluded wins without hand details from percentage calculations.
  * Updated player statistics to display the number of recorded hand wins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->