### PR TITLE
建局后随机分配座位, 全屏计时器, 修拍照识别漏填bug

### DIFF
--- a/server/src/main/java/com/mahjong/omakase/config/GeminiClientConfig.java
+++ b/server/src/main/java/com/mahjong/omakase/config/GeminiClientConfig.java
@@ -3,27 +3,11 @@ package com.mahjong.omakase.config;
 import java.time.Duration;
 import org.springframework.boot.web.client.ClientHttpRequestFactories;
 import org.springframework.boot.web.client.ClientHttpRequestFactorySettings;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
-/**
- * HTTP client used to call Gemini for photo recognition.
- *
- * <p>Kept as its own bean so the timeouts live in one place and {@link
- * com.mahjong.omakase.service.TileRecognitionService} can be handed a test double.
- *
- * <p>The numbers are sized against the gateway in front of us, not against Gemini: Cloudflare's
- * free plan abandons a request after 100s and answers 524, and that ceiling cannot be raised. A
- * single two-image call takes tens of seconds, so the read timeout stays generous — a slow but
- * successful call must not be cut off. What stops a failed rotation from running well past the
- * ceiling is instead {@link com.mahjong.omakase.service.TileRecognitionService#RETRY_BUDGET_MS},
- * which is paired with the read timeout below so that a timed-out attempt ends the rotation.
- */
-@Configuration
+/** HTTP client for Gemini, retired along with {@code TileRecognitionService}. Legacy code. */
 public class GeminiClientConfig {
 
-  @Bean
   public RestClient geminiRestClient(RestClient.Builder builder) {
     return builder
         .requestFactory(

--- a/server/src/main/java/com/mahjong/omakase/config/LocalReaderClientConfig.java
+++ b/server/src/main/java/com/mahjong/omakase/config/LocalReaderClientConfig.java
@@ -10,10 +10,9 @@ import org.springframework.web.client.RestClient;
 /**
  * HTTP client used to call the local tile reader running beside this app.
  *
- * <p>Timeouts are an order of magnitude tighter than the Gemini client's, because the thing on the
- * other end is a sidecar on the same Docker network that answers in about half a second. Generous
- * timeouts would only turn "the reader is down" into a user staring at a spinner, when the useful
- * response to that is to fall back to Gemini quickly.
+ * <p>Timeouts are tight because the thing on the other end is a sidecar on the same Docker network
+ * that answers in about half a second. Generous timeouts would only turn "the reader is down" into
+ * a user staring at a spinner, when the useful response to that is to say so quickly.
  */
 @Configuration
 public class LocalReaderClientConfig {
@@ -26,8 +25,7 @@ public class LocalReaderClientConfig {
                 ClientHttpRequestFactorySettings.DEFAULTS
                     .withConnectTimeout(Duration.ofSeconds(2))
                     // A read of a 2048px photo measures ~0.5s. Ten seconds is room for a cold
-                    // container and a loaded droplet, and still short enough that falling back to
-                    // Gemini afterwards stays inside the gateway's 100s ceiling.
+                    // container and a loaded droplet.
                     .withReadTimeout(Duration.ofSeconds(10))))
         .build();
   }

--- a/server/src/main/java/com/mahjong/omakase/controller/TileRecognitionController.java
+++ b/server/src/main/java/com/mahjong/omakase/controller/TileRecognitionController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Server-side proxy for hand photo recognition — keeps the Gemini key off the client. */
+/** Server-side proxy for hand photo recognition. */
 @Slf4j
 @RestController
 @RequestMapping("/api/recognize")
@@ -30,10 +30,7 @@ public class TileRecognitionController {
     try {
       HandRecognitionService.Recognition recognition =
           service.recognize(
-              request.getImageBase64(),
-              request.getMimeType(),
-              request.getEngine(),
-              request.getSessionId());
+              request.getImageBase64(), request.getMimeType(), request.getSessionId());
       return ResponseEntity.ok(
           new TileRecognitionResponse(
               recognition.rawJson(), recognition.warning(), recognition.sampleId()));

--- a/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/PlayerStatsResponse.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 public class PlayerStatsResponse {
   private Long playerId;
   private String userName;
-  private String displayName;
   private int gamesPlayed;
   private int totalScore;
   private double avgRank;

--- a/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/SessionDetailResponse.java
@@ -34,17 +34,11 @@ public class SessionDetailResponse {
   public static class PlayerInfo {
     private Long id;
     private String userName;
-    private String firstName;
-    private String lastName;
     private Integer seat;
     private String tier;
 
-    public PlayerInfo(Long id, String userName, String firstName, String lastName, Integer seat) {
-      this(id, userName, firstName, lastName, seat, null);
-    }
-
-    public String getDisplayName() {
-      return firstName + " " + lastName;
+    public PlayerInfo(Long id, String userName, Integer seat) {
+      this(id, userName, seat, null);
     }
   }
 

--- a/server/src/main/java/com/mahjong/omakase/dto/TileRecognitionRequest.java
+++ b/server/src/main/java/com/mahjong/omakase/dto/TileRecognitionRequest.java
@@ -1,7 +1,6 @@
 package com.mahjong.omakase.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -19,14 +18,6 @@ public class TileRecognitionRequest {
       regexp = "image/(jpeg|png|webp|heic|heif)",
       message = "仅支持 JPEG / PNG / WebP / HEIC / HEIF 图片")
   private String mimeType = "image/jpeg";
-
-  /**
-   * Which recogniser to use. Defaults to the local reader, so a client that does not send this
-   * field gets the fast free path; the UI's online button sends {@code gemini}.
-   */
-  @NotNull(message = "识别方式不能为空")
-  @Pattern(regexp = "local|gemini", message = "识别方式只能是 local 或 gemini")
-  private String engine = "local";
 
   /** The session this photo is being recognised for, if any — purely for the reader's own log. */
   private Long sessionId;

--- a/server/src/main/java/com/mahjong/omakase/model/GameSession.java
+++ b/server/src/main/java/com/mahjong/omakase/model/GameSession.java
@@ -3,6 +3,7 @@ package com.mahjong.omakase.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -31,7 +32,7 @@ public class GameSession {
   private GameMode gameMode;
 
   @Column(nullable = false)
-  private LocalDateTime createdAt = LocalDateTime.now();
+  private LocalDateTime createdAt = LocalDateTime.now(ZoneOffset.UTC);
 
   @JsonIgnore
   @OneToMany(mappedBy = "gameSession", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/server/src/main/java/com/mahjong/omakase/model/Player.java
+++ b/server/src/main/java/com/mahjong/omakase/model/Player.java
@@ -2,6 +2,7 @@ package com.mahjong.omakase.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -33,7 +34,7 @@ public class Player {
   private String lastName;
 
   @Column(nullable = false)
-  private LocalDateTime createdAt = LocalDateTime.now();
+  private LocalDateTime createdAt = LocalDateTime.now(ZoneOffset.UTC);
 
   @Column(nullable = false, columnDefinition = "boolean default false")
   private boolean bot = false;

--- a/server/src/main/java/com/mahjong/omakase/service/GameService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/GameService.java
@@ -391,11 +391,7 @@ public class GameService {
                   Player p = gsp.getPlayer();
                   SessionDetailResponse.PlayerInfo info =
                       new SessionDetailResponse.PlayerInfo(
-                          p.getId(),
-                          p.getUserName(),
-                          p.getFirstName(),
-                          p.getLastName(),
-                          gsp.getSeat());
+                          p.getId(), p.getUserName(), gsp.getSeat());
                   info.setTier(tierService.computeTier(p, sessionMode, sessionThroneId).name());
                   return info;
                 })
@@ -905,7 +901,6 @@ public class GameService {
               PlayerStatsResponse stat = new PlayerStatsResponse();
               stat.setPlayerId(p.getId());
               stat.setUserName(p.getUserName());
-              stat.setDisplayName(p.getDisplayName());
               stat.setGamesPlayed(gamesPlayed.getOrDefault(p.getId(), 0));
               stat.setTotalScore(totalScores.getOrDefault(p.getId(), 0));
               stat.setWins(wins.getOrDefault(p.getId(), 0));

--- a/server/src/main/java/com/mahjong/omakase/service/HandRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/HandRecognitionService.java
@@ -7,15 +7,8 @@ import org.springframework.stereotype.Service;
 /**
  * Chooses which recogniser answers a photo, and keeps the sample either way.
  *
- * <p>The local reader is the only automatic path — Gemini is not called on a local failure. It used
- * to be: this project's whole point right now is bringing the local model up, and every local miss
- * that got quietly patched over by Gemini was tens of seconds of latency (Gemini's own retry chain
- * can run past a minute) for no benefit to that goal, while also hiding exactly the failures worth
- * looking at. A local miss now returns an empty hand plus a warning, and the user fills it in by
- * hand — which they can also just do in the calculator.
- *
- * <p>Gemini is not deleted: {@link #recognize} still answers {@code engine=gemini} the same as
- * before. There is simply no button that sends it any more.
+ * <p>Local only — Gemini ({@link TileRecognitionService}) is retired and unused legacy code now. A
+ * local miss returns an empty hand plus a warning, and the user fills it in by hand.
  *
  * <p>{@link RecognitionSampleStore#saveFailure} still runs on a local miss — that failure is itself
  * useful signal for the retraining this is all in service of.
@@ -25,7 +18,6 @@ import org.springframework.stereotype.Service;
 public class HandRecognitionService {
 
   public static final String LOCAL = "local";
-  public static final String GEMINI = "gemini";
 
   /** An empty, well-formed hand — safe for the browser to auto-apply as "nothing found". */
   private static final String EMPTY_HAND_JSON =
@@ -42,30 +34,17 @@ public class HandRecognitionService {
   public record Recognition(String rawJson, String warning, String sampleId) {}
 
   private final LocalReaderService reader;
-  private final TileRecognitionService gemini;
   private final RecognitionSampleStore sampleStore;
 
-  public HandRecognitionService(
-      LocalReaderService reader,
-      TileRecognitionService gemini,
-      RecognitionSampleStore sampleStore) {
+  public HandRecognitionService(LocalReaderService reader, RecognitionSampleStore sampleStore) {
     this.reader = reader;
-    this.gemini = gemini;
     this.sampleStore = sampleStore;
   }
 
-  /**
-   * Recognises one photo, locally unless the client asked for Gemini or no reader is configured.
-   */
-  public Recognition recognize(String imageBase64, String mimeType, String engine, Long sessionId) {
-    if (GEMINI.equals(engine) || !reader.isConfigured()) {
-      TileRecognitionService.Answer answer = gemini.recognize(imageBase64, mimeType);
-      return new Recognition(answer.rawJson(), null, answer.sampleId());
-    }
+  /** Recognises one photo, always locally. */
+  public Recognition recognize(String imageBase64, String mimeType, Long sessionId) {
     try {
       String json = reader.recognize(imageBase64, mimeType, sessionId);
-      // The Gemini path saves inside TileRecognitionService, once it has an answer to pair the
-      // photo with; this is the same point in the local path.
       String sampleId = sampleStore.save(imageBase64, mimeType, LOCAL, json);
       return new Recognition(json, null, sampleId);
     } catch (ReaderUnavailableException e) {

--- a/server/src/main/java/com/mahjong/omakase/service/LocalReaderService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/LocalReaderService.java
@@ -19,9 +19,9 @@ import org.springframework.web.client.RestClientResponseException;
  * <p>The reader answers in the same shape Gemini does, so the response travels on to the browser
  * untouched, exactly as the Gemini text does.
  *
- * <p>The distinction this class exists to draw is between the two ways it can fail. Both fall back
- * to Gemini — {@link HandRecognitionService} sees to that, so the user gets their hand either way —
- * but they are not the same thing to tell them:
+ * <p>The distinction this class exists to draw is between the two ways it can fail. Neither falls
+ * back to Gemini any more — {@link HandRecognitionService} returns an empty hand and a warning
+ * instead — but they are not the same thing to tell the user:
  *
  * <ul>
  *   <li><strong>The reader is not there</strong> — container down, wrong URL, timeout. Nothing
@@ -60,11 +60,10 @@ public class LocalReaderService {
     this.restClient = localReaderRestClient;
     // Trailing slash stripped, because the endpoint below appends one. A reader.url ending in "/"
     // would otherwise produce ".../recognize" with a double slash, which the reader answers 404 —
-    // indistinguishable from the container being down, and so a silent fallback to Gemini forever.
+    // indistinguishable from the container being down.
     this.url = url == null ? "" : url.trim().replaceAll("/+$", "");
     if (this.url.isEmpty()) {
-      log.info(
-          "Local tile reader is not configured (reader.url is unset); recognition uses Gemini");
+      log.info("Local tile reader is not configured (reader.url is unset)");
     } else {
       log.info("Local tile reader at {}", this.url);
     }
@@ -112,7 +111,7 @@ public class LocalReaderService {
       return responseBody;
     } catch (ResourceAccessException e) {
       // Connect refused, DNS, or the read timing out. All infrastructure, none of it the user's
-      // problem, so this is the case that falls through to Gemini.
+      // problem.
       throw new ReaderUnavailableException(
           "could not reach the reader at " + url + ": " + e.getMessage(), e);
     } catch (RestClientResponseException e) {
@@ -133,7 +132,7 @@ public class LocalReaderService {
             e);
       }
       log.info("Local reader declined the photo ({}): {}", status, detail);
-      throw new IllegalStateException(detail.isBlank() ? "本地识别没有在照片里找到手牌，请重拍或改用在线识别" : detail, e);
+      throw new IllegalStateException(detail.isBlank() ? "本地识别没有在照片里找到手牌，请重拍或手动输入" : detail, e);
     }
   }
 

--- a/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
+++ b/server/src/main/java/com/mahjong/omakase/service/TileRecognitionService.java
@@ -16,13 +16,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
 /**
  * Sends a hand photo to Gemini and returns the model's raw JSON answer.
+ *
+ * <p>Retired and not wired into Spring (no {@code @Service}) — {@link HandRecognitionService} is
+ * local-only now. Kept as legacy code rather than deleted.
  *
  * <p>The API key never leaves the server: it is read from {@code GEMINI_API_KEYS} and attached as a
  * request header here. Several comma-separated keys may be supplied; on a quota/rate-limit response
@@ -32,7 +34,6 @@ import org.springframework.web.client.RestClientResponseException;
  * caller cannot repurpose this endpoint as a general-purpose Gemini relay.
  */
 @Slf4j
-@Service
 public class TileRecognitionService {
 
   private static final String ENDPOINT =

--- a/server/src/test/java/com/mahjong/omakase/controller/TileRecognitionControllerTest.java
+++ b/server/src/test/java/com/mahjong/omakase/controller/TileRecognitionControllerTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.when;
 import com.mahjong.omakase.dto.TileRecognitionRequest;
 import com.mahjong.omakase.service.HandRecognitionService;
 import com.mahjong.omakase.service.HandRecognitionService.Recognition;
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -35,7 +33,7 @@ class TileRecognitionControllerTest {
    */
   @Test
   void answers503SoTheProxyDoesNotReplaceOurMessage() {
-    when(service.recognize(anyString(), anyString(), anyString(), any()))
+    when(service.recognize(anyString(), anyString(), any()))
         .thenThrow(new IllegalStateException("This model is currently experiencing high demand."));
 
     ResponseEntity<Object> response = controller.recognize(request());
@@ -46,11 +44,11 @@ class TileRecognitionControllerTest {
         .isEqualTo(Map.of("message", "This model is currently experiencing high demand."));
   }
 
-  /** A missing key is a server-side configuration gap, so it belongs on the same branch. */
+  /** Any unexpected IllegalStateException out of the service still degrades to 503, not 500. */
   @Test
-  void answers503WhenNoKeyIsConfigured() {
-    when(service.recognize(anyString(), anyString(), anyString(), any()))
-        .thenThrow(new IllegalStateException("服务端未配置 Gemini API Key，请联系管理员"));
+  void answers503OnAnyUnexpectedFailure() {
+    when(service.recognize(anyString(), anyString(), any()))
+        .thenThrow(new IllegalStateException("something the service did not expect"));
 
     assertThat(controller.recognize(request()).getStatusCode())
         .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
@@ -58,7 +56,7 @@ class TileRecognitionControllerTest {
 
   @Test
   void returnsTheModelJsonOnSuccess() {
-    when(service.recognize(anyString(), anyString(), anyString(), any()))
+    when(service.recognize(anyString(), anyString(), any()))
         .thenReturn(new Recognition("{\"concealed\":[\"1m\"]}", null, "2026-08-09/aabbccdd1122"));
 
     ResponseEntity<Object> response = controller.recognize(request());
@@ -71,37 +69,17 @@ class TileRecognitionControllerTest {
   }
 
   /**
-   * `engine` has a default, and a pattern on its own would let an explicit null through and wipe
-   * it. The values are the contract between the browser and the router that picks a recogniser.
+   * A miss is a success with a note attached, not an error: the hand is empty, and the note is the
+   * only thing standing between "the local reader is broken" and nobody noticing for weeks.
    */
   @Test
-  void rejectsAnEngineThatIsNullOrUnknown() {
-    Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-
-    TileRecognitionRequest nulled = request();
-    nulled.setEngine(null);
-    assertThat(validator.validate(nulled)).hasSize(1);
-
-    TileRecognitionRequest unknown = request();
-    unknown.setEngine("claude");
-    assertThat(validator.validate(unknown)).hasSize(1);
-
-    assertThat(validator.validate(request())).isEmpty();
-    assertThat(new TileRecognitionRequest().getEngine()).isEqualTo("local");
-  }
-
-  /**
-   * A fallback is a success with a note attached, not an error: the hand is usable, and the note is
-   * the only thing standing between "the local reader is broken" and nobody noticing for weeks.
-   */
-  @Test
-  void carriesTheFallbackWarningAlongsideTheHand() {
-    when(service.recognize(anyString(), anyString(), anyString(), any()))
-        .thenReturn(new Recognition("{\"concealed\":[\"1m\"]}", "本地识别服务连不上，已自动改用在线识别", null));
+  void carriesTheMissWarningAlongsideTheEmptyHand() {
+    when(service.recognize(anyString(), anyString(), any()))
+        .thenReturn(new Recognition("{\"concealed\":[]}", "本地识别服务连不上，请直接输入", null));
 
     ResponseEntity<Object> response = controller.recognize(request());
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().toString()).contains("已自动改用在线识别");
+    assertThat(response.getBody().toString()).contains("请直接输入");
   }
 }

--- a/server/src/test/java/com/mahjong/omakase/service/HandRecognitionServiceTest.java
+++ b/server/src/test/java/com/mahjong/omakase/service/HandRecognitionServiceTest.java
@@ -3,7 +3,6 @@ package com.mahjong.omakase.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -11,51 +10,40 @@ import static org.mockito.Mockito.when;
 
 import com.mahjong.omakase.service.HandRecognitionService.Recognition;
 import com.mahjong.omakase.service.LocalReaderService.ReaderUnavailableException;
-import com.mahjong.omakase.service.TileRecognitionService.Answer;
 import org.junit.jupiter.api.Test;
 
 class HandRecognitionServiceTest {
 
   private final LocalReaderService reader = mock(LocalReaderService.class);
-  private final TileRecognitionService gemini = mock(TileRecognitionService.class);
   private final RecognitionSampleStore samples = mock(RecognitionSampleStore.class);
-  private final HandRecognitionService service =
-      new HandRecognitionService(reader, gemini, samples);
+  private final HandRecognitionService service = new HandRecognitionService(reader, samples);
 
   private static final String LOCAL_ANSWER = "{\"concealed\":[\"1m\"]}";
-  private static final String GEMINI_ANSWER = "{\"concealed\":[\"9p\"]}";
-  private static final Answer FROM_GEMINI = new Answer(GEMINI_ANSWER, "2026-08-09/aabbccdd1122");
 
   @Test
-  void readsLocallyByDefaultAndKeepsTheSample() {
-    when(reader.isConfigured()).thenReturn(true);
+  void readsLocallyAndKeepsTheSample() {
     when(reader.recognize(anyString(), anyString(), any())).thenReturn(LOCAL_ANSWER);
     when(samples.save(anyString(), anyString(), anyString(), anyString()))
         .thenReturn("2026-08-09/aabbccdd1122");
 
-    Recognition recognition = service.recognize("BASE64", "image/jpeg", "local", 42L);
+    Recognition recognition = service.recognize("BASE64", "image/jpeg", 42L);
 
     assertThat(recognition.rawJson()).isEqualTo(LOCAL_ANSWER);
     assertThat(recognition.warning()).isNull();
     // Handed to the browser so the hand the user settles on can be filed against this photo.
     assertThat(recognition.sampleId()).isEqualTo("2026-08-09/aabbccdd1122");
     verify(samples).save("BASE64", "image/jpeg", HandRecognitionService.LOCAL, LOCAL_ANSWER);
-    verify(gemini, never()).recognize(anyString(), anyString());
   }
 
-  /**
-   * The reader being unreachable is nobody's fault and nothing the user can act on — it does not
-   * fall back to Gemini any more, it just says so and hands back an empty hand to fill in by hand.
-   */
+  /** The reader being unreachable is nobody's fault and nothing the user can act on. */
   @Test
   void returnsAnEmptyHandWhenTheReaderCannotBeReached() {
-    when(reader.isConfigured()).thenReturn(true);
     when(reader.recognize(anyString(), anyString(), any()))
         .thenThrow(new ReaderUnavailableException("connection refused"));
     when(samples.saveFailure(anyString(), anyString(), anyString(), anyString()))
         .thenReturn("2026-08-09/aabbccdd1122");
 
-    Recognition recognition = service.recognize("BASE64", "image/jpeg", "local", null);
+    Recognition recognition = service.recognize("BASE64", "image/jpeg", null);
 
     assertThat(recognition.rawJson()).contains("\"concealed\":[]");
     assertThat(recognition.warning()).contains("连不上");
@@ -65,25 +53,21 @@ class HandRecognitionServiceTest {
     assertThat(recognition.sampleId()).isEqualTo("2026-08-09/aabbccdd1122");
     verify(samples)
         .saveFailure("BASE64", "image/jpeg", HandRecognitionService.LOCAL, "connection refused");
-    verify(gemini, never()).recognize(anyString(), anyString());
   }
 
   /**
    * The reader looked at the photo and declined it. That detail is worth showing, because the fix
-   * next time is to reframe — but it no longer falls back to Gemini either; an empty hand goes back
-   * and the user fills it in (here or in the calculator directly).
+   * next time is to reframe.
    */
   @Test
   void returnsAnEmptyHandWithAWarningWhenTheReaderDeclinedThePhoto() {
-    when(reader.isConfigured()).thenReturn(true);
     when(reader.recognize(anyString(), anyString(), any()))
         .thenThrow(new IllegalStateException("no line of tiles found"));
 
-    Recognition recognition = service.recognize("BASE64", "image/jpeg", "local", null);
+    Recognition recognition = service.recognize("BASE64", "image/jpeg", null);
 
     assertThat(recognition.rawJson()).contains("\"concealed\":[]");
     assertThat(recognition.warning()).contains("没读出手牌").contains("no line of tiles found");
-    verify(gemini, never()).recognize(anyString(), anyString());
   }
 
   /**
@@ -92,11 +76,10 @@ class HandRecognitionServiceTest {
    */
   @Test
   void recordsWhyTheLocalReadFailedEvenThoughNothingIsFilledIn() {
-    when(reader.isConfigured()).thenReturn(true);
     when(reader.recognize(anyString(), anyString(), any()))
         .thenThrow(new IllegalStateException("no line of tiles found"));
 
-    service.recognize("BASE64", "image/jpeg", "local", null);
+    service.recognize("BASE64", "image/jpeg", null);
 
     verify(samples)
         .saveFailure(
@@ -104,26 +87,15 @@ class HandRecognitionServiceTest {
     verify(samples, never()).save(anyString(), anyString(), anyString(), anyString());
   }
 
+  /** No reader.url configured throws the same exception a reachable-but-down reader would. */
   @Test
-  void asksGeminiWhenTheClientAsksForIt() {
-    when(gemini.recognize(anyString(), anyString())).thenReturn(FROM_GEMINI);
+  void returnsAnEmptyHandWhenNoReaderIsConfigured() {
+    when(reader.recognize(anyString(), anyString(), any()))
+        .thenThrow(new ReaderUnavailableException("reader.url is not set"));
 
-    assertThat(service.recognize("BASE64", "image/jpeg", "gemini", null).rawJson())
-        .isEqualTo(GEMINI_ANSWER);
-    verify(reader, never()).recognize(anyString(), anyString(), any());
-    // TileRecognitionService keeps its own sample once it has an answer, so this path must not add
-    // a second one under the wrong name.
-    verify(samples, never())
-        .save(anyString(), anyString(), eq(HandRecognitionService.LOCAL), any());
-  }
+    Recognition recognition = service.recognize("BASE64", "image/jpeg", null);
 
-  @Test
-  void usesGeminiWhenNoReaderIsConfigured() {
-    when(reader.isConfigured()).thenReturn(false);
-    when(gemini.recognize(anyString(), anyString())).thenReturn(FROM_GEMINI);
-
-    assertThat(service.recognize("BASE64", "image/jpeg", "local", null).rawJson())
-        .isEqualTo(GEMINI_ANSWER);
-    verify(reader, never()).recognize(anyString(), anyString(), any());
+    assertThat(recognition.rawJson()).contains("\"concealed\":[]");
+    assertThat(recognition.warning()).contains("连不上");
   }
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -6,6 +6,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Mahjong Omakase" />
     <link rel="manifest" href="/site.webmanifest" />

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -234,20 +234,17 @@ export async function lookupClaimablePlayer(userName: string, firstName: string,
  * The Gemini key, the prompt and the calibration legend all live server-side, so the
  * browser only ever ships the photo.
  */
-/** `engine` picks the recogniser: the local reader by default, Gemini when the user asks for it. */
 export async function recognizeHandPhoto(
   imageBase64: string,
   mimeType: string,
-  engine: 'local' | 'gemini' = 'local',
   sessionId?: number
 ): Promise<{ rawJson: string; warning?: string; sampleId?: string }> {
   try {
     const res = await fetch(`${API}/recognize`, {
       method: 'POST',
       headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify({ imageBase64, mimeType, engine, sessionId }),
-      // Gemini retries can take upward of a minute; without this, a stalled connection leaves the
-      // recognize button disabled forever instead of surfacing an error.
+      body: JSON.stringify({ imageBase64, mimeType, sessionId }),
+      // Without this a stalled connection leaves the recognize button disabled forever.
       signal: AbortSignal.timeout(90_000),
     })
     const data = await handleResponse<{ rawJson: string; warning?: string; sampleId?: string } | undefined>(res)

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -20,6 +20,27 @@ const exitFs = () => {
   if (fn) Promise.resolve(fn.call(document)).catch(() => {})
 }
 
+export const GAME_DURATION_MS = 60 * 60 * 1000
+export const TIMER_WARNING_MS = 10 * 60 * 1000
+
+export function remainingMs(createdAt: string, now: number): number {
+  return GAME_DURATION_MS - (now - new Date(createdAt).getTime())
+}
+
+export function timerState(createdAt: string, now: number): 'normal' | 'warning' | 'expired' {
+  const remaining = remainingMs(createdAt, now)
+  if (remaining <= 0) return 'expired'
+  if (remaining <= TIMER_WARNING_MS) return 'warning'
+  return 'normal'
+}
+
+export function formatRemaining(createdAt: string, now: number): string {
+  const remaining = Math.max(0, remainingMs(createdAt, now))
+  const minutes = Math.floor(remaining / 60000)
+  const seconds = Math.floor((remaining % 60000) / 1000)
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
 interface PlayerEntry {
   rank: number
   name: string
@@ -51,6 +72,7 @@ export const GameCard: React.FC<Props> = ({
   const navigate = useNavigate()
   const isMobile = useIsMobile()
   const [fullscreen, setFullscreen] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
   const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const closeBtnRef = useRef<HTMLButtonElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -61,6 +83,12 @@ export const GameCard: React.FC<Props> = ({
     },
     []
   )
+
+  useEffect(() => {
+    if (!fullscreen || !isActive) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [fullscreen, isActive])
 
   useEffect(() => {
     if (!fullscreen) return
@@ -123,6 +151,7 @@ export const GameCard: React.FC<Props> = ({
   }, [fullscreen])
 
   const openFullscreen = () => {
+    setNow(Date.now())
     setFullscreen(true)
     if (!fsElement()) requestFs(document.documentElement)
   }
@@ -199,15 +228,17 @@ export const GameCard: React.FC<Props> = ({
       </div>
 
       {fullscreen && (
-        <div ref={overlayRef} className="game-fs-overlay" role="dialog" aria-modal="true" aria-label="全屏看盘">
+        <div
+          ref={overlayRef}
+          className={`game-fs-overlay${isActive ? ` game-fs-overlay-${timerState(createdAt, now)}` : ''}`}
+          role="dialog"
+          aria-modal="true"
+          aria-label="全屏看盘"
+        >
           <div className="game-fs-topbar">
             <div className="game-fs-title-area">
               <span className="game-fs-mode">{gameModeDisplayName}</span>
               <TableStrengthTag table={tableStrength} />
-              <span className={`badge ${isActive ? 'badge-progress' : 'badge-completed'}`}>
-                {isActive && <span className="pulse-dot" />}
-                {roundLabel}
-              </span>
               <span className="game-fs-date">
                 {new Date(createdAt).toLocaleString('en-US', {
                   timeZone: 'America/Los_Angeles',
@@ -235,6 +266,15 @@ export const GameCard: React.FC<Props> = ({
 
           <div className="game-fs-main">
             <div className="game-fs-scoreboard-col">
+              <div className={`badge game-fs-round-badge ${isActive ? 'badge-progress' : 'badge-completed'}`}>
+                {isActive && <span className="pulse-dot" />}
+                {roundLabel}
+              </div>
+              {isActive && (
+                <div className={`game-fs-timer-banner game-fs-timer-${timerState(createdAt, now)}`}>
+                  {timerState(createdAt, now) === 'expired' ? '时间到' : `⏱ ${formatRemaining(createdAt, now)}`}
+                </div>
+              )}
               {players.map((p, idx) => (
                 <div key={idx} className={`game-fs-player-card ${p.isDealer ? 'is-dealer' : ''} rank-${p.rank}`}>
                   <div className="game-fs-player-left">

--- a/ui/src/components/PhotoRecognitionModal.tsx
+++ b/ui/src/components/PhotoRecognitionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Tile, TileSuit } from '../logic/shared/tiles'
 import { recognizeHandPhoto } from '../api'
 
@@ -523,18 +523,30 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
   // so recognition still works — show that rather than a broken-image icon.
   const [previewFailed, setPreviewFailed] = useState(false)
 
+  // Bumped on recognize and on close, so a stale response can't overwrite newer state.
+  const requestIdRef = useRef(0)
+  // Mirrors the latest sessionId so a response can tell whether it is still for the session it was
+  // asked about — a request outliving a session change must not file its sample under the new one.
+  const sessionIdRef = useRef(sessionId)
+  if (sessionIdRef.current !== sessionId) {
+    sessionIdRef.current = sessionId
+    requestIdRef.current++
+  }
+
   // Both callers keep this mounted and only toggle isOpen, so without this a reopen would
   // still show the previous photo.
   const [wasOpen, setWasOpen] = useState(isOpen)
   if (wasOpen !== isOpen) {
     setWasOpen(isOpen)
     if (!isOpen) {
+      requestIdRef.current++
       setSourceImage(null)
       setRotation(0)
       setImagePreview(null)
       setError(null)
       setWarning(null)
       setPreviewFailed(false)
+      setLoading(false)
     }
   }
 
@@ -607,6 +619,8 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
       return
     }
 
+    const requestId = ++requestIdRef.current
+    const requestSessionId = sessionId
     setLoading(true)
     setError(null)
     setWarning(null)
@@ -621,12 +635,12 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
       if (base64.length > 8_000_000) {
         throw new Error('图片过大，请用较低分辨率重拍，或关闭 iPhone 的 ProRAW / 48MP')
       }
-      const {
-        rawJson: responseText,
-        warning: miss,
-        sampleId,
-      } = await recognizeHandPhoto(base64, mimeType, 'local', sessionId)
-      onSample?.(sampleId ?? null)
+      const { rawJson: responseText, warning: miss, sampleId } = await recognizeHandPhoto(base64, mimeType, sessionId)
+      // Still worth recording even if a newer attempt has superseded this one, as long as it is for
+      // the same session — but not once the session itself has moved on underneath it.
+      if (sessionIdRef.current === requestSessionId) onSample?.(sampleId ?? null)
+
+      if (requestId !== requestIdRef.current) return
 
       const jsonOutput = safeParseJSON(responseText)
 
@@ -681,10 +695,11 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
       })
       onClose()
     } catch (err: any) {
+      if (requestId !== requestIdRef.current) return
       console.error('Photo recognition error:', err)
       setError(err.message || '识别失败，请重试')
     } finally {
-      setLoading(false)
+      if (requestId === requestIdRef.current) setLoading(false)
     }
   }
 
@@ -777,16 +792,19 @@ export const PhotoRecognitionModal: React.FC<PhotoRecognitionModalProps> = ({
 
           {error && <div className="photo-rec-error">⚠️ {error}</div>}
           {warning && <div className="photo-rec-warning">ℹ️ {warning}</div>}
+          {(error || warning) && <p className="photo-rec-fallback-text">识别没有成功，请在算番器里手动输入手牌</p>}
 
           <button
             className="btn btn-accent photo-rec-submit-btn"
-            disabled={loading || !imagePreview}
-            onClick={handleRecognize}
+            disabled={loading || (!error && !warning && !imagePreview)}
+            onClick={error || warning ? onClose : handleRecognize}
           >
             {loading ? (
               <span className="loading-spinner-wrap">
                 <span className="spinner"></span> 正在识别中...
               </span>
+            ) : error || warning ? (
+              '关闭识别窗口'
             ) : (
               '✨ 开始识别'
             )}

--- a/ui/src/components/SeatAssignmentModal.tsx
+++ b/ui/src/components/SeatAssignmentModal.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react'
+import { Player } from '../types'
+import { cardFontSize } from '../utils/fontSize'
+import { useIsMobile } from '../hooks/useIsMobile'
+
+function shuffle<T>(arr: T[]): T[] {
+  const result = [...arr]
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[result[i], result[j]] = [result[j], result[i]]
+  }
+  return result
+}
+
+interface SeatAssignmentModalProps {
+  players: Player[]
+  onCancel: () => void
+  onConfirm: (orderedPlayerIds: number[]) => void
+  creating: boolean
+  error: string
+}
+
+const SeatCard: React.FC<{ name: string; wind: string; isMobile: boolean }> = ({ name, wind, isMobile }) => (
+  <div className="seat-card">
+    <div className="seat-card-wind">{wind}</div>
+    <div className="seat-card-name" style={{ fontSize: cardFontSize(name, isMobile) }}>
+      {name}
+    </div>
+  </div>
+)
+
+/** Mount only while open — the shuffle below runs once, on mount. */
+export const SeatAssignmentModal: React.FC<SeatAssignmentModalProps> = ({
+  players,
+  onCancel,
+  onConfirm,
+  creating,
+  error,
+}) => {
+  const isMobile = useIsMobile()
+  const [seated] = useState(() => shuffle(players))
+
+  return (
+    <div className="modal-backdrop" onClick={creating ? undefined : onCancel}>
+      <div
+        className="modal-card seat-assign-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="座位分配"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div className="photo-rec-title">
+            <span className="photo-rec-icon">🀄</span>
+            <div>
+              <h3>座位已分配</h3>
+            </div>
+          </div>
+          <button className="btn-close" onClick={onCancel} disabled={creating}>
+            ✕
+          </button>
+        </div>
+
+        <div className="seat-assign-body">
+          <div className="seat-compass">
+            <div className="seat-compass-slot seat-compass-north">
+              <SeatCard name={seated[0].userName} wind="🀀" isMobile={isMobile} />
+            </div>
+            <div className="seat-compass-slot seat-compass-south">
+              <SeatCard name={seated[1].userName} wind="🀁" isMobile={isMobile} />
+            </div>
+            <div className="seat-compass-slot seat-compass-east">
+              {seated[3] && <SeatCard name={seated[3].userName} wind="🀃" isMobile={isMobile} />}
+            </div>
+            <div className="seat-compass-slot seat-compass-west">
+              <SeatCard name={seated[2].userName} wind="🀂" isMobile={isMobile} />
+            </div>
+          </div>
+
+          {error && <p className="error-text">{error}</p>}
+
+          <button
+            className="btn btn-accent btn-large seat-assign-confirm-btn"
+            onClick={() => onConfirm(seated.map((p) => p.id))}
+            disabled={creating}
+          >
+            {creating ? '创建中...' : '确定，开始游戏'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/__tests__/gameCardTimer.test.ts
+++ b/ui/src/components/__tests__/gameCardTimer.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { remainingMs, timerState, formatRemaining, GAME_DURATION_MS, TIMER_WARNING_MS } from '../GameCard'
+
+// The backend serializes createdAt with a trailing Z (see JacksonConfig) — this pins that contract,
+// since two earlier bugs came from assuming the wrong thing about it (missing Z, then a doubled one).
+const CREATED_AT = '2026-08-19T12:00:00Z'
+
+describe('GameCard timer', () => {
+  it('reads a fresh session as normal, near the full duration', () => {
+    const now = new Date(CREATED_AT).getTime() + 1000
+    expect(timerState(CREATED_AT, now)).toBe('normal')
+    expect(remainingMs(CREATED_AT, now)).toBeCloseTo(GAME_DURATION_MS - 1000, -2)
+  })
+
+  it('switches to warning once inside the warning window', () => {
+    const now = new Date(CREATED_AT).getTime() + GAME_DURATION_MS - TIMER_WARNING_MS + 1
+    expect(timerState(CREATED_AT, now)).toBe('warning')
+  })
+
+  it('expires once the duration has elapsed', () => {
+    const now = new Date(CREATED_AT).getTime() + GAME_DURATION_MS + 1
+    expect(timerState(CREATED_AT, now)).toBe('expired')
+  })
+
+  it('formats remaining time as clamped mm:ss, never negative', () => {
+    const now = new Date(CREATED_AT).getTime() + GAME_DURATION_MS + 60_000
+    expect(formatRemaining(CREATED_AT, now)).toBe('0:00')
+  })
+})

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -46,6 +46,16 @@
   --radius: 12px;
   --shadow: 0 4px 6px -1px rgb(0 0 0 / 5%), 0 2px 4px -1px rgb(0 0 0 / 3%);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 8%), 0 4px 6px -2px rgb(0 0 0 / 3%);
+
+  /* Tailwind-slate/red/green scale — the palette the fullscreen scoreboard (.game-fs-*) draws
+     from, kept separate from the Solarized set above since it's a different design language. */
+  --fs-slate-900: #0f172a;
+  --fs-slate-500: #64748b;
+  --fs-slate-200: #e2e8f0;
+  --fs-slate-50: #f8fafc;
+  --fs-red-600: #dc2626;
+  --fs-red-100: #fee2e2;
+  --fs-green-500: #22c55e;
 }
 
 /* Rank Tags */
@@ -1212,25 +1222,6 @@ table.auto-table {
   border-color: var(--primary);
   background: var(--primary);
   color: white;
-}
-
-.player-card-wind {
-  background: linear-gradient(135deg, var(--accent), #e67e22);
-  color: white;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.75rem;
-  font-weight: 800;
-  box-shadow: 0 2px 5px rgb(0 0 0 / 20%);
-  border: none;
-  position: absolute;
-  top: -8px;
-  right: -8px;
-  z-index: 2;
 }
 
 .player-select-card.disabled {
@@ -3097,8 +3088,8 @@ table.auto-table {
   width: 100vw;
   height: 100vh;
   z-index: 99999;
-  background: #fff;
-  color: #0f172a;
+  background: var(--card);
+  color: var(--fs-slate-900);
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
@@ -3106,6 +3097,15 @@ table.auto-table {
     max(24px, env(safe-area-inset-bottom)) max(24px, env(safe-area-inset-left));
   overflow-y: auto;
   animation: fade-in-fs 0.2s ease-out;
+  transition: background 0.3s ease;
+}
+
+.game-fs-overlay-warning {
+  background: #fde68a;
+}
+
+.game-fs-overlay-expired {
+  background: #fdecea;
 }
 
 @keyframes fade-in-fs {
@@ -3128,7 +3128,7 @@ table.auto-table {
   padding-bottom: 18px;
   padding-left: 64px; /* Clears the system close button iPadOS/iOS puts at the top left of element fullscreen. */
   padding-right: 64px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--fs-slate-200);
   min-height: 44px;
   gap: 16px;
   box-sizing: border-box;
@@ -3147,13 +3147,44 @@ table.auto-table {
 .game-fs-mode {
   font-size: 1.35rem;
   font-weight: 800;
-  color: #0f172a;
+  color: var(--fs-slate-900);
   letter-spacing: -0.02em;
 }
 
 .game-fs-date {
   font-size: 0.9rem;
-  color: #64748b;
+  color: var(--fs-slate-500);
+}
+
+.game-fs-round-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 2.2rem;
+  padding: 14px 32px;
+  margin: 0 auto;
+}
+
+.game-fs-timer-banner {
+  font-size: 3rem;
+  font-weight: 800;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-align: center;
+  padding: 12px;
+  border-radius: 14px;
+  color: var(--fs-slate-500);
+  background: var(--fs-slate-50);
+}
+
+.game-fs-timer-warning {
+  background: #fbbf24;
+  color: #78350f;
+}
+
+.game-fs-timer-expired {
+  background: var(--fs-red-100);
+  color: var(--fs-red-600);
 }
 
 .game-fs-actions {
@@ -3173,16 +3204,16 @@ table.auto-table {
   padding: 8px 18px;
   border-radius: 8px;
   border: 1px solid #cbd5e1;
-  background: #f8fafc;
+  background: var(--fs-slate-50);
   color: #334155;
   font-size: 0.9rem;
   font-weight: 600;
 }
 
 .game-fs-close-btn {
-  background: #fee2e2;
+  background: var(--fs-red-100);
   border-color: #fca5a5;
-  color: #dc2626;
+  color: var(--fs-red-600);
 }
 
 .game-fs-main {
@@ -3204,8 +3235,8 @@ table.auto-table {
 }
 
 .game-fs-player-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--card);
+  border: 1px solid var(--fs-slate-200);
   border-radius: 14px;
   padding: 20px 28px;
   display: flex;
@@ -3217,7 +3248,7 @@ table.auto-table {
 
 .game-fs-player-card.is-dealer {
   border-color: #f59e0b;
-  background: linear-gradient(135deg, #fffbeb 0%, #fff 100%);
+  background: linear-gradient(135deg, #fffbeb 0%, var(--card) 100%);
   box-shadow: 0 4px 20px -2px rgb(245 158 11 / 20%);
 }
 
@@ -3264,7 +3295,7 @@ table.auto-table {
 .game-fs-player-name {
   font-size: 1.4rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--fs-slate-900);
 }
 
 .game-fs-player-score {
@@ -3279,7 +3310,7 @@ table.auto-table {
 }
 
 .game-fs-player-score.score-negative {
-  color: #dc2626;
+  color: var(--fs-red-600);
 }
 
 .pulse-dot {
@@ -3287,9 +3318,9 @@ table.auto-table {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #22c55e;
+  background: var(--fs-green-500);
   margin-right: 6px;
-  box-shadow: 0 0 8px #22c55e;
+  box-shadow: 0 0 8px var(--fs-green-500);
   animation: pulse-dot 1.5s infinite;
 }
 
@@ -3315,12 +3346,12 @@ table.auto-table {
   align-items: center;
   justify-content: space-between;
   padding-top: 16px;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--fs-slate-200);
 }
 
 .game-fs-detail-link {
   background: var(--accent, var(--mj-gold));
-  color: #fff;
+  color: var(--card);
   border: none;
   padding: 10px 22px;
   border-radius: 8px;
@@ -3330,7 +3361,7 @@ table.auto-table {
 
 .game-fs-tip {
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--fs-slate-500);
 }
 
 @media (width <= 768px) {
@@ -3354,6 +3385,14 @@ table.auto-table {
 
   .game-fs-player-name {
     font-size: 1.2rem;
+  }
+
+  .game-fs-timer-banner {
+    font-size: 2.2rem;
+  }
+
+  .game-fs-round-badge {
+    font-size: 1.6rem;
   }
 }
 
@@ -3616,6 +3655,12 @@ table.auto-table {
   font-size: 0.85rem;
 }
 
+.photo-rec-fallback-text {
+  font-size: 0.85rem;
+  color: var(--text-light);
+  margin: 0;
+}
+
 .photo-rec-submit-btn {
   background: linear-gradient(135deg, var(--mj-green) 0%, #1b4d3e 100%);
   color: white;
@@ -3680,4 +3725,90 @@ table.auto-table {
   font-size: 1.1rem;
   font-weight: 700;
   box-shadow: 0 2px 5px rgb(0 0 0 / 8%);
+}
+
+.modal-card.seat-assign-modal {
+  background: var(--card);
+  border-radius: 16px;
+  width: 100%;
+  max-width: 460px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 40px rgb(0 0 0 / 25%);
+  overflow: hidden;
+  animation: modal-pop 0.25s ease-out;
+}
+
+.seat-assign-body {
+  padding: 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.seat-compass {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  gap: 10px;
+  aspect-ratio: 1;
+  max-width: 340px;
+  margin: 0 auto;
+}
+
+.seat-compass-slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.seat-compass-north {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.seat-compass-west {
+  grid-column: 2;
+  grid-row: 3;
+}
+
+.seat-compass-east {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.seat-compass-south {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.seat-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px;
+  border-radius: 12px;
+  background: var(--card);
+  border: 2px solid var(--primary);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.seat-card-wind {
+  font-size: 2.4rem;
+  line-height: 1;
+}
+
+.seat-card-name {
+  font-weight: 600;
+  color: var(--text);
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.seat-assign-confirm-btn {
+  width: 100%;
 }

--- a/ui/src/pages/NewSessionPage.tsx
+++ b/ui/src/pages/NewSessionPage.tsx
@@ -6,6 +6,7 @@ import { cardFontSize } from '../utils/fontSize'
 import { MSG } from '../constants'
 import { abbrName, parseError } from '../utils/format'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { SeatAssignmentModal } from '../components/SeatAssignmentModal'
 
 const MIN_PLAYERS = 3
 const MAX_PLAYERS = 4
@@ -20,6 +21,8 @@ export default function NewSessionPage() {
   const [error, setError] = useState('')
   const [creating, setCreating] = useState(false)
   const [loaded, setLoaded] = useState(false)
+  const [seatModalOpen, setSeatModalOpen] = useState(false)
+  const [seatError, setSeatError] = useState('')
 
   useEffect(() => {
     fetchPlayers()
@@ -54,10 +57,15 @@ export default function NewSessionPage() {
     )
   })
 
-  const handleStart = async () => {
+  const handleStart = () => {
     if (!canStart) return
+    setSeatError('')
+    setSeatModalOpen(true)
+  }
+
+  const handleConfirmSeats = async (orderedPlayerIds: number[]) => {
     setCreating(true)
-    setError('')
+    setSeatError('')
     try {
       const now = new Date()
       // 'en-US' pins the output format (M/D/YYYY, 24h HH:mm) — an empty locale array instead
@@ -71,10 +79,10 @@ export default function NewSessionPage() {
         hour12: false,
       })
       const defaultName = `Game ${dateStr} ${timeStr}`
-      const session = await createSession(defaultName, gameMode, selectedIds)
+      const session = await createSession(defaultName, gameMode, orderedPlayerIds)
       navigate(`/session/${session.id}`)
     } catch (e: unknown) {
-      setError(parseError(e))
+      setSeatError(parseError(e))
       setCreating(false)
     }
   }
@@ -103,11 +111,7 @@ export default function NewSessionPage() {
 
       <div className="form-group">
         <div style={{ display: 'block', marginBottom: 12 }}>
-          选择玩家{' '}
-          <span style={{ fontSize: '0.8rem', color: 'var(--accent)', fontWeight: 'normal' }}>
-            (请按照东南西北顺序点击玩家)
-          </span>{' '}
-          (已选 {selectedIds.length}/{MIN_PLAYERS}-{MAX_PLAYERS})
+          选择玩家 (已选 {selectedIds.length}/{MIN_PLAYERS}-{MAX_PLAYERS})
         </div>
 
         {players.length > 0 && (
@@ -138,9 +142,6 @@ export default function NewSessionPage() {
                   <div style={{ fontSize: '0.85rem', opacity: isSelected ? 0.9 : 0.6 }}>
                     {abbrName(p.firstName + ' ' + p.lastName)}
                   </div>
-                  {isSelected && (
-                    <div className="player-card-wind">{['东', '南', '西', '北'][selectedIds.indexOf(p.id)]}</div>
-                  )}
                 </div>
               )
             })}
@@ -173,10 +174,20 @@ export default function NewSessionPage() {
             </span>
           </div>
         )}
-        <button className="btn btn-accent btn-large" onClick={handleStart} disabled={!canStart || creating}>
-          {creating ? '创建中...' : `开始游戏 (${selectedIds.length}人)`}
+        <button className="btn btn-accent btn-large" onClick={handleStart} disabled={!canStart}>
+          开始游戏 ({selectedIds.length}人)
         </button>
       </div>
+
+      {seatModalOpen && (
+        <SeatAssignmentModal
+          players={players.filter((p) => selectedIds.includes(p.id))}
+          onCancel={() => setSeatModalOpen(false)}
+          onConfirm={handleConfirmSeats}
+          creating={creating}
+          error={seatError}
+        />
+      )}
     </div>
   )
 }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -92,9 +92,6 @@ export interface PlayerPerformance {
 export interface PlayerInfo {
   id: number
   userName: string
-  firstName: string
-  lastName: string
-  displayName: string
   seat: number
   tier?: TierKey | null
 }
@@ -163,7 +160,6 @@ export interface AddRoundData {
 export interface PlayerStats {
   playerId: number
   userName: string
-  displayName: string
   gamesPlayed: number
   totalScore: number
   avgRank: number


### PR DESCRIPTION
## Summary
- **新建游戏**: 不再靠点击顺序决定座位。选完人点开始游戏, 弹出座位分配弹窗, 随机排好座位画一张东南西北风位图, 确认后才真正创建对局
- **全屏看盘**: 进行中的对局在计分板上方加大号计时器和局数状态, 从 `createdAt` 起算1小时, 剩10分钟背景变黄, 到点变红。修了 `GameSession`/`Player` 的 `createdAt` 用 `LocalDateTime.now()` 读 JVM 默认时区的问题 (本地 `gradle bootRun` 和生产 Docker 结果不一致的根源), 改成 `LocalDateTime.now(ZoneOffset.UTC)`
- **拍照识别 bug**: 关闭弹窗后 loading 状态没清, 加了 requestId 去重, 关闭弹窗或发起新一次识别都会让上一次的响应失效, 不再用旧结果覆盖新结果或误关弹窗; 识别失败/没读出手牌时, 原来的"开始识别"按钮变成"关闭识别窗口", 并提示手动输入
- **彻底停用 Gemini**: 之前只是前端不发, 服务端本地 reader 没配置时还是会自动 fallback 到 Gemini, `engine` 传 `"gemini"` 也还能打通。现在 `TileRecognitionService` 去掉 `@Service` 不再被实例化, `engine` 参数整个从 DTO/controller/service 里删掉, 没有任何路径能再触达 Gemini, 代码保留在磁盘上作为 legacy
- 去掉两处玩家真名 (`firstName`+`lastName`) 泄露: `SessionDetailResponse`/`PlayerStatsResponse` 里没人用的 `displayName` 字段
- 补上 `mobile-web-app-capable` meta 标签 (apple 前缀的那个 Chrome 已标 deprecated)

## Test plan
- [x] `./gradlew test pmdMain` 全过
- [x] `npx tsc --noEmit` / `npm run lint:css` / `npm run test:run` 全过
- [ ] 建一局新游戏走一遍座位分配弹窗, 进全屏看计时器倒计时是否正常
- [ ] 拍照识别失败一次, 确认按钮变成"关闭识别窗口"能正常关闭

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a seat-assignment screen with randomized seating, compass layout, confirmation, and responsive sizing.
  - Added a one-hour game timer with normal, warning, and expired states.
  - Enabled standalone mobile web-app behavior.
- **Improvements**
  - Hand recognition now uses the local reader without engine selection.
  - Recognition handles delayed responses more reliably and offers manual entry after errors or missed results.
  - Player displays now use usernames and seats without separate display-name fields.
  - Session timestamps now use a consistent time zone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->